### PR TITLE
Update links for repos that have moved to the swiftlang organization so far

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ mkdir .build/swift-docc-symbol-graphs \
 #### 2. Set the path to your renderer
 
 The best place to get started with Swift-DocC-Render is with the
-instructions in the [project's README](https://github.com/apple/swift-docc-render).
+instructions in the [project's README](https://github.com/swiftlang/swift-docc-render).
 
 If you have Xcode 13 or later installed, you can use the version of Swift-DocC-Render
 that comes included in Xcode with:
@@ -266,11 +266,11 @@ export DOCC_HTML_DIR="$(dirname $(xcrun --find docc))/../share/docc/render"
 ```
 
 Alternatively, you can clone the 
-[Swift-DocC-Render-Artifact repository](https://github.com/apple/swift-docc-render-artifact)
+[Swift-DocC-Render-Artifact repository](https://github.com/swiftlang/swift-docc-render-artifact)
 and use a recent pre-built copy of the renderer:
 
 ```sh
-git clone https://github.com/apple/swift-docc-render-artifact.git
+git clone https://github.com/swiftlang/swift-docc-render-artifact.git
 ```
 
 Then point the `DOCC_HTML_DIR` environment variable
@@ -489,7 +489,7 @@ More concretely, Swift-DocC understands the following kinds of inputs:
 Swift-DocC outputs a machine-readable archive of the compiled documentation.
 This archive contains _render JSON_ files, which fully describe the contents
 of a documentation page and can be processed by a renderer such as
-[Swift-DocC-Render](https://github.com/apple/swift-docc-render).
+[Swift-DocC-Render](https://github.com/swiftlang/swift-docc-render).
 
 For more in-depth technical information about Swift-DocC, please refer to the
 project's technical documentation:
@@ -502,7 +502,7 @@ project's technical documentation:
  - As of Swift 5.5, the [Swift Compiler](https://github.com/apple/swift) is able to 
   emit _Symbol Graph_ files as part of the compilation process.
    
- - [SymbolKit](https://github.com/apple/swift-docc-symbolkit) is a Swift package containing
+ - [SymbolKit](https://github.com/swiftlang/swift-docc-symbolkit) is a Swift package containing
   the specification and reference model for the _Symbol Graph_ File Format.
   
  - [Swift Markdown](https://github.com/apple/swift-markdown) is a 
@@ -510,7 +510,7 @@ project's technical documentation:
   Markdown documents. It includes support for the Block Directive elements
   that Swift-DocC's tutorial files rely on.
    
- - [Swift-DocC-Render](https://github.com/apple/swift-docc-render) 
+ - [Swift-DocC-Render](https://github.com/swiftlang/swift-docc-render) 
   is a web application that understands and renders
   Swift-DocC's _render JSON_ format.
    

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ from the community.
 
 Before contributing code or documentation to Swift-DocC,
 we encourage you to first open a 
-[GitHub issue](https://github.com/apple/swift-docc/issues/new/choose) 
+[GitHub issue](https://github.com/swiftlang/swift-docc/issues/new/choose) 
 for a bug report or feature request.
 This will allow us to provide feedback on the proposed change.
 However, this is not a requirement. If your contribution is small in scope,
@@ -453,7 +453,7 @@ If you do not have commit access, please ask one of the code owners to trigger t
 ## Your First Contribution
 
 Unsure of where to begin contributing to Swift-DocC? You can start by looking at
-the issues on the [good first issue](https://github.com/apple/swift-docc/contribute)
+the issues on the [good first issue](https://github.com/swiftlang/swift-docc/contribute)
 page.
 
 Once you've found an issue to work on,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -494,8 +494,8 @@ of a documentation page and can be processed by a renderer such as
 For more in-depth technical information about Swift-DocC, please refer to the
 project's technical documentation:
 
-- [`SwiftDocC` framework documentation](https://apple.github.io/swift-docc/documentation/swiftdocc/)
-- [`SwiftDocCUtilities` framework documentation](https://apple.github.io/swift-docc/documentation/swiftdoccutilities/)
+- [`SwiftDocC` framework documentation](https://swiftlang.github.io/swift-docc/documentation/swiftdocc/)
+- [`SwiftDocCUtilities` framework documentation](https://swiftlang.github.io/swift-docc/documentation/swiftdoccutilities/)
 
 ### Related Projects
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ active development and source stability is not guaranteed.
 ### Submitting a Bug Report
 
 Swift-DocC tracks all bug reports with 
-[GitHub Issues](https://github.com/apple/swift-docc/issues).
+[GitHub Issues](https://github.com/swiftlang/swift-docc/issues).
 When you submit a bug report we ask that you follow the
-[provided template](https://github.com/apple/swift-docc/issues/new?assignees=&labels=bug&template=BUG_REPORT.yml)
+[provided template](https://github.com/swiftlang/swift-docc/issues/new?assignees=&labels=bug&template=BUG_REPORT.yml)
 and provide as many details as possible.
 
 > **Note:** You can use the [`environment`](bin/environment) script
@@ -92,7 +92,7 @@ it will help us track down the bug faster..
 ### Submitting a Feature Request
 
 For feature requests, please feel free to file a
-[GitHub issue](https://github.com/apple/swift-docc/issues/new?assignees=&labels=enhancement&template=FEATURE_REQUEST.yml)
+[GitHub issue](https://github.com/swiftlang/swift-docc/issues/new?assignees=&labels=enhancement&template=FEATURE_REQUEST.yml)
 or start a discussion on the [Swift Forums](https://forums.swift.org/c/development/swift-docc).
 
 Don't hesitate to submit a feature request if you see a way

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ There are multiple ways you can make use of DocC depending on your use case:
 **1. For documenting packages via SwiftPM:**
 
 If you want to generate documentation for your Swift package we recommend using the Swift-DocC Plugin. Please
-refer to the Plugin's [documentation](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/) to get started with 
-[building](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-a-specific-target), [previewing](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/previewing-documentation),
-and publishing your documentation to your [website](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online) or [GitHub Pages](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages).
+refer to the Plugin's [documentation](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/) to get started with 
+[building](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-a-specific-target), [previewing](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/previewing-documentation),
+and publishing your documentation to your [website](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online) or [GitHub Pages](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages).
 
 **2. For standalone documentation:**
 

--- a/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/RenderNode+NavigatorIndex.swift
@@ -131,7 +131,7 @@ extension NavigatorIndexableRenderNodeRepresentation {
     func navigatorTitle() -> String? {
         let tokens: [DeclarationRenderSection.Token]?
         
-        // FIXME: Use `metadata.navigatorTitle` for all Swift symbols (github.com/apple/swift-docc/issues/176).
+        // FIXME: Use `metadata.navigatorTitle` for all Swift symbols (github.com/swiftlang/swift-docc/issues/176).
         if identifier.sourceLanguage == .swift || (metadata.navigatorTitle ?? []).isEmpty {
             let pageType = navigatorPageType()
             guard !typesThatShouldNotUseNavigatorTitle.contains(pageType) else {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -414,7 +414,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for reference in rootModules {
             if let node = try? entity(with: reference) {
                 // A module node should always have a symbol.
-                // Remove the fallback value and force unwrap `node.symbol` on the main branch: https://github.com/apple/swift-docc/issues/249
+                // Remove the fallback value and force unwrap `node.symbol` on the main branch: https://github.com/swiftlang/swift-docc/issues/249
                 moduleNameCache[reference] = (node.name.plainText, node.symbol?.names.title ?? reference.lastPathComponent)
             }
         }
@@ -1120,7 +1120,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 // FIXME: Update with new SymbolKit API once available.
                 // This is a very inefficient way to gather the source languages
                 // represented in a symbol graph. Adding a dedicated SymbolKit API is tracked
-                // with github.com/apple/swift-docc-symbolkit/issues/32 and rdar://85982095.
+                // with github.com/swiftlang/swift-docc-symbolkit/issues/32 and rdar://85982095.
                 let symbolGraphLanguages = Set(
                     unifiedSymbolGraph.symbols.flatMap(\.value.sourceLanguages)
                 )
@@ -1247,7 +1247,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                     continue
                 }
                 
-                // FIXME: Resolve the link relative to the module https://github.com/apple/swift-docc/issues/516
+                // FIXME: Resolve the link relative to the module https://github.com/swiftlang/swift-docc/issues/516
                 let reference = TopicReference.unresolved(.init(topicURL: url))
                 switch resolve(reference, in: bundle.rootReference, fromSymbolLink: true) {
                 case .success(let resolved):
@@ -1264,7 +1264,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                         // The ConvertService relies on old implementation detail where documentation extension files were always considered "resolved" even when they didn't match a symbol.
                         //
                         // Don't rely on this behavior for new functionality. The behavior will be removed once we have a new solution to meets the needs of the ConvertService. (rdar://108563483)
-                        // https://github.com/apple/swift-docc/issues/567
+                        // https://github.com/swiftlang/swift-docc/issues/567
                         //
                         // The process that interacts with the convert service is responsible for:
                         // - Distinguishing between documentation extension files that match symbols and documentation extension files that don't match symbols.
@@ -1950,7 +1950,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             path: path,
             sourceLanguages: availableSourceLanguages
                 // FIXME: Pages in article-only catalogs should not be inferred as "Swift" as a fallback
-                // (github.com/apple/swift-docc/issues/240).
+                // (github.com/swiftlang/swift-docc/issues/240).
                 ?? [.swift]
         )
         

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -149,7 +149,7 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
         var renderReference = TopicRenderReference(
             identifier: .init(reference),
             title: resolvedInformation.title,
-            // The resolved information only stores the plain text abstract https://github.com/apple/swift-docc/issues/802
+            // The resolved information only stores the plain text abstract https://github.com/swiftlang/swift-docc/issues/802
             abstract: [.text(resolvedInformation.abstract)],
             url: resolvedInformation.url.path,
             kind: kind,
@@ -547,7 +547,7 @@ extension OutOfProcessReferenceResolver {
     public struct ResolvedInformation: Codable {
         // This type is duplicating the information from LinkDestinationSummary with some minor differences.
         // Changes generally need to be made in both places. It would be good to replace this with LinkDestinationSummary.
-        // FIXME: https://github.com/apple/swift-docc/issues/802
+        // FIXME: https://github.com/swiftlang/swift-docc/issues/802
         
         /// Information about the resolved kind.
         public let kind: DocumentationNode.Kind

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -132,7 +132,7 @@ struct PathHierarchy {
 
                     let node = Node(symbol: symbol, name: symbol.pathComponents.last!)
                     // Disfavor synthesized symbols when they collide with other symbol with the same path.
-                    // FIXME: Get information about synthesized symbols from SymbolKit https://github.com/apple/swift-docc-symbolkit/issues/58
+                    // FIXME: Get information about synthesized symbols from SymbolKit https://github.com/swiftlang/swift-docc-symbolkit/issues/58
                     if symbol.identifier.precise.contains("::SYNTHESIZED::") {
                         node.specialBehaviors = [.disfavorInLinkCollision, .excludeFromAutomaticCuration]
                     }

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
@@ -169,7 +169,7 @@ extension UnifiedSymbolGraph.Symbol {
     var sourceLanguages: Set<SourceLanguage> {
         // FIXME: Replace with new SymbolKit API once available.
         // Adding a dedicated SymbolKit API for this purpose is tracked
-        // with github.com/apple/swift-docc-symbolkit/issues/32 and rdar://85982095.
+        // with github.com/swiftlang/swift-docc-symbolkit/issues/32 and rdar://85982095.
         return Set(
             pathComponents.keys.map { selector in
                 SourceLanguage(knownLanguageIdentifier: selector.interfaceLanguage)

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -107,7 +107,7 @@ public class DocumentationContentRenderer {
     /// Returns the given amount of minutes as a string, for example: "1hr 10min".
     func formatEstimatedDuration(minutes: Int) -> String? {
         // TODO: Use DateComponentsFormatter once it's available on Linux (rdar://59787899) and 
-        // when Swift-DocC supports generating localized documentation (github.com/apple/swift-docc/issues/218), since
+        // when Swift-DocC supports generating localized documentation (github.com/swiftlang/swift-docc/issues/218), since
         // DateComponentsFormatter formats content based on the user's locale.
 //        let dateFormatter = DateComponentsFormatter()
 //        if #available(OSX 10.12, *) {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -220,7 +220,7 @@ struct RenderContentCompiler: MarkupVisitor {
         }
         
         // FIXME: Links from this build already exist in the reference index and don't need to be resolved again.
-        // https://github.com/apple/swift-docc/issues/581
+        // https://github.com/swiftlang/swift-docc/issues/581
 
         guard let validatedURL = ValidatedURL(parsingAuthoredLink: destination) else {
             return nil

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -627,7 +627,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         // Emit variants only if we're not compiling an article-only catalog to prevent renderers from
         // advertising the page as "Swift", which is the language DocC assigns to pages in article only pages.
-        // (github.com/apple/swift-docc/issues/240).
+        // (github.com/swiftlang/swift-docc/issues/240).
         if let topLevelModule = context.soleRootModuleReference,
            try! context.entity(with: topLevelModule).kind.isSymbol
         {

--- a/Sources/SwiftDocC/Model/SourceLanguage.swift
+++ b/Sources/SwiftDocC/Model/SourceLanguage.swift
@@ -38,7 +38,7 @@ public struct SourceLanguage: Hashable, Codable, Comparable {
         switch id {
         case "swift": self = .swift
         case "occ", "objc", "objective-c", "c": self = .objectiveC
-        // FIXME: DocC should display C++ and Objective-C++ as their own languages (https://github.com/apple/swift-docc/issues/767)
+        // FIXME: DocC should display C++ and Objective-C++ as their own languages (https://github.com/swiftlang/swift-docc/issues/767)
         case "occ++", "objc++", "objective-c++", "c++": self = .objectiveC
         case "javascript": self = .javaScript
         case "data": self = .data
@@ -113,8 +113,8 @@ public struct SourceLanguage: Hashable, Codable, Comparable {
         idAliases: [
             "objective-c",
             "objc",
-            "c", // FIXME: DocC should display C as its own language (github.com/apple/swift-docc/issues/169).
-            "c++", // FIXME: DocC should display C++ and Objective-C++ as their own languages (https://github.com/apple/swift-docc/issues/767)
+            "c", // FIXME: DocC should display C as its own language (github.com/swiftlang/swift-docc/issues/169).
+            "c++", // FIXME: DocC should display C++ and Objective-C++ as their own languages (https://github.com/swiftlang/swift-docc/issues/767)
             "objective-c++",
             "objc++",
             "occ++",

--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -75,7 +75,7 @@ extension Metadata {
                     }
                 }
                 if rawValue == "*" {
-                    // Reserve the `*` platform for when we have decided on how `*` availability should be displayed (https://github.com/apple/swift-docc/issues/969)
+                    // Reserve the `*` platform for when we have decided on how `*` availability should be displayed (https://github.com/swiftlang/swift-docc/issues/969)
                     return nil
                 } else {
                     self = .other(rawValue)

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -25,7 +25,7 @@ func unresolvedReferenceProblem(source: URL?, range: SourceRange?, severity: Dia
         } else {
             // FIXME: This assumes that the link uses the `<doc:my/reference>` syntax.
             // Links that use the [link text](doc:my/reference) syntax will have incorrect suggestion replacements.
-            // https://github.com/apple/swift-docc/issues/470
+            // https://github.com/swiftlang/swift-docc/issues/470
             
             // Inset the range by 5 at the start and by 1 at the end to skip "<doc:" at the start and ">" at the end.
             return SourceLocation(line: range.lowerBound.line, column: range.lowerBound.column+5, source: range.lowerBound.source) ..< SourceLocation(line: range.upperBound.line, column: range.upperBound.column-1, source: range.upperBound.source)

--- a/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/PlatformName.swift
@@ -114,7 +114,7 @@ public struct PlatformName: Codable, Hashable, Equatable {
     init?(metadataPlatform platform: Metadata.Availability.Platform) {
         // Note: This is still an optional initializer to prevent source breakage when
         // `Availability.Platform` re-introduces the `.any` case
-        // cf. https://github.com/apple/swift-docc/issues/441
+        // cf. https://github.com/swiftlang/swift-docc/issues/441
         if let knowDomain = Self.platformNamesIndex[platform.rawValue.lowercased()] {
             self = knowDomain
         } else {

--- a/Sources/docc/DocCDocumentation.docc/customizing-the-appearance-of-your-documentation-pages.md
+++ b/Sources/docc/DocCDocumentation.docc/customizing-the-appearance-of-your-documentation-pages.md
@@ -250,7 +250,7 @@ Most notably:
 - ``PageImage`` allows you to set a header image of a page.
 - ``PageColor`` allows you to set an accent color of a page.
 
-[1]: https://github.com/apple/swift-docc/blob/main/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
+[1]: https://github.com/swiftlang/swift-docc/blob/main/Sources/SwiftDocC/SwiftDocC.docc/Resources/ThemeSettings.spec.json
 [2]: https://drafts.csswg.org/css-variables/
 [3]: https://mportiz08.github.io/swift-docc/documentation/docc
 [4]: https://mportiz08.github.io/swift-docc/theme-settings.json

--- a/Sources/docc/DocCDocumentation.docc/distributing-documentation-to-other-developers.md
+++ b/Sources/docc/DocCDocumentation.docc/distributing-documentation-to-other-developers.md
@@ -25,7 +25,7 @@ Distributing your documentation involves the following steps:
 ### Generate a Publishable Archive of Your Documentation
 
 To create a documentation archive for a Swift package, use the [SwiftPM DocC
-Plugin](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/)
+Plugin](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/)
 or use Xcode's _Build Documentation_ command.
 
 Alternatively, use the `docc` command-line tool directly, for example:
@@ -143,7 +143,7 @@ You can also configure the base path path via the `--hosting-base-path` option
 when [building documentation using the SwiftPM DocC Plugin][plugin-docs] or via
 the `DOCC_HOSTING_BASE_PATH` build setting when building documentation in Xcode.
 
-[plugin-docs]: https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/
+[plugin-docs]: https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/
 
 #### Host a Documentation Archive Using Custom Routing
 

--- a/Sources/docc/DocCDocumentation.docc/documenting-a-swift-framework-or-package.md
+++ b/Sources/docc/DocCDocumentation.docc/documenting-a-swift-framework-or-package.md
@@ -30,7 +30,7 @@ To build documentation for your Swift framework or package, use the DocC command
 
 > Tip: You can also use the Swift-DocC Plugin to [build a documentation archive for a Swift package][plugin-docs].
 
-[plugin-docs]: https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/
+[plugin-docs]: https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online/
 
 DocC uses the comments you write in your source code as the content for the 
 documentation pages it generates. At a minimum, add basic documentation 
@@ -75,9 +75,9 @@ manifest's Swift tools version is set to `5.5` or later.
 
 The preferred way of building documentation for your Swift package is by using
 the Swift-DocC Plugin. Refer to instructions in the plugin's 
-[documentation](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/)
-to get started with [building](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-a-specific-target), [previewing](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/previewing-documentation),
-and publishing your documentation to your [website](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online) or [GitHub Pages](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages).
+[documentation](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/)
+to get started with [building](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-a-specific-target), [previewing](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/previewing-documentation),
+and publishing your documentation to your [website](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-hosting-online) or [GitHub Pages](https://swiftlang.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages).
 
 You can also use the DocC command-line interface, as described in <doc:distributing-documentation-to-other-developers>.
 

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -1524,7 +1524,7 @@ class ConvertServiceTests: XCTestCase {
                 let referenceStore = try XCTUnwrap(referenceStore)
                 
                 // The ConvertService relies on old implementation detail where documentation extension files were always considered "resolved" even when they didn't match a symbol. (rdar://108563483)
-                // https://github.com/apple/swift-docc/issues/567
+                // https://github.com/swiftlang/swift-docc/issues/567
                 
                 XCTAssertEqual(
                     Set(referenceStore.topics.keys.map(\.path)),

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2470,7 +2470,7 @@ let expected = """
         let topicReference = try XCTUnwrap(renderNode.references[curatedTopic] as? TopicRenderReference)
         XCTAssertEqual(topicReference.title, "An article")
         
-        // This test also reproduce https://github.com/apple/swift-docc/issues/593
+        // This test also reproduce https://github.com/swiftlang/swift-docc/issues/593
         // When that's fixed this test should also use a symbol link to curate the top-level symbol and verify that
         // the symbol link resolves to the symbol.
     }

--- a/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
@@ -129,7 +129,7 @@ class MetadataAvailabilityTests: XCTestCase {
         checkPlatforms += [
             "Package",
             "\"My Package\"", // Also check a platform with spaces in the name
-            // FIXME: Test validArguments with the `*` platform once that's introduced (https://github.com/apple/swift-docc/issues/969)
+            // FIXME: Test validArguments with the `*` platform once that's introduced (https://github.com/swiftlang/swift-docc/issues/969)
 //            "*",
         ]
         

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -52,7 +52,7 @@ swift package \
     --target SwiftDocC \
     --disable-indexing \
     --source-service github \
-    --source-service-base-url https://github.com/apple/swift-docc/blob/main \
+    --source-service-base-url https://github.com/swiftlang/swift-docc/blob/main \
     --checkout-path "$SWIFT_DOCC_ROOT" \
     --transform-for-static-hosting \
     --hosting-base-path swift-docc \
@@ -68,7 +68,7 @@ swift package \
     --target SwiftDocCUtilities \
     --disable-indexing \
     --source-service github \
-    --source-service-base-url https://github.com/apple/swift-docc/blob/main \
+    --source-service-base-url https://github.com/swiftlang/swift-docc/blob/main \
     --checkout-path "$SWIFT_DOCC_ROOT" \
     --transform-for-static-hosting \
     --hosting-base-path swift-docc \


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This makes 4 changes, each in their own commit to update various links from "apple.github.io" to "swiftlang.github.io" and from "github.com/apple" to "github.com/swiftlang". The former is more important since those links don't redirect.

Note that this doesn't update any github.com/apple/swift-nio links or apple.github.io/swift-argument-parser because those repos haven't moved yet.

This also doesn't update the any link in the Package.swift file.

## Dependencies

None.

## Testing

Not applicable

## Checklist

Not applicable