### PR TITLE
Fix a bug where article-only catalogs couldn't resolve external links

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Find.swift
@@ -90,7 +90,7 @@ extension PathHierarchy {
                         // Ignore this error and raise an error about not finding the module instead.
                         break
                     case .unknownName(let partialResult, remaining: _, availableChildren: _):
-                        if partialResult.node.symbol?.kind.identifier == .module {
+                        if modules.contains(where: { $0.identifier == partialResult.node.identifier }) {
                             // Failed to find the first path component. Ignore this error and raise an error about not finding the module instead.
                             break
                         } else {


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This fixes a bug where the `PathHierarchy` didn't correctly identify the root node for article-only documentation, which caused it to not raise a `.moduleNotFound` error, which caused `LinkResolver` to not attempt to resolve external links.

## Dependencies

None.

## Testing



## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ Not applicable.
