### PR TITLE
Support documenting platform specific properties and return values

### DIFF
--- a/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
+++ b/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
@@ -292,6 +292,9 @@ struct ParametersAndReturnValidator {
             }
             // If the two signatures have different parameters, add any missing parameters.
             // This allows for documenting parameters that are only available on some platforms.
+            //
+            // Note: Doing this redundant `elementsEqual(_:by:)` check is significantly faster in the common case when all platforms have the same signature.
+            // In the rare case where platforms have different signatures, the overhead of checking `elementsEqual(_:by:)` first is too small to measure.
             if !existing.parameters.elementsEqual(signature.parameters, by: hasSameNames) {
                 for case .insert(offset: let offset, element: let element, _) in signature.parameters.difference(from: existing.parameters, by: hasSameNames) {
                     existing.parameters.insert(element, at: offset)

--- a/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
+++ b/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
@@ -278,7 +278,32 @@ struct ParametersAndReturnValidator {
             guard let signature = mixin.getValueIfPresent(for: SymbolGraph.Symbol.FunctionSignature.self) else {
                 continue
             }
-            signatures[DocumentationDataVariantsTrait(for: selector)] = signature
+            
+            let trait = DocumentationDataVariantsTrait(for: selector)
+            // Check if we've already encountered a different signature for another platform
+            guard var existing = signatures.removeValue(forKey: trait) else {
+                signatures[trait] = signature
+                continue
+            }
+            
+            // An internal helper function that compares parameter names
+            func hasSameNames(_ lhs: SymbolGraph.Symbol.FunctionSignature.FunctionParameter, _ rhs: SymbolGraph.Symbol.FunctionSignature.FunctionParameter) -> Bool {
+                lhs.name == rhs.name && lhs.externalName == rhs.externalName
+            }
+            // If the two signatures have different parameters, add any missing parameters.
+            // This allows for documenting parameters that are only available on some platforms.
+            if !existing.parameters.elementsEqual(signature.parameters, by: hasSameNames) {
+                for case .insert(offset: let offset, element: let element, _) in signature.parameters.difference(from: existing.parameters, by: hasSameNames) {
+                    existing.parameters.insert(element, at: offset)
+                }
+            }
+            
+            // If the already encountered signature has a void return type, replace it with the non-void return type.
+            // This allows for documenting the return values that are only available on some platforms.
+            if existing.returns != signature.returns, existing.returns == knownVoidReturnValuesByLanguage[.init(id: selector.interfaceLanguage)] {
+                existing.returns = signature.returns
+            }
+            signatures[trait] = existing
         }
         
         guard !signatures.isEmpty else { return nil }


### PR DESCRIPTION

<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://130496794

## Summary

This fixes a special case with the validation of parameter and return value documentation where different platforms have different signatures for the language representation of the same symbol.

## Dependencies

None.

## Testing

- Define a C function with different parameters for different platforms, for example:
  ```c
  #if TARGET_OS_OSX
  void doSomething(int first);
  #else
  int doSomething(int first, int second);
  #endif
  ```

- Extract symbol graph files for both platforms
- Document the function in a documentation extension file:
  ```md
  # ``doSomething``
  
  Some documentation for this function
  
  - Parameters:
    - first: Some description for the parameter that's available on all platforms.
    - second: Some description for the parameter that's available on some platforms.
  - Returns: Some description for the return value that's only available on some platforms.
  ```
- Build documentation using both platform's symbol graph files.
  - There shouldn't be a warning about the documentation for the second parameter or the return value.
  - The rendered page should display both parameter's documentation and the return value documentation.

<img width="1197" alt="Screenshot 2024-07-10 at 15 54 09" src="https://github.com/swiftlang/swift-docc/assets/1228143/a4dd9a11-9a02-44f0-86d3-8b591c962027">



## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
