### PR TITLE
Support documenting http responses, property list values, parameters, etc. with spaces in the name

### DIFF
--- a/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/ListItemExtractor.swift
@@ -284,37 +284,38 @@ private struct ExtractedTag {
         case httpBodyParameters
         
         init?(_ string: String) {
-            let components = string.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+            let separatorIndex = string.firstIndex(where: \.isWhitespace) ?? string.endIndex
+            let secondComponent = String(string[separatorIndex...].drop(while: \.isWhitespace))
             
-            switch components.first?.lowercased() {
+            switch string[..<separatorIndex].lowercased() {
             case "returns":
                 self = .returns
             case "throws":
                 self = .throws
-            case "parameter" where components.count == 2:
-                self = .parameter(String(components.last!))
+            case "parameter" where !secondComponent.isEmpty:
+                self = .parameter(secondComponent)
             case "parameters":
                 self = .parameters
-            case "dictionarykey" where components.count == 2:
-                self = .dictionaryKey(String(components.last!))
+            case "dictionarykey" where !secondComponent.isEmpty:
+                self = .dictionaryKey(secondComponent)
             case "dictionarykeys":
                 self = .dictionaryKeys
-            case "possiblevalue" where components.count == 2:
-                self = .possibleValue(String(components.last!))
+            case "possiblevalue" where !secondComponent.isEmpty:
+                self = .possibleValue(secondComponent)
             case "possiblevalues":
                 self = .possibleValues
             case "httpbody":
                 self = .httpBody
-            case "httpresponse" where components.count == 2:
-                self = .httpResponse(String(components.last!))
+            case "httpresponse" where !secondComponent.isEmpty:
+                self = .httpResponse(secondComponent)
             case "httpresponses":
                 self = .httpResponses
-            case "httpparameter" where components.count == 2:
-                self = .httpParameter(String(components.last!))
+            case "httpparameter" where !secondComponent.isEmpty:
+                self = .httpParameter(secondComponent)
             case "httpparameters":
                 self = .httpParameters
-            case "httpbodyparameter" where components.count == 2:
-                self = .httpBodyParameter(String(components.last!))
+            case "httpbodyparameter" where !secondComponent.isEmpty:
+                self = .httpBodyParameter(secondComponent)
             case "httpbodyparameters":
                 self = .httpBodyParameters
             default:

--- a/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
@@ -70,8 +70,8 @@ class ListItemExtractorTests: XCTestCase {
         XCTAssert(extractedTags("- Parameter: Missing parameter name.").parameters.isEmpty)
         XCTAssert(extractedTags("- Parameter  : Missing parameter name.").parameters.isEmpty)
         
-        XCTAssert(extractedTags("- DictionaryKey: Missing key name.").parameters.isEmpty)
-        XCTAssert(extractedTags("- PossibleValue: Missing value name.").parameters.isEmpty)
+        XCTAssert(extractedTags("- DictionaryKey: Missing key name.").dictionaryKeys.isEmpty)
+        XCTAssert(extractedTags("- PossibleValue: Missing value name.").possiblePropertyListValues.isEmpty)
     }
     
     func testExtractingTags() throws {

--- a/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
@@ -66,6 +66,12 @@ class ListItemExtractorTests: XCTestCase {
         XCTAssertEqual(possibleValue.contents.map { $0.format() }, ["Some description of this value."])
         XCTAssertEqual(possibleValue.nameRange?.source?.path, testSource.path)
         XCTAssertEqual(possibleValue.range?.source?.path, testSource.path)
+        
+        XCTAssert(extractedTags("- Parameter: Missing parameter name.").parameters.isEmpty)
+        XCTAssert(extractedTags("- Parameter  : Missing parameter name.").parameters.isEmpty)
+        
+        XCTAssert(extractedTags("- DictionaryKey: Missing key name.").parameters.isEmpty)
+        XCTAssert(extractedTags("- PossibleValue: Missing value name.").parameters.isEmpty)
     }
     
     func testExtractingTags() throws {

--- a/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
@@ -15,6 +15,59 @@ import Markdown
 
 class ListItemExtractorTests: XCTestCase {
     
+    func testSupportsSpacesInTaggedElementNames() throws {
+        let testSource = URL(fileURLWithPath: "/path/to/test-source-\(ProcessInfo.processInfo.globallyUniqueString)")
+        func extractedTags(_ markup: String) -> TaggedListItemExtractor {
+            let document = Document(parsing: markup, source: testSource, options: .parseSymbolLinks)
+            
+            var extractor = TaggedListItemExtractor()
+            _ = extractor.visit(document)
+            return extractor
+        }
+    
+        for whitespace in [" ", "   ", "\t"] {
+            let parameters = extractedTags("""
+            - Parameter\(whitespace)some parameter with spaces: Some description of this parameter.
+            """).parameters
+            XCTAssertEqual(parameters.count, 1)
+            let parameter = try XCTUnwrap(parameters.first)
+            XCTAssertEqual(parameter.name, "some parameter with spaces")
+            XCTAssertEqual(parameter.contents.map { $0.format() }, ["Some description of this parameter."])
+            XCTAssertEqual(parameter.nameRange?.source?.path, testSource.path)
+            XCTAssertEqual(parameter.range?.source?.path, testSource.path)
+        }
+
+        let parameters = extractedTags("""
+        - Parameters:
+          - some parameter with spaces: Some description of this parameter.
+        """).parameters
+        XCTAssertEqual(parameters.count, 1)
+        let parameter = try XCTUnwrap(parameters.first)
+        XCTAssertEqual(parameter.name, "some parameter with spaces")
+        XCTAssertEqual(parameter.contents.map { $0.format() }, ["Some description of this parameter."])
+        XCTAssertEqual(parameter.nameRange?.source?.path, testSource.path)
+        XCTAssertEqual(parameter.range?.source?.path, testSource.path)
+        
+        let dictionaryKeys = extractedTags("""
+        - DictionaryKeys:
+          - some key with spaces: Some description of this key.
+        """).dictionaryKeys
+        XCTAssertEqual(dictionaryKeys.count, 1)
+        let dictionaryKey = try XCTUnwrap(dictionaryKeys.first)
+        XCTAssertEqual(dictionaryKey.name, "some key with spaces")
+        XCTAssertEqual(dictionaryKey.contents.map { $0.format() }, ["Some description of this key."])
+        
+        let possibleValues = extractedTags("""
+        - PossibleValue some value with spaces: Some description of this value.
+        """).possiblePropertyListValues
+        XCTAssertEqual(possibleValues.count, 1)
+        let possibleValue = try XCTUnwrap(possibleValues.first)
+        XCTAssertEqual(possibleValue.value, "some value with spaces")
+        XCTAssertEqual(possibleValue.contents.map { $0.format() }, ["Some description of this value."])
+        XCTAssertEqual(possibleValue.nameRange?.source?.path, testSource.path)
+        XCTAssertEqual(possibleValue.range?.source?.path, testSource.path)
+    }
+    
     func testExtractingTags() throws {
         try assertExtractsRichContentFor(
             tagName: "Returns",


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://134705941

## Summary

This updates the parsing for "tagged" list (http responses, property list values, parameters, etc.) to support documenting responses/values/keys/parameters with spaces in the name.

For example:
```md
- DictionaryKey some key with spaces: Some description of this dictionary key.
```
now parses the entire "some key with spaces" as the name of the dictionary key that the documentation applies to.

## Dependencies

None.

## Testing

The hardest part of testing this is using a symbol graph file with list elements with spaces in the names. There is one such example among the test bundles.

- Add a new documentation extension file to `Tests/S` with the following content:

  ```md
  # ``DictionaryData/Genre``
  
  A musical genre.
  
  - PossibleValue Classic Rock: Some description of the classic rock genre.
  - PossibleValue Folk: Some description of the folk genre.
  ```
  
- Run `swift run docc preview /Tests/SwiftDocCTests/Test\ Bundles/DictionaryData.docc` and navigate to the "Genre" page.
  - Both the "Classic Rock" and "Folk" values should display their possible-value description
  
  <img width="508" alt="Screenshot 2024-09-02 at 15 00 23" src="https://github.com/user-attachments/assets/27055a5e-d0ae-4aeb-a003-5ef6cc2127b1">


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
