### PR TITLE
use SymbolKit's unified graph overload grouping

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
       "state" : {
-        "branch" : "reunify-overloads",
-        "revision" : "24c3ba103bca35da96890a0e5047646d7e4494fd"
+        "branch" : "main",
+        "revision" : "4c245d4b7264fbabb0fa1f7b3411c2c5bce4e2d9"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
         "branch" : "reunify-overloads",
-        "revision" : "c395db1572f1ada21499597b0fa4c2257a6be02c"
+        "revision" : "24c3ba103bca35da96890a0e5047646d7e4494fd"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/QuietMisdreavus/swift-docc-symbolkit",
       "state" : {
-        "branch" : "main",
-        "revision" : "19e41b0f84770c41375f5f58844038dda4c5c935"
+        "branch" : "reunify-overloads",
+        "revision" : "c395db1572f1ada21499597b0fa4c2257a6be02c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "reunify-overloads"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/QuietMisdreavus/swift-docc-symbolkit", branch: "reunify-overloads"),
+        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
     ]

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -120,16 +120,6 @@ struct PathHierarchy {
                 } else {
                     assert(!symbol.pathComponents.isEmpty, "A symbol should have at least its own name in its path components.")
 
-                    if symbol.identifier.precise.hasSuffix(SymbolGraph.Symbol.overloadGroupIdentifierSuffix),
-                       loader.unifiedGraphs[moduleNode.name]?.symbols.keys.contains(symbol.identifier.precise) != true {
-                        // Overload groups can be discarded in the unified symbol graph collector if
-                        // they don't reflect the default overload across all platforms. In this
-                        // case, we don't want to add these nodes to the path hierarchy since
-                        // they've been discarded from the unified graph that's used to generate
-                        // documentation nodes.
-                        continue
-                    }
-
                     let node = Node(symbol: symbol, name: symbol.pathComponents.last!)
                     // Disfavor synthesized symbols when they collide with other symbol with the same path.
                     // FIXME: Get information about synthesized symbols from SymbolKit https://github.com/swiftlang/swift-docc-symbolkit/issues/58
@@ -146,13 +136,6 @@ struct PathHierarchy {
                     }
                     allNodes[id, default: []].append(node)
                 }
-            }
-
-            for relationship in graph.relationships where relationship.kind == .overloadOf {
-                // An 'overloadOf' relationship points from symbol -> group. We want to disfavor the
-                // individual overload symbols in favor of resolving links to their overload group
-                // symbol.
-                nodes[relationship.source]?.specialBehaviors.formUnion([.disfavorInLinkCollision, .excludeFromAutomaticCuration])
             }
 
             // If there are multiple symbol graphs (for example for different source languages or platforms) then the nodes may have already been added to the hierarchy.

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -78,10 +78,6 @@ struct SymbolGraphLoader {
                 
                 configureSymbolGraph?(&symbolGraph)
 
-                if FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled {
-                    symbolGraph.createOverloadGroupSymbols()
-                }
-
                 let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)
                 // If the bundle provides availability defaults add symbol availability data.
                 self.addDefaultAvailability(to: &symbolGraph, moduleName: moduleName)
@@ -149,8 +145,10 @@ struct SymbolGraphLoader {
         }
         
         self.symbolGraphs = loadedGraphs.mapValues(\.graph)
