### PR TITLE
Fix tests for Linux CI

### DIFF
--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -458,7 +458,7 @@ class ExternalLinkableTests: XCTestCase {
                 .init(
                     title: "Type Methods",
                     identifiers: [
-                        summary.referenceURL.appendingPathComponent("myStringFunction(_:)").absoluteString,
+                        summary.referenceURL.appendingPathComponent("myStringFunction(_:)").absoluteString.removingPercentEncoding!,
                     ]
                 ),
             ])

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -144,7 +144,7 @@ class FileRequestHandlerTests: XCTestCase {
             ])
         ])
 
-        let request = makeRequestHead(uri: "https://invalid host.com", headers: [("Range", "bytes=0-1")])
+        let request = makeRequestHead(uri: "https://example-host.com:-80", headers: [("Range", "bytes=0-1")])
         let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
         let response = try responseWithPipeline(request: request, handler: factory)
         


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Attempts to fix a number of tests which are not working on Linux CI since yesterday.

### `ExternalLinkableTests.testVariantSummaries`
```
/home/build-user/swift-docc/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift:457: error: ExternalLinkableTests.testVariantSummaries : XCTAssertEqual failed: ("Optional([SwiftDocC.LinkDestinationSummary.TaskGroup(title: Optional("Type Methods"), identifiers: ["doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)"])])") is not equal to ("Optional([SwiftDocC.LinkDestinationSummary.TaskGroup(title: Optional("Type Methods"), identifiers: ["doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/Bar/myStringFunction(_%3A)"])])") - 
```

Looks like it's related to how the character `:` is being encoded in the URL:
`myStringFunction(_:)` vs `myStringFunction(_%3A)`

This is an attempt to fix the test by removing percent encoding from the test URL.

### `FileRequestHandlerTests.testMalformedURI`
```
/home/build-user/swift-docc/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift:152: error: FileRequestHandlerTests.testMalformedURI : XCTAssertEqual failed: ("Optional(401)") is not equal to ("Optional(400)") - 
```

Spaces no longer cause a URL to be malformed in Linux, as they're automatically encoded into percentages.

To create a malformed URI, use a negative port number instead.

### (**WIP**) `ConvertActionTests`

```
<EXPR>:0: error: ConvertActionTests.testCopyingVideoAssets : threw error "Error Domain=NSCocoaErrorDomain Code=260 "The file doesn’t exist.""
```

- [ ] TODO: Currently trying to figure out how to fix this test

## Dependencies

None.

## Testing

Unit tests should pass in Linux CI.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~~[ ] Added tests~~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~ N/A
