### PR TITLE
Available directive docs

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,50 +12,34 @@ import Foundation
 import Markdown
 
 extension Metadata {
-    /// A directive that sets the platform availability information for a documentation page.
+    /// A directive that specifies when a documentation page is available for a given platform.
     ///
-    /// `@Available` is analogous to the `@available` attribute in Swift: It allows you to specify a
-    /// platform version that the page relates to. To specify a platform and version, list the platform
-    /// name and use the `introduced` argument. In addition, you can also specify a deprecated
-    /// version, using the `deprecated` argument:
+    /// Whenever possible, prefer to specify availability information using in-source annotations such as the `@available` attribute in Swift or the `API_AVAILABLE` macro in Objective-C.
+    /// Using in-source annotations ensures that your documentation matches the availability of your API.
+    /// If you duplicate availability information in the documentation markup, the information from the `@Available` directive overrides the information for the in-source annotations from that platform and risks being inaccurate.
     ///
-    /// ```markdown
-    /// @Available(macOS, introduced: "12.0")
-    /// @Available(macOS, introduced: "12.0", deprecated: "14.0")
-    /// ```
+    /// If your source language doesn't have a mechanism for specifying API availability or if you're writing articles about a newly introduced or deprecated API,
+    /// you can use the `@Available` directive to specify when you introduced, and optionally deprecated, an API or documentation page for a given platform.
     ///
-    /// Any text can be given to the first argument, and will be displayed in the page's
-    /// availability data. The platforms `iOS`, `macOS`, `watchOS`, and `tvOS` will be matched
-    /// case-insensitively, but anything else will be printed verbatim.
-    ///
-    /// To provide a platform name with spaces in it, provide it as a quoted string:
-    ///
-    /// ```markdown
-    /// @Available("My Package", introduced: "1.0")
-    /// ```
-    ///
-    /// Only strings which are valid semantic version numbers may be passed to the `introduced` and `deprecated` arguments. Specifying an incomplete version number is allowed, as long as all components of the version are valid numbers:
-    ///
-    /// ```markdown
-    /// @Available("My Package", introduced: "1.0.0")
-    /// @Available("My Package", introduced: "1.0")
-    /// @Available("My Package", introduced: "1")
-    /// @Available("My Package", introduced: "1.0.0", deprecated: "2.3.2")
-    /// ```
-    ///
-    /// If an invalid semantic version number is provided, a compiler warning will be issued and the directive will be ignored.
-    ///
-    /// This directive is available on both articles and documentation extension files. In extension
-    /// files, the information overrides any information from the symbol itself.
-    ///
-    /// This directive is only valid within a ``Metadata`` directive:
+    /// Each `@Available` directive specifies the availability information for a single platform.
+    /// The directive matches the `iOS`, `macOS`, `watchOS`, and `tvOS` platform names case-insensitively.
+    /// Any other platform names are displayed verbatim.
+    /// If a platform name contains whitespace, commas, or other special characters you need to surround it with quotation marks (`"`).
     ///
     /// ```markdown
     /// @Metadata {
-    ///     @Available(macOS, introduced: "12.0")
     ///     @Available(iOS, introduced: "15.0")
+    ///     @Available(macOS, introduced: "12.0", deprecated: "14.0")
+    ///     @Available("My Package", introduced: "1.2.3")
     /// }
     /// ```
+    ///
+    /// Both the "introduced" and "deprecated" parameters take string representations of semantic version numbers (major`.`minor`.`patch).
+    /// If you omit the "patch" or "minor" components, they are assumed to be `0`.
+    /// This means that `"1.0.0"`, `"1.0"`, and `"1"` all specify the same semantic version.
+    ///
+    /// > Earlier Versions:
+    /// > Before Swift-DocC 6.0, the `@Available` directive didn't support the "deprecated" parameter.
     public final class Availability: Semantic, AutomaticDirectiveConvertible {
         public static let directiveName: String = "Available"
         public static let introducedVersion = "5.8"
@@ -97,15 +81,15 @@ extension Metadata {
             }
         }
 
-        /// The platform that this argument's information applies to.
+        /// The platform name that this version information applies to.
         @DirectiveArgumentWrapped(name: .unnamed)
         public var platform: Platform
 
-        /// The platform version that this page was introduced in.
+        /// The semantic version (major`.`minor`.`patch) when you introduced this API or documentation page.
         @DirectiveArgumentWrapped
         public var introduced: SemanticVersion
 
-        /// The platform version that this page was deprecated in.
+        /// The semantic version (major`.`minor`.`patch) when you deprecated this API or documentation page.
         @DirectiveArgumentWrapped
         public var deprecated: SemanticVersion? = nil
 

--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -40,6 +40,10 @@ extension Metadata {
     ///
     /// > Earlier Versions:
     /// > Before Swift-DocC 6.0, the `@Available` directive didn't support the "deprecated" parameter.
+    ///
+    /// > Tip:
+    /// > In addition to specifying the version when you deprecated an API or documentation page,
+    /// > you can use the ``DeprecationSummary`` directive to provide the reader with additional information about the deprecation or refer them to a replacement API.
     public final class Availability: Semantic, AutomaticDirectiveConvertible {
         public static let directiveName: String = "Available"
         public static let introducedVersion = "5.8"

--- a/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,24 @@
 import Foundation
 import Markdown
 
-/// A directive to add custom deprecation summary to an already deprecated symbol.
+/// A directive that specifies a custom deprecation summary message to an already deprecated symbol.
+///
+/// Many in-source deprecation annotations—such as the `@available` attribute in Swift—allow you to specify a plain text deprecation message.
+/// You can use the `@DeprecationSummary` directive to override that deprecation message with one or more paragraphs of formatted documentation markup.
+/// For example,
+///
+/// ```md
+/// @DeprecationSummary {
+///     This method is unsafe because it could potentially cause buffer overruns.
+///     Use ``getBytes(_:length:)`` or ``getBytes(_:range:)`` instead.
+/// }
+/// ```
+///
+/// You can use the `@DeprecationSummary` directive top-level in both articles and documentation extension files.
+///
+/// > Tip:
+/// > If you are writing a custom deprecation summary message for an API or documentation page that isn't already deprecated,
+/// > you should also deprecate it—using in-source annotations when possible or ``Available`` directives when in-source annotations aren't available—so that the reader knows the version when you deprecated that API or documentation page.
 public final class DeprecationSummary: Semantic, AutomaticDirectiveConvertible {
     public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective
@@ -27,8 +44,6 @@ public final class DeprecationSummary: Semantic, AutomaticDirectiveConvertible {
     static var keyPaths: [String : AnyKeyPath] = [
         "content" : \DeprecationSummary._content
     ]
-    
-    static var hiddenFromDocumentation = true
     
     /// Creates a new deprecation summary from the content of the given directive.
     /// - Parameters:

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -767,6 +767,18 @@
             "text" : "> Before Swift-DocC 6.0, the `@Available` directive didn't support the \"deprecated\" parameter."
           },
           {
+            "text" : ""
+          },
+          {
+            "text" : "> Tip:"
+          },
+          {
+            "text" : "> In addition to specifying the version when you deprecated an API or documentation page,"
+          },
+          {
+            "text" : "> you can use the ``DeprecationSummary`` directive to provide the reader with additional information about the deprecation or refer them to a replacement API."
+          },
+          {
             "text" : "- Parameters:"
           },
           {
@@ -1951,6 +1963,126 @@
       },
       "pathComponents" : [
         "ContentAndMedia"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
+            "major" : 5,
+            "minor" : 5,
+            "patch" : 0
+          }
+        }
+      ],
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "DeprecationSummary"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " {\n    ...\n}"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that specifies a custom deprecation summary message to an already deprecated symbol."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Many in-source deprecation annotations—such as the `@available` attribute in Swift—allow you to specify a plain text deprecation message."
+          },
+          {
+            "text" : "You can use the `@DeprecationSummary` directive to override that deprecation message with one or more paragraphs of formatted documentation markup."
+          },
+          {
+            "text" : "For example,"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "@DeprecationSummary {"
+          },
+          {
+            "text" : "    This method is unsafe because it could potentially cause buffer overruns."
+          },
+          {
+            "text" : "    Use ``getBytes(_:length:)`` or ``getBytes(_:range:)`` instead."
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "You can use the `@DeprecationSummary` directive top-level in both articles and documentation extension files."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "> Tip:"
+          },
+          {
+            "text" : "> If you are writing a custom deprecation summary message for an API or documentation page that isn't already deprecated,"
+          },
+          {
+            "text" : "> you should also deprecate it—using in-source annotations when possible or ``Available`` directives when in-source annotations aren't available—so that the reader knows the version when you deprecated that API or documentation page."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$DeprecationSummary"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$DeprecationSummary",
+            "spelling" : "DeprecationSummary"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "DeprecationSummary"
+          }
+        ],
+        "title" : "DeprecationSummary"
+      },
+      "pathComponents" : [
+        "DeprecationSummary"
       ]
     },
     {

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -653,7 +653,27 @@
         },
         {
           "kind" : "typeIdentifier",
-          "spelling" : "String"
+          "spelling" : "SemanticVersion"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ", "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "deprecated"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "SemanticVersion"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "?"
         },
         {
           "kind" : "text",
@@ -663,76 +683,43 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive that sets the platform availability information for a documentation page."
+            "text" : "A directive that specifies when a documentation page is available for a given platform."
           },
           {
             "text" : ""
           },
           {
-            "text" : "`@Available` is analogous to the `@available` attribute in Swift: It allows you to specify a"
+            "text" : "Whenever possible, prefer to specify availability information using in-source annotations such as the `@available` attribute in Swift or the `API_AVAILABLE` macro in Objective-C."
           },
           {
-            "text" : "platform version that the page relates to. To specify a platform and version, list the platform"
+            "text" : "Using in-source annotations ensures that your documentation matches the availability of your API."
           },
           {
-            "text" : "name and use the `introduced` argument:"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "```markdown"
-          },
-          {
-            "text" : "@Available(macOS, introduced: \"12.0\")"
-          },
-          {
-            "text" : "```"
+            "text" : "If you duplicate availability information in the documentation markup, the information from the `@Available` directive overrides the information for the in-source annotations from that platform and risks being inaccurate."
           },
           {
             "text" : ""
           },
           {
-            "text" : "Any text can be given to the first argument, and will be displayed in the page's"
+            "text" : "If your source language doesn't have a mechanism for specifying API availability or if you're writing articles about a newly introduced or deprecated API,"
           },
           {
-            "text" : "availability data. The platforms `iOS`, `macOS`, `watchOS`, and `tvOS` will be matched"
-          },
-          {
-            "text" : "case-insensitively, but anything else will be printed verbatim."
+            "text" : "you can use the `@Available` directive to specify when you introduced, and optionally deprecated, an API or documentation page for a given platform."
           },
           {
             "text" : ""
           },
           {
-            "text" : "To provide a platform name with spaces in it, provide it as a quoted string:"
+            "text" : "Each `@Available` directive specifies the availability information for a single platform."
           },
           {
-            "text" : ""
+            "text" : "The directive matches the `iOS`, `macOS`, `watchOS`, and `tvOS` platform names case-insensitively."
           },
           {
-            "text" : "```markdown"
+            "text" : "Any other platform names are displayed verbatim."
           },
           {
-            "text" : "@Available(\"My Package\", introduced: \"1.0\")"
-          },
-          {
-            "text" : "```"
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is available on both articles and documentation extension files. In extension"
-          },
-          {
-            "text" : "files, the information overrides any information from the symbol itself."
-          },
-          {
-            "text" : ""
-          },
-          {
-            "text" : "This directive is only valid within a ``Metadata`` directive:"
+            "text" : "If a platform name contains whitespace, commas, or other special characters you need to surround it with quotation marks (`\"`)."
           },
           {
             "text" : ""
@@ -744,10 +731,13 @@
             "text" : "@Metadata {"
           },
           {
-            "text" : "    @Available(macOS, introduced: \"12.0\")"
+            "text" : "    @Available(iOS, introduced: \"15.0\")"
           },
           {
-            "text" : "    @Available(iOS, introduced: \"15.0\")"
+            "text" : "    @Available(macOS, introduced: \"12.0\", deprecated: \"14.0\")"
+          },
+          {
+            "text" : "    @Available(\"My Package\", introduced: \"1.2.3\")"
           },
           {
             "text" : "}"
@@ -756,19 +746,46 @@
             "text" : "```"
           },
           {
+            "text" : ""
+          },
+          {
+            "text" : "Both the \"introduced\" and \"deprecated\" parameters take string representations of semantic version numbers (major`.`minor`.`patch)."
+          },
+          {
+            "text" : "If you omit the \"patch\" or \"minor\" components, they are assumed to be `0`."
+          },
+          {
+            "text" : "This means that `\"1.0.0\"`, `\"1.0\"`, and `\"1\"` all specify the same semantic version."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "> Earlier Versions:"
+          },
+          {
+            "text" : "> Before Swift-DocC 6.0, the `@Available` directive didn't support the \"deprecated\" parameter."
+          },
+          {
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - platform: The platform that this argument's information applies to."
+            "text" : "  - platform: The platform name that this version information applies to."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "  - introduced: The platform version that this page applies to."
+            "text" : "  - introduced: The semantic version (major`.`minor`.`patch) when you introduced this API or documentation page."
           },
           {
             "text" : "     **(required)**"
+          },
+          {
+            "text" : "  - deprecated: The semantic version (major`.`minor`.`patch) when you deprecated this API or documentation page."
+          },
+          {
+            "text" : "     **(optional)**"
           }
         ]
       },
