### PR TITLE
Display entitlement key in symbol reference

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -365,12 +365,11 @@ public class DocumentationContentRenderer {
         let estimatedTime = (node?.semantic as? Timed)?.durationMinutes.flatMap(formatEstimatedDuration(minutes:))
         
         // Add key information for property lists.
-        var propertyListKeyNames: TopicRenderReference.PropertyListKeyNames? = nil
-        if let nodePropertyListDetails = node?.symbol?.plistDetails  {
-            propertyListKeyNames = TopicRenderReference.PropertyListKeyNames(
-                titleStyle: (nodePropertyListDetails.customTitle != nil) ? .useDisplayName : .useRawKey,
-                rawKey: nodePropertyListDetails.rawKey,
-                displayName: nodePropertyListDetails.customTitle
+        let propertyListKeyNames = node?.symbol?.plistDetails.map {
+            TopicRenderReference.PropertyListKeyNames(
+                titleStyle: ($0.customTitle != nil) ? .useDisplayName : .useRawKey,
+                rawKey: $0.rawKey,
+                displayName: $0.customTitle
             )
         }
         

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -363,7 +363,17 @@ public class DocumentationContentRenderer {
         let isRequired = (node?.semantic as? Symbol)?.isRequired ?? false
 
         let estimatedTime = (node?.semantic as? Timed)?.durationMinutes.flatMap(formatEstimatedDuration(minutes:))
-
+        
+        // Add key information for property lists.
+        var propertyListKeyNames: TopicRenderReference.PropertyListKeyNames? = nil
+        if let nodePropertyListDetails = node?.symbol?.plistDetails  {
+            propertyListKeyNames = TopicRenderReference.PropertyListKeyNames(
+                titleStyle: (nodePropertyListDetails.customTitle != nil) ? .useDisplayName : .useRawKey,
+                rawKey: nodePropertyListDetails.rawKey,
+                displayName: nodePropertyListDetails.customTitle
+            )
+        }
+        
         var renderReference = TopicRenderReference(
             identifier: .init(referenceURL),
             titleVariants: VariantCollection<String>(from: titleVariants) ?? .init(defaultValue: ""),
@@ -372,7 +382,8 @@ public class DocumentationContentRenderer {
             kind: kind,
             required: isRequired,
             role: referenceRole,
-            estimatedTime: estimatedTime
+            estimatedTime: estimatedTime,
+            propertyListKeyNames: propertyListKeyNames
         )
         
         renderReference.images = node?.metadata?.pageImages.compactMap { pageImage -> TopicImage? in

--- a/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/TopicRenderReference.swift
@@ -270,7 +270,7 @@ public struct TopicRenderReference: RenderReference, VariantContainer, Equatable
         let propertyListTitleStyle = try values.decodeIfPresent(PropertyListTitleStyle.self, forKey: .propertyListTitleStyle)
         let propertyListRawKey = try values.decodeIfPresent(String.self, forKey: .propertyListRawKey)
         let propertyListDisplayName = try values.decodeIfPresent(String.self, forKey: .propertyListDisplayName)
-        if propertyListRawKey != nil || propertyListRawKey != nil || propertyListDisplayName != nil {
+        if propertyListRawKey != nil || propertyListTitleStyle != nil || propertyListDisplayName != nil {
             propertyListKeyNames = PropertyListKeyNames(
                 titleStyle: propertyListTitleStyle,
                 rawKey: propertyListRawKey,

--- a/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
@@ -11,6 +11,8 @@
 import Foundation
 import XCTest
 @testable import SwiftDocC
+import SwiftDocCTestUtilities
+import SymbolKit
 
 fileprivate extension [RenderBlockContent] {
     var firstParagraphText: String? {
@@ -309,4 +311,85 @@ class RESTSymbolsTests: XCTestCase {
         
         AssertRoundtrip(for: object)
     }
+    
+    func testReferenceOfEntitlementWithKeyName() throws {
+        
+        // The symbol has a custom title.
+        
+        var exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    SymbolGraph.Symbol(
+                        identifier: .init(precise: "symbol-id", interfaceLanguage: "swift"),
+                        names: .init(title: "Symbol Name", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["Symbol Name"],
+                        docComment: nil,
+                        accessLevel: .public,
+                        kind: .init(parsedIdentifier: .typeProperty, displayName: "Type Property"),
+                        mixins: [SymbolGraph.Symbol.PlistDetails.mixinKey:SymbolGraph.Symbol.PlistDetails(rawKey: "plist-key-symbolname", customTitle: "Symbol Custom Title")]
+                    )
+                ]
+            )),
+            TextFile(name: "symbol-id.md", utf8Content: """
+            # ``ModuleName/symbol-id``
+            
+            This is an entitlement key.
+            """)
+        ])
+        
+        var tempURL = try createTempFolder(content: [exampleDocumentation])
+        var (_, bundle, context) = try loadBundle(from: tempURL)
+        var moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        var entity = try context.entity(with: moduleReference)
+        var moduleSymbol = try XCTUnwrap(entity.semantic as? Symbol)
+        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleReference)
+        var renderNode = translator.visit(moduleSymbol) as! RenderNode
+        var propertyListKeyNames = try XCTUnwrap((renderNode.references["doc://unit-test/documentation/ModuleName/Symbol_Name"] as? TopicRenderReference)?.propertyListKeyNames)
+        
+        // Check that the reference contains the key symbol name.
+        XCTAssertEqual(propertyListKeyNames.titleStyle, .useDisplayName)
+        XCTAssertEqual(propertyListKeyNames.rawKey, "plist-key-symbolname")
+        XCTAssertEqual(propertyListKeyNames.displayName, "Symbol Custom Title")
+        
+        // The symbol does not have a custom title.
+        
+        exampleDocumentation = Folder(name: "unit-test.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                moduleName: "ModuleName",
+                symbols: [
+                    SymbolGraph.Symbol(
+                        identifier: .init(precise: "symbol-id", interfaceLanguage: "swift"),
+                        names: .init(title: "Symbol Name", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["Symbol Name"],
+                        docComment: nil,
+                        accessLevel: .public,
+                        kind: .init(parsedIdentifier: .typeProperty, displayName: "Type Property"),
+                        mixins: [SymbolGraph.Symbol.PlistDetails.mixinKey:SymbolGraph.Symbol.PlistDetails(rawKey: "plist-key-symbolname")]
+                    )
+                ]
+            )),
+            TextFile(name: "symbol-id.md", utf8Content: """
+            # ``ModuleName/symbol-id``
+            
+            This is an entitlement key.
+            """)
+        ])
+        
+        tempURL = try createTempFolder(content: [exampleDocumentation])
+        (_, bundle, context) = try loadBundle(from: tempURL)
+        moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        entity = try context.entity(with: moduleReference)
+        moduleSymbol = try XCTUnwrap(entity.semantic as? Symbol)
+        translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleReference)
+        renderNode = translator.visit(moduleSymbol) as! RenderNode
+        propertyListKeyNames = try XCTUnwrap((renderNode.references["doc://unit-test/documentation/ModuleName/Symbol_Name"] as? TopicRenderReference)?.propertyListKeyNames)
+        
+        // Check that the reference does not contain the key symbol name.
+        XCTAssertEqual(propertyListKeyNames.titleStyle, .useRawKey)
+        XCTAssertEqual(propertyListKeyNames.rawKey, "plist-key-symbolname")
+        XCTAssertNil(propertyListKeyNames.displayName)
+    }
+    
+    
 }


### PR DESCRIPTION
Bug/issue #, if applicable:  129540266

## Summary

Property list keys that define a human readable title (https://github.com/swiftlang/swift-docc/pull/987) should show the key name under the abstract when referenced form another symbol.

This pr adds the implementation to get this working by passing the property list key information to the topic render reference.

## Dependencies

N/A

## Testing

Steps:
1. Preview the attached docc archive.
2. Assert that in the top level page, the foo symbol displays the key name under the abstract section.

[plistkey.docc.zip](https://github.com/user-attachments/files/16849526/plistkey.docc.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
