### PR TITLE
Synthesize a minimal landing page for combined archives

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -82,6 +82,15 @@ public struct RenderIndex: Codable, Equatable {
         includedArchiveIdentifiers.append(contentsOf: other.includedArchiveIdentifiers)
     }
     
+    /// Insert a root node with a given name for each interface language and move the previous root node(s) under the new root node.
+    /// - Parameter named: The name of the new root node
+    public mutating func insertRoot(named: String) {
+        for (languageID, nodes) in interfaceLanguages {
+            let root = Node(title: named, path: "/documentation", pageType: .framework, isDeprecated: false, children: nodes, icon: nil)
+            interfaceLanguages[languageID] = [root]
+        }
+    }
+    
     enum MergeError: DescribedError {
         case referenceCollision(String)
         

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/String+Whitespace.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/String+Whitespace.swift
@@ -17,7 +17,7 @@ extension String {
     ///
     /// - Parameter separator: The string to replace contiguous sequences of whitespace and punctuation with.
     /// - Returns: A new string with all whitespace and punctuation replaced with a given separator.
-    func replacingWhitespaceAndPunctuation(with separator: String) -> String {
+    package func replacingWhitespaceAndPunctuation(with separator: String) -> String {
         let charactersToStrip = CharacterSet.whitespaces.union(.punctuationCharacters)
         return components(separatedBy: charactersToStrip).filter({ !$0.isEmpty }).joined(separator: separator)
     }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -1,0 +1,145 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SwiftDocC
+
+extension MergeAction {
+    struct RootRenderReferences {
+        var documentation, tutorials: [TopicRenderReference]
+        
+        fileprivate var all: [TopicRenderReference] {
+            documentation + tutorials
+        }
+        var isEmpty: Bool {
+            documentation.isEmpty && tutorials.isEmpty
+        }
+        fileprivate var containsBothKinds: Bool {
+            !documentation.isEmpty && !tutorials.isEmpty
+        }
+    }
+    
+    func readRootNodeRenderReferencesIn(dataDirectory: URL) throws -> RootRenderReferences {
+        func inner(url: URL) throws -> [TopicRenderReference] {
+            try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
+                .compactMap {
+                    guard $0.pathExtension == "json" else {
+                        return nil
+                    }
+                    
+                    let data = try fileManager.contents(of: $0)
+                    return try JSONDecoder().decode(RootNodeRenderReference.self, from: data)
+                        .renderReference
+                }
+                .sorted(by: { lhs, rhs in
+                    lhs.title < rhs.title
+                })
+        }
+        
+        return .init(
+            documentation: try inner(url: dataDirectory.appendingPathComponent("documentation", isDirectory: true)),
+            tutorials:     try inner(url: dataDirectory.appendingPathComponent("tutorials", isDirectory: true))
+        )
+    }
+    
+    func makeSynthesizedLandingPage(
+        name: String,
+        reference: ResolvedTopicReference,
+        roleHeading: String,
+        rootRenderReferences: RootRenderReferences
+    ) -> RenderNode {
+        var renderNode = RenderNode(identifier: reference, kind: .article)
+        
+        renderNode.topicSectionsStyle = .detailedGrid
+        renderNode.metadata.title = name
+        renderNode.metadata.roleHeading = roleHeading
+        renderNode.metadata.role = "collection"
+        renderNode.hierarchy = nil
+        renderNode.sections = []
+        
+        if rootRenderReferences.containsBothKinds {
+            // If the combined archive contains both documentation and tutorial content, create separate topic sections for each.
+            renderNode.topicSections = [
+                .init(title: "Modules", abstract: nil, discussion: nil, identifiers: rootRenderReferences.documentation.map(\.identifier.identifier)),
+                .init(title: "Tutorials", abstract: nil, discussion: nil, identifiers: rootRenderReferences.tutorials.map(\.identifier.identifier)),
+            ]
+        } else {
+            // Otherwise, create a single unnamed topic section
+            renderNode.topicSections = [
+                .init(title: nil, abstract: nil, discussion: nil, identifiers: (rootRenderReferences.all).map(\.identifier.identifier)),
+            ]
+        }
+        
+        for renderReference in rootRenderReferences.documentation {
+            renderNode.references[renderReference.identifier.identifier] = renderReference
+        }
+        for renderReference in rootRenderReferences.tutorials {
+            renderNode.references[renderReference.identifier.identifier] = renderReference
+        }
+        
+        return renderNode
+    }
+}
+
+/// A type that decodes the root node reference from a root node's encoded render node data.
+private struct RootNodeRenderReference: Decodable {
+    /// The decoded root node render reference
+    var renderReference: TopicRenderReference
+    
+    enum CodingKeys: CodingKey {
+        // The only render node keys that should be needed
+        case identifier, references
+        // Extra render node keys in case we need to re-create the render reference from page content.
+        case metadata, abstract, kind
+    }
+    
+    struct StringCodingKey: CodingKey {
+        var stringValue: String
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+        var intValue: Int? = nil
+        init?(intValue: Int) {
+            fatalError("`SparseRenderNode.StringCodingKey` only support string values")
+        }
+    }
+    
+    init(from decoder: any Decoder) throws {
+        // Instead of decoding the full render node, we only decode the information that's needed.
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let identifier = try container.decode(ResolvedTopicReference.self, forKey: .identifier)
+        let rawIdentifier = identifier.url.absoluteString
+        let referencesContainer = try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: .references)
+        
+        // Every node should include a reference to the root page.
+        // For reference documentation, this is because the root appears as a link in the breadcrumbs on every page.
+        // For tutorials, this is because the tutorial table of content appears as a link in the top navigator.
+        //
+        // If the root page has a reference to itself, then that the fastest and easiest way to access the correct topic render reference.
+        if let selfReference = try referencesContainer.decodeIfPresent(TopicRenderReference.self, forKey: .init(stringValue: rawIdentifier)!) {
+            renderReference = selfReference
+            return
+        }
+        
+        // If for some unexpected reason this wasn't true, for example because of an unknown page kind,
+        // we can create a new topic reference by decoding a little bit more information from the render node.
+        let metadata = try container.decode(RenderMetadata.self, forKey: .metadata)
+        
+        renderReference = TopicRenderReference(
+            identifier: RenderReferenceIdentifier(rawIdentifier),
+            title: metadata.title ?? identifier.lastPathComponent,
+            abstract: try container.decodeIfPresent([RenderInlineContent].self, forKey: .abstract) ?? [],
+            url: identifier.path.lowercased(),
+            kind: try container.decode(RenderNode.Kind.self, forKey: .kind),
+            images: metadata.images
+        )
+    }
+}

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -53,11 +53,17 @@ extension MergeAction {
         name: String,
         reference: ResolvedTopicReference,
         roleHeading: String,
+        topicsStyle: TopicsVisualStyle.Style,
         rootRenderReferences: RootRenderReferences
     ) -> RenderNode {
         var renderNode = RenderNode(identifier: reference, kind: .article)
         
-        renderNode.topicSectionsStyle = .detailedGrid
+        renderNode.topicSectionsStyle = switch topicsStyle {
+            case .list:         .list
+            case .compactGrid:  .compactGrid
+            case .detailedGrid: .detailedGrid
+            case .hidden:       .hidden
+        }
         renderNode.metadata.title = name
         renderNode.metadata.roleHeading = roleHeading
         renderNode.metadata.role = "collection"

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -117,16 +117,18 @@ private struct RootNodeRenderReference: Decodable {
         
         let identifier = try container.decode(ResolvedTopicReference.self, forKey: .identifier)
         let rawIdentifier = identifier.url.absoluteString
-        let referencesContainer = try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: .references)
         
         // Every node should include a reference to the root page.
         // For reference documentation, this is because the root appears as a link in the breadcrumbs on every page.
         // For tutorials, this is because the tutorial table of content appears as a link in the top navigator.
         //
         // If the root page has a reference to itself, then that the fastest and easiest way to access the correct topic render reference.
-        if let selfReference = try referencesContainer.decodeIfPresent(TopicRenderReference.self, forKey: .init(stringValue: rawIdentifier)!) {
-            renderReference = selfReference
-            return
+        if container.contains(.references) {
+            let referencesContainer = try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: .references)
+            if let selfReference = try referencesContainer.decodeIfPresent(TopicRenderReference.self, forKey: .init(stringValue: rawIdentifier)!) {
+                renderReference = selfReference
+                return
+            }
         }
         
         // If for some unexpected reason this wasn't true, for example because of an unknown page kind,

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
@@ -21,8 +21,8 @@ struct MergeAction: Action {
     
     /// Information about how the merge action should create landing page content for the combined archive
     enum LandingPageInfo {
-        /// The merge action should build landing page content from a provided documentation catalog.
-        case buildFromCatalog(documentationCatalog: URL)
+        // This enum will have a case for a landing page catalog when we add support for that.
+        
         /// The merge action should synthesize a minimal landing page with a given name and kind.
         case synthesize(name: String, kind: String)
     }
@@ -76,8 +76,6 @@ struct MergeAction: Action {
         }
         
         switch landingPageInfo {
-        case .buildFromCatalog:
-            fatalError("Custom landing page catalogs are not supported. `Merge.run()` currently always passed `.synthesize()`.")
         case .synthesize(let name, let kind):
             try synthesizeLandingPage(landingPageName: name, landingPageKind: kind, combinedIndex: &combinedJSONIndex, targetURL: targetURL)
         }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -141,6 +141,17 @@ extension Docc {
             )
             var kind: String = "Package"
             
+            @Option(
+                name: .customLong("synthesized-landing-page-topics-style"),
+                help: ArgumentHelp(
+                    "The visual style of the topic section for the combined archive's synthesized landing page.",
+                    discussion: """
+                    If you pass both this value and a `--landing-page-catalog` value, the documentation compiler will only use the `--landing-page-catalog` value. 
+                    """,
+                    valueName: "style"
+                )
+            )
+            var topicStyle: TopicsVisualStyle.Style = .detailedGrid
         }
         
         public var archives: [URL] {
@@ -160,14 +171,23 @@ extension Docc {
         public var synthesizedLandingPageKind: String {
             synthesizedLandingPageOptions.kind
         }
+        public var synthesizedLandingPageTopicsStyle: TopicsVisualStyle.Style {
+            synthesizedLandingPageOptions.topicStyle
+        }
         
         public mutating func run() throws {
             // Initialize a `ConvertAction` from the current options in the `Convert` command.
-            var convertAction = MergeAction(archives: archives, landingPageInfo: .synthesize(name: synthesizedLandingPageName, kind: synthesizedLandingPageKind), outputURL: outputURL, fileManager: Self._fileManager)
+            var convertAction = MergeAction(
+                archives: archives,
+                landingPageInfo: .synthesize(.init(name: synthesizedLandingPageName, kind: synthesizedLandingPageKind, style: synthesizedLandingPageTopicsStyle)),
+                outputURL: outputURL,
+                fileManager: Self._fileManager
+            )
             
             // Perform the conversion and print any warnings or errors found
             try convertAction.performAndHandleResult()
         }
-        
     }
 }
+
+extension TopicsVisualStyle.Style: ExpressibleByArgument {}

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -19,7 +19,7 @@ extension Docc {
         
         public static var configuration = CommandConfiguration(
             abstract: "Merge a list of documentation archives into a combined archive.",
-            usage: "docc merge <archive-path> ... [[--landing-page-catalog <catalog-path>] | [<synthesized-landing-page-options>]] [--output-path <output-path>]"
+            usage: "docc merge <archive-path> ... [<synthesized-landing-page-options>] [--output-path <output-path>]"
         )
         
         private static let archivePathExtension = "doccarchive"
@@ -52,7 +52,8 @@ extension Docc {
                     The documentation compiler uses this catalog content to create a landing page, and optionally additional top-level articles, for the combined archive.
                     Because the documentation compiler won't synthesize any landing page content, also passing a `--synthesized-landing-page-name` value has no effect. 
                     """,
-                    valueName: "catalog-path"),
+                    valueName: "catalog-path",
+                    visibility: .hidden),
                 transform: URL.init(fileURLWithPath:))
             var landingPageCatalog: URL?
             
@@ -121,9 +122,6 @@ extension Docc {
                 name: .customLong("synthesized-landing-page-name"),
                 help: ArgumentHelp(
                     "A display name for the combined archive's synthesized landing page.",
-                    discussion: """
-                    If you pass both this value and a `--landing-page-catalog` value, the documentation compiler will only use the `--landing-page-catalog` value. 
-                    """,
                     valueName: "name"
                 )
             )
@@ -133,9 +131,6 @@ extension Docc {
                 name: .customLong("synthesized-landing-page-kind"),
                 help: ArgumentHelp(
                     "A page kind that displays as a title heading for the combined archive's synthesized landing page.",
-                    discussion: """
-                    If you pass both this value and a `--landing-page-catalog` value, the documentation compiler will only use the `--landing-page-catalog` value. 
-                    """,
                     valueName: "kind"
                 )
             )
@@ -145,9 +140,6 @@ extension Docc {
                 name: .customLong("synthesized-landing-page-topics-style"),
                 help: ArgumentHelp(
                     "The visual style of the topic section for the combined archive's synthesized landing page.",
-                    discussion: """
-                    If you pass both this value and a `--landing-page-catalog` value, the documentation compiler will only use the `--landing-page-catalog` value. 
-                    """,
                     valueName: "style"
                 )
             )

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -18,7 +18,8 @@ extension Docc {
         public init() {}
         
         public static var configuration = CommandConfiguration(
-            abstract: "Merge a list of documentation archives into a combined archive."
+            abstract: "Merge a list of documentation archives into a combined archive.",
+            usage: "docc merge <archive-path> ... [[--landing-page-catalog <catalog-path>] | [<synthesized-landing-page-options>]] [--output-path <output-path>]"
         )
         
         private static let archivePathExtension = "doccarchive"
@@ -47,6 +48,10 @@ extension Docc {
             @Option(
                 help: ArgumentHelp(
                     "Path to a '.\(Merge.catalogPathExtension)' documentation catalog directory with content for the landing page.",
+                    discussion: """
+                    The documentation compiler uses this catalog content to create a landing page, and optionally additional top-level articles, for the combined archive.
+                    Because the documentation compiler won't synthesize any landing page content, also passing a `--synthesized-landing-page-name` value has no effect. 
+                    """,
                     valueName: "catalog-path"),
                 transform: URL.init(fileURLWithPath:))
             var landingPageCatalog: URL?
@@ -94,6 +99,8 @@ extension Docc {
                     guard fileManager.directoryExists(atPath: catalog.path) else {
                         throw ValidationError("No directory exists at '\(catalog.path)'")
                     }
+                    
+                    print("note: Using a custom landing page catalog isn't supported yet. Will synthesize a default landing page instead.")
                 }
                 
                 // Validate that the directory above the output location exist so that the merge command doesn't need to create intermediate directories.
@@ -107,6 +114,35 @@ extension Docc {
             }
         }
         
+        @OptionGroup(title: "Synthesized landing page options")
+        var synthesizedLandingPageOptions: SynthesizedLandingPageOptions
+        struct SynthesizedLandingPageOptions: ParsableArguments {
+            @Option(
+                name: .customLong("synthesized-landing-page-name"),
+                help: ArgumentHelp(
+                    "A display name for the combined archive's synthesized landing page.",
+                    discussion: """
+                    If you pass both this value and a `--landing-page-catalog` value, the documentation compiler will only use the `--landing-page-catalog` value. 
+                    """,
+                    valueName: "name"
+                )
+            )
+            var name: String = "Documentation"
+            
+            @Option(
+                name: .customLong("synthesized-landing-page-kind"),
+                help: ArgumentHelp(
+                    "A page kind that displays as a title heading for the combined archive's synthesized landing page.",
+                    discussion: """
+                    If you pass both this value and a `--landing-page-catalog` value, the documentation compiler will only use the `--landing-page-catalog` value. 
+                    """,
+                    valueName: "kind"
+                )
+            )
+            var kind: String = "Package"
+            
+        }
+        
         public var archives: [URL] {
             get { inputsAndOutputs.archives }
             set { inputsAndOutputs.archives = newValue}
@@ -118,10 +154,16 @@ extension Docc {
         public var outputURL: URL {
             inputsAndOutputs.outputURL
         }
+        public var synthesizedLandingPageName: String {
+            synthesizedLandingPageOptions.name
+        }
+        public var synthesizedLandingPageKind: String {
+            synthesizedLandingPageOptions.kind
+        }
         
         public mutating func run() throws {
             // Initialize a `ConvertAction` from the current options in the `Convert` command.
-            var convertAction = MergeAction(archives: archives, landingPageCatalog: landingPageCatalog, outputURL: outputURL, fileManager: Self._fileManager)
+            var convertAction = MergeAction(archives: archives, landingPageInfo: .synthesize(name: synthesizedLandingPageName, kind: synthesizedLandingPageKind), outputURL: outputURL, fileManager: Self._fileManager)
             
             // Perform the conversion and print any warnings or errors found
             try convertAction.performAndHandleResult()

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/MergeSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/MergeSubcommandTests.swift
@@ -71,11 +71,6 @@ class MergeSubcommandTests: XCTestCase {
             XCTAssertEqual(command.synthesizedLandingPageKind, "Package")
         }
         
-        // Incomplete catalog argument
-        XCTAssertThrowsError(try Docc.Merge.parse(["/path/to/First.doccarchive", "--landing-page-catalog"])) { error in
-            XCTAssertEqual(Docc.Merge.message(for: error), "Missing value for '--landing-page-catalog <catalog-path>'")
-        }
-        
         // Input catalog with unexpected path extension
         XCTAssertThrowsError(try Docc.Merge.parse(["/path/to/First.doccarchive", "--landing-page-catalog", "/path/to/not-a-catalog"])) { error in
             XCTAssertEqual(Docc.Merge.message(for: error), "Missing 'docc' path extension for catalog '/path/to/not-a-catalog'")

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/MergeSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/MergeSubcommandTests.swift
@@ -66,6 +66,9 @@ class MergeSubcommandTests: XCTestCase {
             
             XCTAssertNil(command.landingPageCatalog)
             XCTAssertEqual(command.outputURL, URL(fileURLWithPath: fileSystem.currentDirectoryPath).appendingPathComponent("Combined.doccarchive", isDirectory: true))
+            
+            XCTAssertEqual(command.synthesizedLandingPageName, "Documentation")
+            XCTAssertEqual(command.synthesizedLandingPageKind, "Package")
         }
         
         // Incomplete catalog argument
@@ -114,6 +117,20 @@ class MergeSubcommandTests: XCTestCase {
             
             XCTAssertEqual(command.landingPageCatalog, URL(fileURLWithPath: "/path/to/LandingPage.docc"))
             XCTAssertEqual(command.outputURL, URL(fileURLWithPath: fileSystem.currentDirectoryPath).appendingPathComponent("Combined.doccarchive", isDirectory: true))
+        }
+        
+        // Synthesized landing page info
+        XCTAssertNoThrow(try Docc.Merge.parse(["/path/to/First.doccarchive", "--synthesized-landing-page-name", "Test Landing Page Name"]))
+        XCTAssertNoThrow(try Docc.Merge.parse(["/path/to/First.doccarchive", "--synthesized-landing-page-kind", "Test Landing Page Kind"]))
+        
+        do {
+            let command = try Docc.Merge.parse([
+                "/path/to/First.doccarchive",
+                "--synthesized-landing-page-name", "Test Landing Page Name",
+                "--synthesized-landing-page-kind", "Test Landing Page Kind"
+            ])
+            XCTAssertEqual(command.synthesizedLandingPageName, "Test Landing Page Name")
+            XCTAssertEqual(command.synthesizedLandingPageKind, "Test Landing Page Kind")
         }
         
         // Incomplete output argument

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -15,6 +15,8 @@ import SwiftDocCTestUtilities
 
 class MergeActionTests: XCTestCase {
     
+    private let testLandingPageInfo = MergeAction.LandingPageInfo.synthesize(name: "Test Landing Page Name", kind: "Test Landing Page Kind")
+    
     func testCopiesArchivesIntoOutputLocation() throws {
         let fileSystem = try TestFileSystem(
             folders: [
@@ -60,6 +62,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/First.doccarchive"),
                 URL(fileURLWithPath: "/Second.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -73,6 +76,7 @@ class MergeActionTests: XCTestCase {
         ├─ css/
         │  ╰─ something.css
         ├─ data/
+        │  ├─ documentation.json
         │  ├─ documentation/
         │  │  ├─ first.json
         │  │  ├─ first/
@@ -143,6 +147,26 @@ class MergeActionTests: XCTestCase {
            ╰─ com.example.second/
               ╰─ something.mov
         """)
+        
+        let synthesizedRootNode = try fileSystem.renderNode(atPath: "/Output.doccarchive/data/documentation.json")
+        XCTAssertEqual(synthesizedRootNode.metadata.title, "Test Landing Page Name")
+        XCTAssertEqual(synthesizedRootNode.metadata.roleHeading, "Test Landing Page Kind")
+        XCTAssertEqual(synthesizedRootNode.topicSectionsStyle, .detailedGrid)
+        XCTAssertEqual(synthesizedRootNode.topicSections.flatMap { [$0.title ?? ""] + $0.identifiers }, [
+            "Modules",
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/documentation/second.json",
+
+            "Tutorials",
+            "doc://org.swift.test/tutorials/first.json",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
+        XCTAssertEqual(synthesizedRootNode.references.keys.sorted(), [
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/documentation/second.json",
+            "doc://org.swift.test/tutorials/first.json",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
     }
     
     func testCreatesDataDirectoryWhenMergingSingleEmptyArchive() throws {
@@ -166,6 +190,7 @@ class MergeActionTests: XCTestCase {
             archives: [
                 URL(fileURLWithPath: "/Empty.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -256,6 +281,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/First.doccarchive"),
                 URL(fileURLWithPath: "/Second.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -269,6 +295,7 @@ class MergeActionTests: XCTestCase {
         ├─ css/
         │  ╰─ something.css
         ├─ data/
+        │  ├─ documentation.json
         │  ├─ documentation/
         │  │  ├─ first.json
         │  │  ╰─ first/
@@ -318,6 +345,22 @@ class MergeActionTests: XCTestCase {
            ╰─ com.example.second/
               ╰─ something.mov
         """)
+        
+        let synthesizedRootNode = try fileSystem.renderNode(atPath: "/Output.doccarchive/data/documentation.json")
+        XCTAssertEqual(synthesizedRootNode.metadata.title, "Test Landing Page Name")
+        XCTAssertEqual(synthesizedRootNode.metadata.roleHeading, "Test Landing Page Kind")
+        XCTAssertEqual(synthesizedRootNode.topicSectionsStyle, .detailedGrid)
+        XCTAssertEqual(synthesizedRootNode.topicSections.flatMap { [$0.title ?? ""] + $0.identifiers }, [
+            "Modules",
+            "doc://org.swift.test/documentation/first.json",
+
+            "Tutorials",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
+        XCTAssertEqual(synthesizedRootNode.references.keys.sorted(), [
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
     }
     
     func testCanMergeReferenceOnlyArchiveWithTutorialOnlyArchiveWithoutStaticHosting() throws {
@@ -359,6 +402,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/First.doccarchive"),
                 URL(fileURLWithPath: "/Second.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -372,6 +416,7 @@ class MergeActionTests: XCTestCase {
         ├─ css/
         │  ╰─ something.css
         ├─ data/
+        │  ├─ documentation.json
         │  ├─ documentation/
         │  │  ├─ first.json
         │  │  ╰─ first/
@@ -407,6 +452,22 @@ class MergeActionTests: XCTestCase {
            ╰─ com.example.second/
               ╰─ something.mov
         """)
+        
+        let synthesizedRootNode = try fileSystem.renderNode(atPath: "/Output.doccarchive/data/documentation.json")
+        XCTAssertEqual(synthesizedRootNode.metadata.title, "Test Landing Page Name")
+        XCTAssertEqual(synthesizedRootNode.metadata.roleHeading, "Test Landing Page Kind")
+        XCTAssertEqual(synthesizedRootNode.topicSectionsStyle, .detailedGrid)
+        XCTAssertEqual(synthesizedRootNode.topicSections.flatMap { [$0.title ?? ""] + $0.identifiers }, [
+            "Modules",
+            "doc://org.swift.test/documentation/first.json",
+
+            "Tutorials",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
+        XCTAssertEqual(synthesizedRootNode.references.keys.sorted(), [
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
     }
     
     func testSupportsArchivesWithoutStaticHosting() throws {
@@ -456,6 +517,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/First.doccarchive"),
                 URL(fileURLWithPath: "/Second.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -469,6 +531,7 @@ class MergeActionTests: XCTestCase {
         ├─ css/
         │  ╰─ something.css
         ├─ data/
+        │  ├─ documentation.json
         │  ├─ documentation/
         │  │  ├─ first.json
         │  │  ├─ first/
@@ -513,6 +576,82 @@ class MergeActionTests: XCTestCase {
            ╰─ com.example.second/
               ╰─ something.mov
         """)
+        
+        let synthesizedRootNode = try fileSystem.renderNode(atPath: "/Output.doccarchive/data/documentation.json")
+        XCTAssertEqual(synthesizedRootNode.metadata.title, "Test Landing Page Name")
+        XCTAssertEqual(synthesizedRootNode.metadata.roleHeading, "Test Landing Page Kind")
+        XCTAssertEqual(synthesizedRootNode.topicSectionsStyle, .detailedGrid)
+        XCTAssertEqual(synthesizedRootNode.topicSections.flatMap { [$0.title ?? ""] + $0.identifiers }, [
+            "Modules",
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/documentation/second.json",
+
+            "Tutorials",
+            "doc://org.swift.test/tutorials/first.json",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
+        XCTAssertEqual(synthesizedRootNode.references.keys.sorted(), [
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/documentation/second.json",
+            "doc://org.swift.test/tutorials/first.json",
+            "doc://org.swift.test/tutorials/second.json",
+        ])
+    }
+    
+    func testReferenceOnlyArchivesDoNotSynthesizeTutorialsTopicSection() throws {
+        let fileSystem = try TestFileSystem(
+            folders: [
+                Folder(name: "Output.doccarchive", content: []),
+                Self.makeArchive(
+                    name: "First",
+                    documentationPages: [
+                        "First",
+                        "First/SomeClass",
+                        "First/SomeClass/someProperty",
+                        "First/SomeClass/someFunction(:_)",
+                    ],
+                    tutorialPages: []
+                ),
+                Self.makeArchive(
+                    name: "Second",
+                    documentationPages: [
+                        "Second",
+                        "Second/SomeStruct",
+                        "Second/SomeStruct/someProperty",
+                        "Second/SomeStruct/someFunction(:_)",
+                    ],
+                    tutorialPages: []
+                ),
+            ]
+        )
+        
+        let logStorage = LogHandle.LogStorage()
+        var action = MergeAction(
+            archives: [
+                URL(fileURLWithPath: "/First.doccarchive"),
+                URL(fileURLWithPath: "/Second.doccarchive"),
+            ],
+            landingPageInfo: testLandingPageInfo,
+            outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
+            fileManager: fileSystem
+        )
+        
+        _ = try action.perform(logHandle: .memory(logStorage))
+        XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
+        
+        let synthesizedRootNode = try fileSystem.renderNode(atPath: "/Output.doccarchive/data/documentation.json")
+        XCTAssertEqual(synthesizedRootNode.metadata.title, "Test Landing Page Name")
+        XCTAssertEqual(synthesizedRootNode.metadata.roleHeading, "Test Landing Page Kind")
+        XCTAssertEqual(synthesizedRootNode.topicSectionsStyle, .detailedGrid)
+        XCTAssertEqual(synthesizedRootNode.topicSections.flatMap { [$0.title].compactMap({ $0 }) + $0.identifiers }, [
+            // No title
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/documentation/second.json",
+        ])
+        XCTAssertEqual(synthesizedRootNode.references.keys.sorted(), [
+            "doc://org.swift.test/documentation/first.json",
+            "doc://org.swift.test/documentation/second.json",
+        ])
     }
     
     func testErrorWhenArchivesContainOverlappingData() throws {
@@ -574,6 +713,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/Second.doccarchive"),
                 URL(fileURLWithPath: "/Third.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -611,6 +751,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/First.doccarchive"),
                 URL(fileURLWithPath: "/Second.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -672,6 +813,7 @@ class MergeActionTests: XCTestCase {
                 URL(fileURLWithPath: "/First.doccarchive"),
                 URL(fileURLWithPath: "/Second.doccarchive"),
             ],
+            landingPageInfo: testLandingPageInfo,
             outputURL: URL(fileURLWithPath: "/Output.doccarchive"),
             fileManager: fileSystem
         )
@@ -861,7 +1003,7 @@ class MergeActionTests: XCTestCase {
                 ]
             }
             dataContent += [
-                Folder(name: "documentation", content: Folder.makeStructure(filePaths: documentationPages.map { "\($0.lowercased()).json" })),
+                Folder(name: "documentation", content: Folder.makeStructure(filePaths: documentationPages.map { "\($0.lowercased()).json" }, renderNodeReferencePrefix: "/documentation")),
             ]
         }
         if !tutorialPages.isEmpty {
@@ -871,7 +1013,7 @@ class MergeActionTests: XCTestCase {
                 ]
             }
             dataContent += [
-                Folder(name: "tutorials", content: Folder.makeStructure(filePaths: tutorialPages.map { "\($0.lowercased()).json" })),
+                Folder(name: "tutorials", content: Folder.makeStructure(filePaths: tutorialPages.map { "\($0.lowercased()).json" }, renderNodeReferencePrefix: "/tutorials")),
             ]
         }
         if !dataContent.isEmpty {
@@ -906,5 +1048,13 @@ class MergeActionTests: XCTestCase {
         ]
         
         return Folder(name: "\(name).doccarchive", content: content)
+    }
+}
+
+private extension TestFileSystem {
+    func renderNode(atPath path: String) throws -> RenderNode {
+        let data = try contents(of: URL(fileURLWithPath: path))
+        
+        return try JSONDecoder().decode(RenderNode.self, from: data)
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -15,7 +15,13 @@ import SwiftDocCTestUtilities
 
 class MergeActionTests: XCTestCase {
     
-    private let testLandingPageInfo = MergeAction.LandingPageInfo.synthesize(name: "Test Landing Page Name", kind: "Test Landing Page Kind")
+    private let testLandingPageInfo = MergeAction.LandingPageInfo.synthesize(
+        .init(
+            name: "Test Landing Page Name",
+            kind: "Test Landing Page Kind",
+            style: .detailedGrid
+        )
+    )
     
     func testCopiesArchivesIntoOutputLocation() throws {
         let fileSystem = try TestFileSystem(

--- a/features.json
+++ b/features.json
@@ -8,6 +8,9 @@
     },
     {
       "name": "overloads"
+    },
+    {
+      "name": "synthesized-landing-page-name"
     }
   ]
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://79160385

## Summary

This makes the `docc merge` command synthesize a minimal "landing page" for the combined documentation. 

It also adds two new flags `--synthesized-landing-page-name` and `--synthesized-landing-page-kind` to customize small details about this page. The existence of the pair of these flags is indicted by a new entry in "features.json"

## Dependencies

None

## Testing

- Build documentation for two targets with dependencies. For example: [Inner.doccarchive (zip)](https://github.com/user-attachments/files/16658116/Inner.doccarchive.zip) and 
[Outer.doccarchive (zip)](https://github.com/user-attachments/files/16658118/Outer.doccarchive.zip).

### Default name and kind

- Merge the two archives into a combined archive using
  ```
  swift docc merge /path/to/Inner.doccarchive /path/to/Outer.doccarchive
  ```
- Preview the combined documentation. For example:
  - Run `cd Combined.doccarchive` followed by `ruby -run -ehttpd . -p8080`
  
- Open a browser and navigate to <localhost:8080/documentation/>
  - The landing page should display "Documentation" for the title in the navigator and display name on the page
  - The landing page should display "Package" for the title heading.
  - The landing page should display links to both modules (in alphabetical order)
  <img width="1532" alt="Screenshot 2024-08-19 at 11 15 15" src="https://github.com/user-attachments/assets/6f95dcdc-e3f6-4793-9ff8-645ac30c8204">

  
### Custom name and kind

- Remove the previous combined archive:
  `rm -rf Combined.doccarchive`

- Merge the two archives into a combined archive using, passing a custom name and/or kind
  ```
  swift docc merge \
    /path/to/Inner.doccarchive /path/to/Outer.doccarchive \
    --synthesized-landing-page-name "My Custom Combined Title" \
    --synthesized-landing-page-kind "My Custom Landing Page Kind" 
  ```
- (_unchanged_) Preview the combined documentation. For example:
  - Run `cd Combined.doccarchive` followed by `ruby -run -ehttpd . -p8080`
  
- Open a browser and navigate to <localhost:8080/documentation/>
  - The landing page should display your custom landing page title for the title in the navigator and display name on the page
  - The landing page should display your custom landing page kind for the title heading.
  - (_unchanged_) The landing page should display links to both modules (in alphabetical order)
  <img width="1532" alt="Screenshot 2024-08-19 at 11 14 49" src="https://github.com/user-attachments/assets/f1319b06-92a3-41cf-916d-6b9269156e5a">


### Navigate the combined archive

- While still previewing the combined documentation:
  - Click a few elements in the navigator hierarchy:
    - You should navigate to that page
    - The navigator hierarchy should continue to display the landing page and both modules
  - Click the landing page title at the top of the navigator hierarchy:
    - You should navigate to the landing page 
    - (_unchanged_) The navigator hierarchy should continue to display the landing page and both modules
    
## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ This feature is still experimental and may change
