### PR TITLE
Fix Diagnose invalid characters in bundle identifiers

### DIFF
--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticBundleIdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticBundleIdentifierTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class DiagnosticBundleIdentifierTests: XCTestCase {
 
     func testValidBundleIdentifier() throws {
-        // GIVEN: A valid bundle identifier
+        // GIVEN
         let outputURL = try createTemporaryDirectory().appendingPathComponent("valid-bundle")
         let builder = NavigatorIndex.Builder(
             outputURL: outputURL,

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticBundleIdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticBundleIdentifierTests.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+@testable import SwiftDocC
+
+final class DiagnosticBundleIdentifierTests: XCTestCase {
+
+    func testValidBundleIdentifier() throws {
+        // GIVEN: A valid bundle identifier
+        let outputURL = try createTemporaryDirectory().appendingPathComponent("valid-bundle")
+        let builder = NavigatorIndex.Builder(
+            outputURL: outputURL,
+            bundleIdentifier: "com.example.valid-bundle_identifier"
+        )
+
+        // WHEN
+        builder.setup()
+
+        // THEN
+        XCTAssertTrue(builder.problems.isEmpty, "No problems should be reported for a valid bundle identifier")
+    }
+
+    func testInvalidBundleIdentifierWithSpace() throws {
+        // GIVEN
+        let outputURL = try createTemporaryDirectory().appendingPathComponent("invalid-bundle-space")
+        let builder = NavigatorIndex.Builder(
+            outputURL: outputURL,
+            bundleIdentifier: "com.example.invalid bundle"
+        )
+
+        // WHEN
+        builder.setup()
+
+        // THEN
+        XCTAssertFalse(builder.problems.isEmpty, "A problem should be reported for a bundle identifier with spaces")
+        let problem = try XCTUnwrap(builder.problems.first)
+        XCTAssertEqual(problem.diagnostic.identifier, "org.swift.docc.InvalidBundleIdentifier")
+        XCTAssertEqual(problem.diagnostic.severity, .warning)
+        XCTAssertEqual(problem.diagnostic.summary, "Invalid characters in bundle identifier")
+
+        let explanation = try XCTUnwrap(problem.diagnostic.explanation)
+        XCTAssertTrue(explanation.contains("Bundle identifier 'com.example.invalid bundle' contains characters that are not valid in URL hosts"))
+    }
+
+    func testInvalidBundleIdentifierWithSpecialCharacters() throws {
+        // GIVEN
+        let outputURL = try createTemporaryDirectory().appendingPathComponent("invalid-bundle-special-chars")
+        let builder = NavigatorIndex.Builder(
+            outputURL: outputURL,
+            bundleIdentifier: "com.example.invalid$bundle"
+        )
+
+        // WHEN
+        builder.setup()
+
+        // THEN
+        XCTAssertFalse(builder.problems.isEmpty, "A problem should be reported for a bundle identifier with invalid special characters")
+        let problem = try XCTUnwrap(builder.problems.first)
+        XCTAssertEqual(problem.diagnostic.identifier, "org.swift.docc.InvalidBundleIdentifier")
+        XCTAssertEqual(problem.diagnostic.severity, .warning)
+        XCTAssertEqual(problem.diagnostic.summary, "Invalid characters in bundle identifier")
+
+        let explanation = try XCTUnwrap(problem.diagnostic.explanation)
+        XCTAssertTrue(explanation.contains("Bundle identifier 'com.example.invalid$bundle' contains characters that are not valid in URL hosts"))
+    }
+
+    func testBundleIdentifierWithValidSpecialCharacters() throws {
+        // GIVEN
+        let outputURL = try createTemporaryDirectory().appendingPathComponent("valid-bundle-special-chars")
+        let builder = NavigatorIndex.Builder(
+            outputURL: outputURL,
+            bundleIdentifier: "com.example.valid-bundle_identifier.with~tilde"
+        )
+
+        // WHEN
+        builder.setup()
+
+        // THEN
+        XCTAssertTrue(builder.problems.isEmpty, "No problems should be reported for a bundle identifier with valid special characters")
+    }
+}


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Fixes: #290

## Changes

This PR introduces bundle identifier validation in the `NavigatorIndex.Builder` class and adds corresponding unit tests to ensure its correctness.

### Implementation

- Added a private `validateBundleIdentifier()` method to `NavigatorIndex.Builder`.
- The method checks for invalid characters in the bundle identifier based on RFC 3986 URL host requirements.
- Invalid bundle identifiers trigger a warning diagnostic with a detailed explanation.

### Tests

- Created `DiagnosticBundleIdentifierTests` to thoroughly test the new validation logic.
- Tests cover valid bundle identifiers, identifiers with spaces, and identifiers with both valid and invalid special characters.
- Implemented using the GIVEN-WHEN-THEN structure for improved readability and maintainability.

## Rationale

1. **Improved Data Integrity**: Validating bundle identifiers ensures that only valid identifiers are used, preventing potential issues downstream in the documentation generation process.

2. **Compliance with Standards**: By adhering to RFC 3986 for URL hosts, we ensure that our bundle identifiers are compatible with web-based systems and avoid potential conflicts or encoding issues.

3. **Early Error Detection**: Catching invalid bundle identifiers early in the process allows developers to address issues promptly, improving the overall quality of documentation projects.

4. **Clear Feedback**: The detailed error messages provide developers with actionable information to correct invalid bundle identifiers.

5. **Robust Testing**: The comprehensive test suite ensures that the validation logic works as expected and helps prevent regressions in future updates.

## Impact
- Developers will receive immediate feedback if they use invalid characters in bundle identifiers.
- This change may catch existing invalid bundle identifiers in projects, requiring updates to conform to the new validation rules.
- The documentation generation process will be more robust against potential issues caused by malformed bundle identifiers.

## Notes for Reviewers
- Please pay special attention to the character set used for validation. Are there any additional characters we should consider allowing or restricting?
- The error message content and severity (warning) are open for discussion. Should we consider making this a more severe error?
- The test coverage aims to be comprehensive. Are there any additional edge cases you think we should test?

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
