### PR TITLE
Remove un-actionable warning about not finding an external symbol

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1621,9 +1621,9 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for symbolID in symbolsToResolve {
             if let (reference, entity) = resolveSymbol(symbolID: symbolID) {
                 externalCache.add(entity, reference: reference, symbolID: symbolID)
-            } else {
-                diagnosticEngine.emit(Problem(diagnostic: Diagnostic(source: nil, severity: .warning, range: nil, identifier: "org.swift.docc.ReferenceSymbolNotFound", summary: "Symbol with identifier \(symbolID.singleQuoted) was referenced in the combined symbol graph but couldn't be found in the symbol graph or externally."), possibleSolutions: []))
             }
+            // It's expected that some symbols won't resolve.
+            // The build doesn't necessarily include all documentation dependencies that appear in declarations, conformances, etc.
         }
     }
     


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This removes an un-actionable warning. We've already removed a similar warning in #966. However, this warning is different in that there are real scenarios where we don't expect to resolve all external symbols, in which case this warning would be noise for expected behavior. 

## Dependencies

None.

## Testing

None

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added tests~ Not applicable 
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