@@ -835,7 +852,23 @@
           },
           {
             "kind" : "typeIdentifier",
-            "spelling" : "String"
+            "spelling" : "SemanticVersion"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ", "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "deprecated"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "SemanticVersion"
           },
           {
             "kind" : "text",

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -1,4 +1,4 @@
-# ``docc/Metadata``
+# ``Metadata``
 
 Use metadata directives to instruct DocC how to build certain documentation files.
 
@@ -82,6 +82,7 @@ previous versions, @Redirected must be used as a top level directive.
 ### Customizing the Availability Information of a Page
 
 - ``Available``
+- ``DeprecationSummary``
 
 ### Specifying an Additional URL of a Page
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://131987745

## Summary

This PR updates the documentation for the `@Available` directive to:
- lead with information about when to use it and when to use in-source annotation instead
- add documentation for the new "deprecated" parameter and mention which versions of DocC support it.
- rephrases several sentences to avoid passive voice, for preferring "when you introduced this API" over "when this API was introduced".
- Combine the 3 code examples into 1 and wraps it in a `@Metadata` directive so that it's clearer that `@Available` is used within `@Metadata`.

It also unhides and documents the `@DeprecationSummary` directive to:
- provide information about when to use `@DeprecationSummary` and when to use in-source annotation instead
- provide tips about using `@DeprecationSummary` and `@Available` together to give the reader the most information about a deprecated API.

## Dependencies

None

## Testing

Run `swift run docc preview Sources/docc/DocCDocumentation.docc` and preview:
- http://localhost:8080/documentation/docc/available
- http://localhost:8080/documentation/docc/deprecationsummary

<img width="1205" alt="Screenshot 2024-07-18 at 16 58 02" src="https://github.com/user-attachments/assets/901b139e-6007-443b-a22c-a3eb6dbb2c46">
<img width="1205" alt="Screenshot 2024-07-18 at 16 58 07" src="https://github.com/user-attachments/assets/b8ed87d2-6f7f-409d-8df9-1a2bdd5e1567">


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~ Not applicable
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
