### PR TITLE
Support parsing links to C++ operators with trailing anchors and disambiguation 

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -223,7 +223,6 @@ private struct PathComponentScanner {
     }
     
     private mutating func scanUntilSeparator() -> Substring {
-        // If the string doesn't contain a slash then the rest of the string is the component
         guard let index = remaining.firstIndex(of: Self.separator) else {
             defer { remaining.removeAll() }
             return remaining

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -2209,6 +2209,185 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("/MainModule/TopLevelProtocol/InnerStruct/extensionMember(_:)", in: tree, asSymbolID: "extensionMember2")
     }
     
+    func testLinksToCxxOperators() throws {
+        let (_, context) = try testBundleAndContext(named: "CxxOperators")
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        // MyClass operator+() const;                     // unary plus
+        // MyClass operator+(const MyClass& other) const; // addition
+        try assertPathCollision("/CxxOperators/MyClass/operator+", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator+#1", disambiguation: "15qb6"),
+            (symbolID: "c:@S@MyClass@F@operator+#&1$@S@MyClass#1", disambiguation: "8k1ef"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator+-15qb6", in: tree, asSymbolID: "c:@S@MyClass@F@operator+#1")
+        try assertFindsPath("/CxxOperators/MyClass/operator+-8k1ef", in: tree, asSymbolID: "c:@S@MyClass@F@operator+#&1$@S@MyClass#1")
+
+        // MyClass operator-() const;                     // unary minus
+        // MyClass operator-(const MyClass& other) const; // subtraction
+        try assertPathCollision("/CxxOperators/MyClass/operator-", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator-#1", disambiguation: "1c6gw"),
+            (symbolID: "c:@S@MyClass@F@operator-#&1$@S@MyClass#1", disambiguation: "6knvo"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator--1c6gw", in: tree, asSymbolID: "c:@S@MyClass@F@operator-#1")
+        try assertFindsPath("/CxxOperators/MyClass/operator--6knvo", in: tree, asSymbolID: "c:@S@MyClass@F@operator-#&1$@S@MyClass#1")
+
+        // MyClass& operator*();                          // indirect access
+        // MyClass operator*(const MyClass& other) const; // multiplication
+        try assertPathCollision("/CxxOperators/MyClass/operator*", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator*#&1$@S@MyClass#1", disambiguation: "6oso3"),
+            (symbolID: "c:@S@MyClass@F@operator*#", disambiguation: "8vjwm"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator*-6oso3", in: tree, asSymbolID: "c:@S@MyClass@F@operator*#&1$@S@MyClass#1")
+        try assertFindsPath("/CxxOperators/MyClass/operator*-8vjwm", in: tree, asSymbolID: "c:@S@MyClass@F@operator*#")
+
+        // MyClass operator/(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator/", in: tree, asSymbolID: "c:@S@MyClass@F@operator/#&1$@S@MyClass#1")
+
+        // MyClass operator%(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator%", in: tree, asSymbolID: "c:@S@MyClass@F@operator%#&1$@S@MyClass#1")
+
+        // MyClass operator~() const;
+        try assertFindsPath("/CxxOperators/MyClass/operator~", in: tree, asSymbolID: "c:@S@MyClass@F@operator~#1")
+
+        // MyClass* operator&();                          // address-of
+        // MyClass operator&(const MyClass& other) const; // bitwise and
+        try assertPathCollision("/CxxOperators/MyClass/operator&", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator&#&1$@S@MyClass#1", disambiguation: "3ob2f"),
+            (symbolID: "c:@S@MyClass@F@operator&#", disambiguation: "8vnp2"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator&-3ob2f", in: tree, asSymbolID: "c:@S@MyClass@F@operator&#&1$@S@MyClass#1")
+        try assertFindsPath("/CxxOperators/MyClass/operator&-8vnp2", in: tree, asSymbolID: "c:@S@MyClass@F@operator&#")
+
+        // MyClass operator|(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator|", in: tree, asSymbolID: "c:@S@MyClass@F@operator|#&1$@S@MyClass#1")
+
+        // MyClass operator^(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator^", in: tree, asSymbolID: "c:@S@MyClass@F@operator^#&1$@S@MyClass#1")
+
+        // MyClass operator<<(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator<<", in: tree, asSymbolID: "c:@S@MyClass@F@operator<<#&1$@S@MyClass#1")
+
+        // MyClass operator>>(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator>>", in: tree, asSymbolID: "c:@S@MyClass@F@operator>>#&1$@S@MyClass#1")
+
+        // MyClass operator++(int); // post-increment
+        // MyClass& operator++();   // pre-increment
+        try assertPathCollision("/CxxOperators/MyClass/operator++", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator++#", disambiguation: "15swg"),
+            (symbolID: "c:@S@MyClass@F@operator++#I#", disambiguation: "68oe0"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator++-68oe0", in: tree, asSymbolID: "c:@S@MyClass@F@operator++#I#")
+        try assertFindsPath("/CxxOperators/MyClass/operator++-15swg", in: tree, asSymbolID: "c:@S@MyClass@F@operator++#")
+
+        // MyClass operator--(int); // post-decrement
+        // MyClass& operator--();   // pre-decrement
+        try assertPathCollision("/CxxOperators/MyClass/operator--", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator-#", disambiguation: "8vk0i"),
+            (symbolID: "c:@S@MyClass@F@operator-#I#", disambiguation: "9wv7m"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator---9wv7m", in: tree, asSymbolID: "c:@S@MyClass@F@operator-#I#")
+        try assertFindsPath("/CxxOperators/MyClass/operator---8vk0i", in: tree, asSymbolID: "c:@S@MyClass@F@operator-#")
+
+        // bool operator!() const;
+        try assertFindsPath("/CxxOperators/MyClass/operator!", in: tree, asSymbolID: "c:@S@MyClass@F@operator!#1")
+
+        // bool operator&&(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator&&", in: tree, asSymbolID: "c:@S@MyClass@F@operator&&#&1$@S@MyClass#1")
+
+        // bool operator||(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator||", in: tree, asSymbolID: "c:@S@MyClass@F@operator||#&1$@S@MyClass#1")
+
+        // bool operator==(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator==", in: tree, asSymbolID: "c:@S@MyClass@F@operator==#&1$@S@MyClass#1")
+
+        // bool operator!=(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator!=", in: tree, asSymbolID: "c:@S@MyClass@F@operator!=#&1$@S@MyClass#1")
+
+        // bool operator<(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator<", in: tree, asSymbolID: "c:@S@MyClass@F@operator<#&1$@S@MyClass#1")
+
+        // bool operator>(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator>", in: tree, asSymbolID: "c:@S@MyClass@F@operator>#&1$@S@MyClass#1")
+
+        // bool operator<=(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator<=", in: tree, asSymbolID: "c:@S@MyClass@F@operator<=#&1$@S@MyClass#1")
+
+        // bool operator>=(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator>=", in: tree, asSymbolID: "c:@S@MyClass@F@operator>=#&1$@S@MyClass#1")
+
+        // std::weak_ordering operator<=>(const MyClass& other) const;
+        try assertFindsPath("/CxxOperators/MyClass/operator<=>", in: tree, asSymbolID: "c:@S@MyClass@F@operator<=>#&1$@S@MyClass#1")
+
+        // MyClass operator=(const MyClass other);    // pass-by-value copy assignment
+        // MyClass& operator=(const MyClass& other);  // copy assignment
+        // MyClass& operator=(const MyClass&& other); // move assignment
+        try assertPathCollision("/CxxOperators/MyClass/operator=", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator=#&1$@S@MyClass#", disambiguation: "36ink"),
+            (symbolID: "c:@S@MyClass@F@operator=#1$@S@MyClass#", disambiguation: "5360m"),
+            (symbolID: "c:@S@MyClass@F@operator=#&&1$@S@MyClass#", disambiguation: "6e1gm"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator=-5360m", in: tree, asSymbolID: "c:@S@MyClass@F@operator=#1$@S@MyClass#")
+        try assertFindsPath("/CxxOperators/MyClass/operator=-36ink", in: tree, asSymbolID: "c:@S@MyClass@F@operator=#&1$@S@MyClass#")
+        try assertFindsPath("/CxxOperators/MyClass/operator=-6e1gm", in: tree, asSymbolID: "c:@S@MyClass@F@operator=#&&1$@S@MyClass#")
+
+        // MyClass& operator+=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator+=", in: tree, asSymbolID: "c:@S@MyClass@F@operator+=#&1$@S@MyClass#")
+
+        // MyClass& operator-=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator-=", in: tree, asSymbolID: "c:@S@MyClass@F@operator-=#&1$@S@MyClass#")
+
+        // MyClass& operator*=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator*=", in: tree, asSymbolID: "c:@S@MyClass@F@operator*=#&1$@S@MyClass#")
+
+        // MyClass& operator/=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator/=", in: tree, asSymbolID: "c:@S@MyClass@F@operator/=#&1$@S@MyClass#")
+
+        // MyClass& operator%=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator%=", in: tree, asSymbolID: "c:@S@MyClass@F@operator%=#&1$@S@MyClass#")
+
+        // MyClass operator&=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator&=", in: tree, asSymbolID: "c:@S@MyClass@F@operator&=#&1$@S@MyClass#")
+
+        // MyClass operator|=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator|=", in: tree, asSymbolID: "c:@S@MyClass@F@operator|=#&1$@S@MyClass#")
+
+        // MyClass operator^=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator^=", in: tree, asSymbolID: "c:@S@MyClass@F@operator^=#&1$@S@MyClass#")
+
+        // MyClass operator<<=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator<<=", in: tree, asSymbolID: "c:@S@MyClass@F@operator<<=#&1$@S@MyClass#")
+
+        // MyClass operator>>=(const MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator>>=", in: tree, asSymbolID: "c:@S@MyClass@F@operator>>=#&1$@S@MyClass#")
+
+        // MyClass& operator[](std::string& key);              // subscript
+        // static void operator[](MyClass& lhs, MyClass& rhs); // subscript
+        try assertPathCollision("/CxxOperators/MyClass/operator[]", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator[]#&$@S@MyClass#S0_#S", disambiguation: "8qcye"),
+            (symbolID: "c:@S@MyClass@F@operator[]#&$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#", disambiguation: "9758f"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator[]-9758f", in: tree, asSymbolID: "c:@S@MyClass@F@operator[]#&$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#")
+        try assertFindsPath("/CxxOperators/MyClass/operator[]-8qcye", in: tree, asSymbolID: "c:@S@MyClass@F@operator[]#&$@S@MyClass#S0_#S")
+
+        // MyClass& operator->();
+        try assertFindsPath("/CxxOperators/MyClass/operator->", in: tree, asSymbolID: "c:@S@MyClass@F@operator->#")
+
+        // MyClass& operator->*(const std::string& key);
+        try assertFindsPath("/CxxOperators/MyClass/operator->*", in: tree, asSymbolID: "c:@S@MyClass@F@operator->*#&1$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#")
+
+        // MyClass& operator()(MyClass& arg1, MyClass& arg2, MyClass& arg3); // function-call
+        // static void operator()(MyClass& lhs, MyClass& rhs);               // function-call
+        try assertPathCollision("/CxxOperators/MyClass/operator()", in: tree, collisions: [
+            (symbolID: "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S", disambiguation: "212ks"),
+            (symbolID: "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S0_#", disambiguation: "65g9a"),
+        ])
+        try assertFindsPath("/CxxOperators/MyClass/operator()-65g9a", in: tree, asSymbolID: "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S0_#")
+        try assertFindsPath("/CxxOperators/MyClass/operator()-212ks", in: tree, asSymbolID: "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S")
+
+        // MyClass& operator,(MyClass& other);
+        try assertFindsPath("/CxxOperators/MyClass/operator,", in: tree, asSymbolID: "c:@S@MyClass@F@operator,#&$@S@MyClass#")
+    }
+    
     func testParsingPaths() {
         // Check path components without disambiguation
         assertParsedPathComponents("", [])
@@ -2254,7 +2433,7 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("MyNumber////=(_:_:)", [("MyNumber", nil), ("///=(_:_:)", nil)])
         assertParsedPathComponents("MyNumber/+/-(_:_:)", [("MyNumber", nil), ("+/-(_:_:)", nil)])
         
-        let knownCppOperators = [
+        let knownCxxOperators = [
             // Arithmetic
             "+", "-", "*", "/", "%",
             // Bitwise arithmetic
@@ -2276,8 +2455,8 @@ class PathHierarchyTests: XCTestCase {
             // Other
             ","
         ]
-         
-        for operatorSymbol in knownCppOperators {
+        
+        for operatorSymbol in knownCxxOperators {
             let operatorName = "operator\(operatorSymbol)"
             assertParsedPathComponents(operatorName, [(operatorName, nil)])
             assertParsedPathComponents("MyClass/\(operatorName)", [("MyClass", nil), (operatorName, nil)])

--- a/Tests/SwiftDocCTests/Test Bundles/CxxOperators.docc/CxxOperators.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/CxxOperators.docc/CxxOperators.symbols.json
@@ -1,0 +1,7156 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 5,
+      "patch": 3
+    },
+    "generator": "Apple clang version 16.0.0 (clang-1600.0.24.1)"
+  },
+  "module": {
+    "name": "CxxOperators",
+    "platform": {
+      "architecture": "arm64",
+      "operatingSystem": {
+        "minimumVersion": {
+          "major": 11,
+          "minor": 0,
+          "patch": 0
+        },
+        "name": "macosx"
+      },
+      "vendor": "apple"
+    }
+  },
+  "relationships": [
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator+#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator-#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator+#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator-#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator*#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator/#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator%#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator~#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator&#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator|#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator^#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator<<#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator>>#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator++#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator-#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator++#I#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator-#I#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator!#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator&&#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator||#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator==#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator!=#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator<#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator>#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator<=#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator>=#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator<=>#&1$@S@MyClass#1",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator=#1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator=#&&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@MyClass#&$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@MyClass#&&$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator+=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator-=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator*=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator/=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator%=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator&=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator|=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator^=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator<<=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator>>=#&1$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator[]#&$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator[]#&$@S@MyClass#S0_#S",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator*#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator&#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator->#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator->*#&1$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S0_#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:@S@MyClass@F@operator,#&$@S@MyClass#",
+      "target": "c:@S@MyClass",
+      "targetFallback": "MyClass"
+    }
+  ],
+  "symbols": [
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass"
+      },
+      "kind": {
+        "displayName": "Class",
+        "identifier": "objective-c++.class"
+      },
+      "location": {
+        "position": {
+          "character": 6,
+          "line": 12
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "title": "MyClass"
+      },
+      "pathComponents": [
+        "MyClass"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "identifier",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 29,
+                "line": 16
+              },
+              "start": {
+                "character": 8,
+                "line": 16
+              }
+            },
+            "text": "A default initializer"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@MyClass#"
+      },
+      "kind": {
+        "displayName": "Constructor",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 4,
+          "line": 17
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "title": "MyClass"
+      },
+      "pathComponents": [
+        "MyClass",
+        "MyClass"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator+"
+        },
+        {
+          "kind": "text",
+          "spelling": "() "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 23
+              },
+              "start": {
+                "character": 8,
+                "line": 23
+              }
+            },
+            "text": "An unary plus operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator+#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 24
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator+"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator+"
+          }
+        ],
+        "title": "operator+"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator+"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator-"
+        },
+        {
+          "kind": "text",
+          "spelling": "() "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 28
+              },
+              "start": {
+                "character": 8,
+                "line": 28
+              }
+            },
+            "text": "A unary minus operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator-#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 29
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator-"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator-"
+          }
+        ],
+        "title": "operator-"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator-"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator+"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 28,
+                "line": 34
+              },
+              "start": {
+                "character": 8,
+                "line": 34
+              }
+            },
+            "text": "An addition operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator+#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 35
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator+"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator+"
+          }
+        ],
+        "title": "operator+"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator+"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator-"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 39
+              },
+              "start": {
+                "character": 8,
+                "line": 39
+              }
+            },
+            "text": "A subtraction operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator-#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 40
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator-"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator-"
+          }
+        ],
+        "title": "operator-"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator-"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator*"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 33,
+                "line": 44
+              },
+              "start": {
+                "character": 8,
+                "line": 44
+              }
+            },
+            "text": "A multiplication operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator*#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 45
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator*"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator*"
+          }
+        ],
+        "title": "operator*"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator*"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator/"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 27,
+                "line": 49
+              },
+              "start": {
+                "character": 8,
+                "line": 49
+              }
+            },
+            "text": "A division operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator/#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 50
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator/"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator/"
+          }
+        ],
+        "title": "operator/"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator/"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator%"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 26,
+                "line": 54
+              },
+              "start": {
+                "character": 8,
+                "line": 54
+              }
+            },
+            "text": "A modulus operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator%#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 55
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator%"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator%"
+          }
+        ],
+        "title": "operator%"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator%"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator~"
+        },
+        {
+          "kind": "text",
+          "spelling": "() "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 64
+              },
+              "start": {
+                "character": 8,
+                "line": 64
+              }
+            },
+            "text": "A bitwise not operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator~#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 65
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator~"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator~"
+          }
+        ],
+        "title": "operator~"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator~"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator&"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 69
+              },
+              "start": {
+                "character": 8,
+                "line": 69
+              }
+            },
+            "text": "A bitwise and operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator&#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 70
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&"
+          }
+        ],
+        "title": "operator&"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator&"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator|"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 29,
+                "line": 74
+              },
+              "start": {
+                "character": 8,
+                "line": 74
+              }
+            },
+            "text": "A bitwise or operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator|#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 75
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator|"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator|"
+          }
+        ],
+        "title": "operator|"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator|"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator^"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 36,
+                "line": 79
+              },
+              "start": {
+                "character": 8,
+                "line": 79
+              }
+            },
+            "text": "A bitwise either-or operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator^#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 80
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator^"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator^"
+          }
+        ],
+        "title": "operator^"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator^"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator<<"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 37,
+                "line": 84
+              },
+              "start": {
+                "character": 8,
+                "line": 84
+              }
+            },
+            "text": "A bitwise left-shift operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator<<#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 85
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<<"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<<"
+          }
+        ],
+        "title": "operator<<"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator<<"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator>>"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 38,
+                "line": 89
+              },
+              "start": {
+                "character": 8,
+                "line": 89
+              }
+            },
+            "text": "A bitwise right-shift operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator>>#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 90
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>>"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>>"
+          }
+        ],
+        "title": "operator>>"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator>>"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator++"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 32,
+                "line": 99
+              },
+              "start": {
+                "character": 8,
+                "line": 99
+              }
+            },
+            "text": "A pre-increment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator++#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 100
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator++"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator++"
+          }
+        ],
+        "title": "operator++"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator++"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator--"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 32,
+                "line": 104
+              },
+              "start": {
+                "character": 8,
+                "line": 104
+              }
+            },
+            "text": "A pre-decrement operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator-#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 105
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator--"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator--"
+          }
+        ],
+        "title": "operator--"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator--"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator++"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:I",
+          "spelling": "int"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": ""
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 33,
+                "line": 110
+              },
+              "start": {
+                "character": 8,
+                "line": 110
+              }
+            },
+            "text": "A post-increment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:I",
+                "spelling": "int"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": ""
+              }
+            ],
+            "name": ""
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator++#I#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 111
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator++"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator++"
+          }
+        ],
+        "title": "operator++"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator++"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator--"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:I",
+          "spelling": "int"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": ""
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 33,
+                "line": 115
+              },
+              "start": {
+                "character": 8,
+                "line": 115
+              }
+            },
+            "text": "A post-decrement operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:I",
+                "spelling": "int"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": ""
+              }
+            ],
+            "name": ""
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator-#I#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 116
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator--"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator--"
+          }
+        ],
+        "title": "operator--"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator--"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator!"
+        },
+        {
+          "kind": "text",
+          "spelling": "() "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 35,
+                "line": 125
+              },
+              "start": {
+                "character": 8,
+                "line": 125
+              }
+            },
+            "text": "A logical negation operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator!#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 126
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator!"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator!"
+          }
+        ],
+        "title": "operator!"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator!"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator&&"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 130
+              },
+              "start": {
+                "character": 8,
+                "line": 130
+              }
+            },
+            "text": "A logical and operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator&&#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 131
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&&"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&&"
+          }
+        ],
+        "title": "operator&&"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator&&"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator||"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 39,
+                "line": 135
+              },
+              "start": {
+                "character": 8,
+                "line": 135
+              }
+            },
+            "text": "A logical inclusive or operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator||#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 136
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator||"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator||"
+          }
+        ],
+        "title": "operator||"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator||"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator=="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 28,
+                "line": 145
+              },
+              "start": {
+                "character": 8,
+                "line": 145
+              }
+            },
+            "text": "An equal-to operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator==#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 146
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator=="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator=="
+          }
+        ],
+        "title": "operator=="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator=="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator!="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 32,
+                "line": 150
+              },
+              "start": {
+                "character": 8,
+                "line": 150
+              }
+            },
+            "text": "An not-equal-to operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator!=#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 151
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator!="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator!="
+          }
+        ],
+        "title": "operator!="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator!="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator<"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 29,
+                "line": 156
+              },
+              "start": {
+                "character": 8,
+                "line": 156
+              }
+            },
+            "text": "An less-than operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator<#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 157
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<"
+          }
+        ],
+        "title": "operator<"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator<"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator>"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 32,
+                "line": 161
+              },
+              "start": {
+                "character": 8,
+                "line": 161
+              }
+            },
+            "text": "An greater-than operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator>#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 162
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>"
+          }
+        ],
+        "title": "operator>"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator>"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator<="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 38,
+                "line": 167
+              },
+              "start": {
+                "character": 8,
+                "line": 167
+              }
+            },
+            "text": "An less-than-or-equal operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator<=#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 168
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<="
+          }
+        ],
+        "title": "operator<="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator<="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:b",
+          "spelling": "bool"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator>="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 41,
+                "line": 172
+              },
+              "start": {
+                "character": 8,
+                "line": 172
+              }
+            },
+            "text": "An greater-than-or-equal operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:b",
+            "spelling": "bool"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator>=#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 9,
+          "line": 173
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>="
+          }
+        ],
+        "title": "operator>="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator>="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "identifier",
+          "preciseIdentifier": "c:@N@std",
+          "spelling": "std"
+        },
+        {
+          "kind": "text",
+          "spelling": "::"
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@N@std@N@__1@S@weak_ordering",
+          "spelling": "weak_ordering"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator<=>"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": ";"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 39,
+                "line": 178
+              },
+              "start": {
+                "character": 8,
+                "line": 178
+              }
+            },
+            "text": "A three-way comparison operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "identifier",
+            "preciseIdentifier": "c:@N@std",
+            "spelling": "std"
+          },
+          {
+            "kind": "text",
+            "spelling": "::"
+          },
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@N@std@N@__1@S@weak_ordering",
+            "spelling": "weak_ordering"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator<=>#&1$@S@MyClass#1"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 23,
+          "line": 179
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<=>"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<=>"
+          }
+        ],
+        "title": "operator<=>"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator<=>"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 34,
+                "line": 188
+              },
+              "start": {
+                "character": 8,
+                "line": 188
+              }
+            },
+            "text": "A copy assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 189
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator="
+          }
+        ],
+        "title": "operator="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 48,
+                "line": 190
+              },
+              "start": {
+                "character": 8,
+                "line": 190
+              }
+            },
+            "text": "A pass-by-value copy assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator=#1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 191
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator="
+          }
+        ],
+        "title": "operator="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " && "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 34,
+                "line": 193
+              },
+              "start": {
+                "character": 8,
+                "line": 193
+              }
+            },
+            "text": "A move assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " && "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator=#&&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 194
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator="
+          }
+        ],
+        "title": "operator="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "identifier",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 26,
+                "line": 196
+              },
+              "start": {
+                "character": 8,
+                "line": 196
+              }
+            },
+            "text": "A copy constructor"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@MyClass#&$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Constructor",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 4,
+          "line": 197
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "title": "MyClass"
+      },
+      "pathComponents": [
+        "MyClass",
+        "MyClass"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "identifier",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " && "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 26,
+                "line": 198
+              },
+              "start": {
+                "character": 8,
+                "line": 198
+              }
+            },
+            "text": "A move constructor"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " && "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@MyClass#&&$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Constructor",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 4,
+          "line": 199
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "title": "MyClass"
+      },
+      "pathComponents": [
+        "MyClass",
+        "MyClass"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator+="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 39,
+                "line": 205
+              },
+              "start": {
+                "character": 8,
+                "line": 205
+              }
+            },
+            "text": "An addition assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator+=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 206
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator+="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator+="
+          }
+        ],
+        "title": "operator+="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator+="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator-="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 41,
+                "line": 210
+              },
+              "start": {
+                "character": 8,
+                "line": 210
+              }
+            },
+            "text": "A subtraction assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator-=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 211
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator-="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator-="
+          }
+        ],
+        "title": "operator-="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator-="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator*="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 44,
+                "line": 215
+              },
+              "start": {
+                "character": 8,
+                "line": 215
+              }
+            },
+            "text": "A multiplication assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator*=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 216
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator*="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator*="
+          }
+        ],
+        "title": "operator*="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator*="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator/="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 38,
+                "line": 220
+              },
+              "start": {
+                "character": 8,
+                "line": 220
+              }
+            },
+            "text": "A division assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator/=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 221
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator/="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator/="
+          }
+        ],
+        "title": "operator/="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator/="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator%="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 37,
+                "line": 225
+              },
+              "start": {
+                "character": 8,
+                "line": 225
+              }
+            },
+            "text": "A modulus assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator%=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 226
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator%="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator%="
+          }
+        ],
+        "title": "operator%="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator%="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator&="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 41,
+                "line": 233
+              },
+              "start": {
+                "character": 8,
+                "line": 233
+              }
+            },
+            "text": "A bitwise and assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator&=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 234
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&="
+          }
+        ],
+        "title": "operator&="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator&="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator|="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 40,
+                "line": 238
+              },
+              "start": {
+                "character": 8,
+                "line": 238
+              }
+            },
+            "text": "A bitwise or assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator|=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 239
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator|="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator|="
+          }
+        ],
+        "title": "operator|="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator|="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator^="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 47,
+                "line": 243
+              },
+              "start": {
+                "character": 8,
+                "line": 243
+              }
+            },
+            "text": "A bitwise either-or assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator^=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 244
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator^="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator^="
+          }
+        ],
+        "title": "operator^="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator^="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator<<="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 48,
+                "line": 248
+              },
+              "start": {
+                "character": 8,
+                "line": 248
+              }
+            },
+            "text": "A bitwise left-shift assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator<<=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 249
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<<="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator<<="
+          }
+        ],
+        "title": "operator<<="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator<<="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator>>="
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 49,
+                "line": 253
+              },
+              "start": {
+                "character": 8,
+                "line": 253
+              }
+            },
+            "text": "A bitwise right-shift assignment operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator>>=#&1$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 254
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>>="
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator>>="
+          }
+        ],
+        "title": "operator>>="
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator>>="
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator[]"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "identifier",
+          "preciseIdentifier": "c:@N@std",
+          "spelling": "std"
+        },
+        {
+          "kind": "text",
+          "spelling": "::"
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C",
+          "spelling": "string"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "key"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 35,
+                "line": 263
+              },
+              "start": {
+                "character": 8,
+                "line": 263
+              }
+            },
+            "text": "A static subscript operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "preciseIdentifier": "c:@N@std",
+                "spelling": "std"
+              },
+              {
+                "kind": "text",
+                "spelling": "::"
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C",
+                "spelling": "string"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "key"
+              }
+            ],
+            "name": "key"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator[]#&$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 264
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator[]"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator[]"
+          }
+        ],
+        "title": "operator[]"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator[]"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator[]"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "lhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "rhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 35,
+                "line": 268
+              },
+              "start": {
+                "character": 8,
+                "line": 268
+              }
+            },
+            "text": "A static subscript operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "lhs"
+              }
+            ],
+            "name": "lhs"
+          },
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "rhs"
+              }
+            ],
+            "name": "rhs"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator[]#&$@S@MyClass#S0_#S"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 16,
+          "line": 269
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator[]"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator[]"
+          }
+        ],
+        "title": "operator[]"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator[]"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator*"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 31,
+                "line": 274
+              },
+              "start": {
+                "character": 8,
+                "line": 274
+              }
+            },
+            "text": "An indirection operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator*#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 275
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator*"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator*"
+          }
+        ],
+        "title": "operator*"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator*"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " * "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator&"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 30,
+                "line": 279
+              },
+              "start": {
+                "character": 8,
+                "line": 279
+              }
+            },
+            "text": "An address-of operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " *"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator&#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 280
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator&"
+          }
+        ],
+        "title": "operator&"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator&"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator->"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 36,
+                "line": 285
+              },
+              "start": {
+                "character": 8,
+                "line": 285
+              }
+            },
+            "text": "A member-of-pointer operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator->#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 286
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator->"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator->"
+          }
+        ],
+        "title": "operator->"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator->"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator->*"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "const"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "preciseIdentifier": "c:@N@std",
+          "spelling": "std"
+        },
+        {
+          "kind": "text",
+          "spelling": "::"
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C",
+          "spelling": "string"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "key"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 47,
+                "line": 291
+              },
+              "start": {
+                "character": 8,
+                "line": 291
+              }
+            },
+            "text": "A pointer-to-member-of-pointer operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "keyword",
+                "spelling": "const"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "identifier",
+                "preciseIdentifier": "c:@N@std",
+                "spelling": "std"
+              },
+              {
+                "kind": "text",
+                "spelling": "::"
+              },
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C",
+                "spelling": "string"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "key"
+              }
+            ],
+            "name": "key"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator->*#&1$@N@std@N@__1@S@basic_string>#C#$@N@std@N@__1@S@char_traits>#C#$@N@std@N@__1@S@allocator>#C#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 292
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator->*"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator->*"
+          }
+        ],
+        "title": "operator->*"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator->*"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator()"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "lhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "rhs"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 39,
+                "line": 301
+              },
+              "start": {
+                "character": 8,
+                "line": 301
+              }
+            },
+            "text": "A static function-call operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "lhs"
+              }
+            ],
+            "name": "lhs"
+          },
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "rhs"
+              }
+            ],
+            "name": "rhs"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 16,
+          "line": 302
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator()"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator()"
+          }
+        ],
+        "title": "operator()"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator()"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator()"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "arg1"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "arg2"
+        },
+        {
+          "kind": "text",
+          "spelling": ", "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "arg3"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 42,
+                "line": 307
+              },
+              "start": {
+                "character": 8,
+                "line": 307
+              }
+            },
+            "text": "An instance function-call operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "arg1"
+              }
+            ],
+            "name": "arg1"
+          },
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "arg2"
+              }
+            ],
+            "name": "arg2"
+          },
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "arg3"
+              }
+            ],
+            "name": "arg3"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator()#&$@S@MyClass#S0_#S0_#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 308
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator()"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator()"
+          }
+        ],
+        "title": "operator()"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator()"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "operator,"
+        },
+        {
+          "kind": "text",
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:@S@MyClass",
+          "spelling": "MyClass"
+        },
+        {
+          "kind": "text",
+          "spelling": " & "
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "other"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 24,
+                "line": 313
+              },
+              "start": {
+                "character": 8,
+                "line": 313
+              }
+            },
+            "text": "A comma operator"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:@S@MyClass",
+                "spelling": "MyClass"
+              },
+              {
+                "kind": "text",
+                "spelling": " & "
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "other"
+              }
+            ],
+            "name": "other"
+          }
+        ],
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:@S@MyClass",
+            "spelling": "MyClass"
+          },
+          {
+            "kind": "text",
+            "spelling": " &"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c++",
+        "precise": "c:@S@MyClass@F@operator,#&$@S@MyClass#"
+      },
+      "kind": {
+        "displayName": "Instance Method",
+        "identifier": "objective-c++.method"
+      },
+      "location": {
+        "position": {
+          "character": 13,
+          "line": 314
+        },
+        "uri": "file:///Users/username/path/to/CxxOperators.hpp"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "operator,"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "operator,"
+          }
+        ],
+        "title": "operator,"
+      },
+      "pathComponents": [
+        "MyClass",
+        "operator,"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://119616317

## Summary

This improves support for parsing links to C++ operators so that `operator/=` and `operator-=-hash` are treated as single components (the latter with hash disambiguation).

It also refractors the path parsing code to extract and reuse common logic to make the main implementation more readable.

This is a small change (~100 LOC) with mostly tests (~200 LOC) and a very large symbol graph test file (7k+ LOC).

## Dependencies

None

## Testing

Define a type with some C++ operators. For example:
```cpp
/// A class with some custom operators
///
/// Links to those operators:
/// - ``operator+-15qb6``
/// - ``operator+-8k1ef``
/// - ``operator/``
/// - ``operator/=``
/// - ``operator--``
/// - ``operator++``
/// - ``operator[]``
/// - ``operator()``
/// - ``operator,``
class MyClass
{
public:
    /// An unary plus operator
    MyClass operator+() const;
    /// An addition operator
    MyClass operator+(const MyClass& other) const;
    
    /// A division operator
    MyClass operator/(const MyClass& other) const;
    /// A division assignment operator
    MyClass& operator/=(const MyClass& other);
    
    /// A pre-decrement operator
    MyClass& operator--();
    /// A post-increment operator
    MyClass operator++(int);
    
    /// A subscript operator
    MyClass& operator[](std::string& key);
    
    /// A function-call operator
    MyClass& operator()(MyClass& arg1, MyClass& arg2, MyClass& arg3);
    
    /// A comma operator
    MyClass& operator,(MyClass& other);
};
```

Build documentation for this project. 

- It should be possible to link to `operator/` and `operator/=`.
- It should be possible to link to `operator-` and `operator--` with disambiguation (adding an extra `-` to each link)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
