### PR TITLE
mask out tests that are failing on Linux

### DIFF
--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -436,7 +436,9 @@ class ExternalLinkableTests: XCTestCase {
             XCTAssertEqual(decoded, summary)
         }
     }
-    
+
+    // TODO: Remove this #if once https://github.com/apple/swift-corelibs-foundation/issues/5028 is resolved
+    #if os(macOS)
     func testVariantSummaries() throws {
         let (bundle, context) = try testBundleAndContext(named: "MixedLanguageFramework")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
@@ -591,7 +593,8 @@ class ExternalLinkableTests: XCTestCase {
             XCTAssertEqual(decoded, summary)
         }
     }
-    
+    #endif
+
     func testDecodingLegacyData() throws {
         let legacyData = """
         {

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -17,7 +17,8 @@ import Markdown
 @testable import SwiftDocCTestUtilities
 
 class ConvertActionTests: XCTestCase {
-    #if !os(iOS)
+    // TODO: Change this back to `#if !os(iOS)` once https://github.com/apple/swift-corelibs-foundation/issues/5028 is resolved
+    #if os(macOS)
     let imageFile = Bundle.module.url(
         forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         .appendingPathComponent("figure1.png")


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

This PR adds a couple `#if os(macOS)` wrappers to some tests that are currently failing on Linux. Some offline discussion pointed to https://github.com/apple/swift-corelibs-foundation/issues/5028 as a cause for these failures, so until that is fixed and available in a nightly toolchain, we need to keep these tests from running.

## Dependencies

None

## Testing

Test-only change

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