-        (self.unifiedGraphs, self.graphLocations) = graphLoader.finishLoading()
-        
+        (self.unifiedGraphs, self.graphLocations) = graphLoader.finishLoading(
+            createOverloadGroups: FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled
+        )
+
         for var unifiedGraph in unifiedGraphs.values {
             var defaultUnavailablePlatforms = [PlatformName]()
             var defaultAvailableInformation = [DefaultAvailability.ModuleAvailability]()

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5276,6 +5276,75 @@ let expected = """
         }
     }
 
+    func testContextGeneratesOverloadGroupsForDisjointOverloads() throws {
+        enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
+
+        let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
+
+        let tempURL = try createTempFolder(content: [
+            Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName-macos.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    platform: .init(operatingSystem: .init(name: "macosx")),
+                    symbols: [
+                        makeSymbol(identifier: "symbol-1", kind: symbolKind),
+                    ])),
+                JSONFile(name: "ModuleName-ios.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    platform: .init(operatingSystem: .init(name: "ios")),
+                    symbols: [
+                        makeSymbol(identifier: "symbol-2", kind: symbolKind),
+                    ])),
+            ])
+        ])
+        let (_, bundle, context) = try loadBundle(from: tempURL)
+        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+
+        let overloadGroupNode: DocumentationNode
+        let overloadGroupSymbol: Symbol
+        let overloadGroupReferences: Symbol.Overloads
+
+        switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference, fromSymbolLink: true) {
+        case let .failure(_, errorMessage):
+            XCTFail("Could not resolve overload group page. Error message: \(errorMessage)")
+            return
+        case let .success(overloadGroupReference):
+            overloadGroupNode = try context.entity(with: overloadGroupReference)
+            overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
+            overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+
+            XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
+
+            let unifiedSymbol = try XCTUnwrap(overloadGroupNode.unifiedSymbol)
+            XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
+        }
+
+        let overloadedReferences = try ["symbol-1", "symbol-2"]
+            .map { try XCTUnwrap(context.documentationCache.reference(symbolID: $0)) }
+
+        for (index, reference) in overloadedReferences.indexed() {
+            let overloadedDocumentationNode = try XCTUnwrap(context.documentationCache[reference])
+            let overloadedSymbol = try XCTUnwrap(overloadedDocumentationNode.semantic as? Symbol)
+
+            let overloads = try XCTUnwrap(overloadedSymbol.overloadsVariants.firstValue)
+
+            // Make sure that each symbol contains all of its sibling overloads.
+            XCTAssertEqual(overloads.references.count, overloadedReferences.count - 1)
+            for (otherIndex, otherReference) in overloadedReferences.indexed() where otherIndex != index {
+                XCTAssert(overloads.references.contains(otherReference))
+            }
+
+            if overloads.displayIndex == 0 {
+                // The first declaration in the display list should be the same declaration as
+                // the overload group page
+                XCTAssertEqual(overloadedSymbol.declaration.first?.value.declarationFragments, overloadGroupSymbol.declaration.first?.value.declarationFragments)
+            } else {
+                // Otherwise, this reference should also be referenced by the overload group
+                XCTAssert(overloadGroupReferences.references.contains(reference))
+            }
+        }
+    }
+
     // A test helper that creates a symbol with a given identifier and kind.
     private func makeSymbol(
         name: String = "SymbolName",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://128624412

## Summary

This PR uses a new overload grouping implementation in SymbolKit to create overload group symbols in the unified symbol graph, rather than unifying individual symbol graphs' overload groups after the fact. This fixes a bug where disjoint overload groups (whether between platforms or via extensions) were not being combined.

## Dependencies

https://github.com/swiftlang/swift-docc-symbolkit/pull/81

## Testing

[This example doc catalog](https://github.com/user-attachments/files/16199979/asdf.docc.zip) contains two symbol graphs, one for macOS and one for iOS, each with one symbol that technically overload. It was generated from the following source code:

```swift
@available(macOS, unavailable)
public func myFunc(param: String) {}

@available(iOS, unavailable)
public func myFunc(param: Int) {}
```

Steps:
1. Download and extract `asdf.docc`, linked above.
2. `swift run docc preview --enable-experimental-overloaded-symbol-presentation /path/to/asdf.docc`
3. Navigate to the resulting documentation for `CrossPlatformOverloads`.
4. Ensure that only one page for `myFunc(param:)` is curated at the top level.
5. If you have a recent main-branch build of Swift-DocC-Render set into the `DOCC_HTML_DIR` environment variable, ensure that both the `Int` and `String` variants of `myFunc(param:)` are shown in the resulting overload page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
