### PR TITLE
Populate the "Possible Values" section based on OAS data

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -295,6 +295,7 @@ public struct DocumentationNode {
             returnsSectionVariants: .empty,
             parametersSectionVariants: .empty,
             dictionaryKeysSectionVariants: .empty,
+            possibleValuesSectionVariants: .empty,
             httpEndpointSectionVariants: endpointVariants,
             httpBodySectionVariants: .empty,
             httpParametersSectionVariants: .empty,
@@ -387,6 +388,12 @@ public struct DocumentationNode {
         if let keys = markupModel.discussionTags?.dictionaryKeys, !keys.isEmpty {
             // Record the keys extracted from the markdown
             semantic.dictionaryKeysSectionVariants[.fallback] = DictionaryKeysSection(dictionaryKeys:keys)
+        }
+        
+        if let values = markupModel.discussionTags?.possibleValues, !values.isEmpty {
+            // Record the values extracted from the markdown and the complete set defined by the symbol
+            let section = PossibleValuesSection(documentedValues: values, definedValues: symbol?.allowedValues ?? [])
+            semantic.possibleValuesSectionVariants[.fallback] = section
         }
         
         if let parameters = markupModel.discussionTags?.httpParameters, !parameters.isEmpty {
@@ -654,6 +661,7 @@ public struct DocumentationNode {
             returnsSectionVariants: .init(swiftVariant: markupModel.discussionTags.flatMap({ $0.returns.isEmpty ? nil : ReturnsSection(content: $0.returns[0].contents) })),
             parametersSectionVariants: .init(swiftVariant: markupModel.discussionTags.flatMap({ $0.parameters.isEmpty ? nil : ParametersSection(parameters: $0.parameters) })),
             dictionaryKeysSectionVariants: .init(swiftVariant: markupModel.discussionTags.flatMap({ $0.dictionaryKeys.isEmpty ? nil : DictionaryKeysSection(dictionaryKeys: $0.dictionaryKeys) })),
+            possibleValuesSectionVariants: .init(swiftVariant: markupModel.discussionTags.flatMap({ $0.possibleValues.isEmpty ? nil : PossibleValuesSection(documentedValues: $0.possibleValues, definedValues: []) })),
             httpEndpointSectionVariants: .empty,
             httpBodySectionVariants: .empty,
             httpParametersSectionVariants: .empty,

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1379,6 +1379,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
                     HTTPBodySectionTranslator(),
                     HTTPResponsesSectionTranslator(),
                     DictionaryKeysSectionTranslator(),
+                    PossibleValuesSectionTranslator(),
                     AttributesSectionTranslator(),
                     ReturnsSectionTranslator(),
                     MentionsSectionTranslator(referencingSymbol: identifier),

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/PossibleValuesSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/PossibleValuesSectionTranslator.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// Translates a symbol's possible values into a render node's Possible Values section.
+struct PossibleValuesSectionTranslator: RenderSectionTranslator {
+    func translateSection(
+        for symbol: Symbol,
+        renderNode: inout RenderNode,
+        renderNodeTranslator: inout RenderNodeTranslator
+    ) -> VariantCollection<CodableContentSection?>? {
+        translateSectionToVariantCollection(
+            documentationDataVariants: symbol.possibleValuesSectionVariants
+        ) { _, possibleValuesSection in
+            // Render section only if values were listed in the markdown
+            // and there are value defined in the symbol graph.
+            guard !possibleValuesSection.documentedValues.isEmpty else { return nil }
+            guard !possibleValuesSection.definedValues.isEmpty else { return nil }
+            
+            // Build a lookup table of the documented values
+            var documentationLookup = [String: PossibleValue]()
+            possibleValuesSection.documentedValues.forEach { documentationLookup[$0.value] = $0 }
+
+            // Generate list of possible values for rendering from the full list of defined values,
+            // pulling in any documentation from the documented values list when available.
+            let renderedValues = possibleValuesSection.definedValues.map {
+                let valueString = String($0)
+                let possibleValue = documentationLookup[valueString] ?? PossibleValue(value: valueString, contents: [])
+                let valueContent = renderNodeTranslator.visitMarkupContainer(
+                    MarkupContainer(possibleValue.contents)
+                ) as! [RenderBlockContent]
+                return PossibleValuesRenderSection.NamedValue(name: possibleValue.value, content: valueContent)
+            }
+            
+            return PossibleValuesRenderSection(
+                title: PossibleValuesSection.title,
+                values: renderedValues
+            )
+        }
+    }
+}

--- a/Sources/SwiftDocC/Model/Section/Sections/PossibleValuesSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/PossibleValuesSection.swift
@@ -1,0 +1,24 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SymbolKit
+
+/// A section that contains an type's possible values.
+public struct PossibleValuesSection {
+    public static var title: String {
+        return "Possible Values"
+    }
+    
+    /// The list of possible values.
+    public var documentedValues: [PossibleValue]
+    
+    /// The list of defined values for the symbol.
+    public var definedValues: [SymbolGraph.AnyScalar]
+}

--- a/Sources/SwiftDocC/Model/Semantics/PossibleValue.swift
+++ b/Sources/SwiftDocC/Model/Semantics/PossibleValue.swift
@@ -1,0 +1,20 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Markdown
+import SymbolKit
+
+/// Documentation about the possible values for a symbol.
+public struct PossibleValue {
+    /// The string representation of the value.
+    public var value: String
+    /// The content that describe the value.
+    public var contents: [Markup]
+}

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -451,6 +451,12 @@ struct ReferenceResolver: SemanticVisitor {
             }
             return DictionaryKeysSection(dictionaryKeys: keys)
         }
+        let newPossibleValuesVariants = symbol.possibleValuesSectionVariants.map { possibleValuesSection -> PossibleValuesSection in
+            let keys = possibleValuesSection.documentedValues.map {
+                PossibleValue(value: $0.value, contents: $0.contents.map { visitMarkup($0) })
+            }
+            return PossibleValuesSection(documentedValues: keys, definedValues: possibleValuesSection.definedValues)
+        }
         let newHTTPEndpointVariants = symbol.httpEndpointSectionVariants.map { httpEndpointSection -> HTTPEndpointSection in
             return HTTPEndpointSection(endpoint: httpEndpointSection.endpoint)
         }
@@ -499,6 +505,7 @@ struct ReferenceResolver: SemanticVisitor {
             returnsSectionVariants: newReturnsVariants,
             parametersSectionVariants: newParametersVariants,
             dictionaryKeysSectionVariants: newDictionaryKeysVariants,
+            possibleValuesSectionVariants: newPossibleValuesVariants,
             httpEndpointSectionVariants: newHTTPEndpointVariants,
             httpBodySectionVariants: newHTTPBodyVariants,
             httpParametersSectionVariants: newHTTPParametersVariants,

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -36,6 +36,7 @@ import SymbolKit
 /// - ``accessLevelVariants``
 /// - ``deprecatedSummaryVariants``
 /// - ``declarationVariants``
+/// - ``possibleValuesVariants``
 /// - ``attributesVariants``
 /// - ``locationVariants``
 /// - ``constraintsVariants``
@@ -149,7 +150,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     /// The symbol's alternate declarations in each language variant the symbol is available in.
     public var alternateDeclarationVariants = DocumentationDataVariants<[[PlatformName?]: [SymbolGraph.Symbol.DeclarationFragments]]>()
 
-    /// The symbol's possible values in each language variant the symbol is available in.
+    /// The symbol's set of attributes in each language variant the symbol is available in.
     public var attributesVariants = DocumentationDataVariants<[RenderAttribute.Kind: Any]>()
     
     public var locationVariants = DocumentationDataVariants<SymbolGraph.Symbol.Location>()
@@ -206,6 +207,9 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
     /// Any dictionary keys of the symbol, if the symbol accepts keys, in each language variant the symbol is available in.
     public var dictionaryKeysSectionVariants: DocumentationDataVariants<DictionaryKeysSection>
 
+    /// The symbol's possible values in each language variant the symbol is available in.
+    public var possibleValuesSectionVariants = DocumentationDataVariants<PossibleValuesSection>()
+    
     /// The HTTP endpoint of an HTTP request, in each language variant the symbol is available in.
     public var httpEndpointSectionVariants: DocumentationDataVariants<HTTPEndpointSection>
 
@@ -275,6 +279,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         returnsSectionVariants: DocumentationDataVariants<ReturnsSection>,
         parametersSectionVariants: DocumentationDataVariants<ParametersSection>,
         dictionaryKeysSectionVariants: DocumentationDataVariants<DictionaryKeysSection>,
+        possibleValuesSectionVariants: DocumentationDataVariants<PossibleValuesSection>,
         httpEndpointSectionVariants: DocumentationDataVariants<HTTPEndpointSection>,
         httpBodySectionVariants: DocumentationDataVariants<HTTPBodySection>,
         httpParametersSectionVariants: DocumentationDataVariants<HTTPParametersSection>,
@@ -304,6 +309,7 @@ public final class Symbol: Semantic, Abstracted, Redirected, AutomaticTaskGroups
         
         self.deprecatedSummaryVariants = deprecatedSummaryVariants
         self.declarationVariants = declarationVariants
+        self.possibleValuesSectionVariants = possibleValuesSectionVariants
         
         self.mixinsVariants = mixinsVariants
         

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeDictionaryDataTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeDictionaryDataTests.swift
@@ -24,6 +24,9 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
             // Genre string type - ``Genre``:
             "data:test:Genre": [.data],
             
+            // Month string type - ``Month``:
+            "data:test:Month": [.data],
+            
             // Module - ``DictionaryData``:
             "DictionaryData": [.data, .swift, .objectiveC],
             
@@ -92,6 +95,7 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
                 "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/Artist",
                 "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/Genre",
                 "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/FooSwift",
+                "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/Month",
             ],
             referenceTitles: [
                 "Artist",
@@ -99,10 +103,12 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
                 "FooObjC",
                 "FooSwift",
                 "Genre",
+                "Month",
             ],
             referenceFragments: [
                 "object Artist",
                 "string Genre",
+                "string Month",
             ],
             failureMessage: { fieldName in
                 "'DictionaryData' module has unexpected content for '\(fieldName)'."
@@ -125,6 +131,7 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
                 "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/Artist",
                 "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/Genre",
                 "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/FooObjC",
+                "doc://org.swift.docc.DictionaryData/documentation/DictionaryData/Month",
             ],
             referenceTitles: [
                 "Artist",
@@ -132,10 +139,12 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
                 "FooObjC",
                 "FooSwift",
                 "Genre",
+                "Month",
             ],
             referenceFragments: [
                 "object Artist",
                 "string Genre",
+                "string Month",
             ],
             failureMessage: { fieldName in
                 "'DictionaryData' module has unexpected content for '\(fieldName)'."
@@ -235,6 +244,7 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
             navigatorTitle: nil,
             abstract: nil,
             attributes: [.maximumLength("40"), .allowedTypes([[type1], [type2]]), .allowedValues(["Classic Rock", "Folk", "null"])],
+            possibleValues: nil,
             declarationTokens: [
                 "string ",
                 "Genre"
@@ -256,4 +266,35 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
         )
     }
 
+    func testTypeRenderNodeHasExpectedPossibleValuesContent() throws {
+        let outputConsumer = try renderNodeConsumer(for: "DictionaryData")
+        let genreRenderNode = try outputConsumer.renderNode(withIdentifier: "data:test:Month")
+        
+        assertExpectedContent( 
+            genreRenderNode,
+            sourceLanguage: "data",
+            symbolKind: "typealias",
+            title: "Month",
+            navigatorTitle: nil,
+            abstract: nil,
+            attributes: [.allowedValues(["January", "February", "March"])],
+            possibleValues: ["January", "February", "March"],
+            declarationTokens: [
+                "string ",
+                "Month"
+            ],
+            discussionSection: nil,
+            topicSectionIdentifiers: [],
+            referenceTitles: [
+                "DictionaryData",
+                "Month",
+            ],
+            referenceFragments: [
+                "string Month",
+            ],
+            failureMessage: { fieldName in
+                "'Month' symbol has unexpected content for '\(fieldName)'."
+            }
+        )
+    }
 }

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -223,6 +223,7 @@ private extension DocumentationContentRendererTests {
             returnsSectionVariants: .init(swiftVariant: nil),
             parametersSectionVariants: .init(swiftVariant: nil),
             dictionaryKeysSectionVariants: .init(swiftVariant: nil),
+            possibleValuesSectionVariants: .init(swiftVariant: nil),
             httpEndpointSectionVariants: .init(swiftVariant: nil),
             httpBodySectionVariants: .init(swiftVariant: nil),
             httpParametersSectionVariants: .init(swiftVariant: nil),

--- a/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/Month.md
+++ b/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/Month.md
@@ -1,0 +1,8 @@
+#  ``Month``
+
+- PossibleValues:
+  - February: Second
+  - January: First
+  - Friday: Fake
+
+<!-- Copyright (c) 2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DictionaryData.docc/dictionary.symbols.json
@@ -345,6 +345,48 @@
       "pathComponents": [
         "FooSwift"
       ]
+    },
+    {
+      "accessLevel": "public",
+      "allowedValues": [
+        "January",
+        "February",
+        "March"
+      ],
+      "declarationFragments": [
+        {
+          "kind": "text",
+          "spelling": "string "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Month"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "data",
+        "precise": "data:test:Month"
+      },
+      "kind": {
+        "displayName": "Type",
+        "identifier": "typealias"
+      },
+      "names": {
+        "subHeading": [
+          {
+            "kind": "text",
+            "spelling": "string "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "Month"
+          }
+        ],
+        "title": "Month"
+      },
+      "pathComponents": [
+        "Month"
+      ],
     }
   ]
 }

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -24,6 +24,7 @@ extension XCTestCase {
         navigatorTitle expectedNavigatorTitle: String?,
         abstract expectedAbstract: String?,
         attributes expectedAttributes: [RenderAttribute]? = nil,
+        possibleValues expectedPossibleValues: [String]? = nil,
         declarationTokens expectedDeclarationTokens: [String]?,
         endpointTokens expectedEndpointTokens: [String]? = nil,
         httpParameters expectedHTTPParameters: [String]? = nil,
@@ -68,6 +69,15 @@ extension XCTestCase {
             attributesSection?.attributes,
             expectedAttributes,
             failureMessageForField("attributes"),
+            file: file,
+            line: line
+        )
+        
+        let possibleValuesSection = renderNode.primaryContentSections.compactMap { $0 as? PossibleValuesRenderSection }.first
+        XCTAssertEqual(
+            possibleValuesSection?.values.map { $0.name },
+            expectedPossibleValues,
+            failureMessageForField("possibleValues"),
             file: file,
             line: line
         )


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://123262314

## Summary

REST/JSON data types support defining the allowed set of values a type can take (ie, an enumerated type) using the `allowedValues` key. These changes add support for generating a "Possible Values" section type for documenting the individual values, using a `- PossibleValues:` group in markdown. The rendered values will be limited to values defined by the symbol graph and will be presented in the same order as in the `allowedValues` key for the symbol.

## Dependencies

None

## Testing

Run DocC on the DictionaryData.docc fixture within the repo. The `Month` symbol includes 3 enumerated values and its markdown file attempts to document 2 of them out of order along with an invalid third entry. When rendered the real 3 values should be rendered in proper order along with the documentation for 2 of them.

Steps:
1. Build docc for this branch
2. Preview `DictionaryData.docc` and review (and edit) the `Month` page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (n/a)
