### PR TITLE
Deprecate an unused public render node transformer

### DIFF
--- a/Sources/SwiftDocC/Converter/Rewriter/RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation.swift
+++ b/Sources/SwiftDocC/Converter/Rewriter/RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -9,6 +9,7 @@
 */
 
 /// A transformation that removes automatically curated See Also sections.
+@available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
 public struct RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation: RenderNodeTransforming {
     /// Creates a new transformer.
     public init() {}

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/PersistingDocumentation.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/PersistingDocumentation.md
@@ -34,7 +34,6 @@ The precise path inside the output folder where resulting JSON file is saved is 
 ### Render Node Rewriter
 
 - ``RenderNodeTransforming``
-- ``RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation``
 - ``RemoveUnusedReferencesTransformation``
 - ``RenderNodeTransformationComposition``
 - ``RenderNodeTransformationContext``

--- a/Tests/SwiftDocCTests/Converter/RenderNodeTransformerTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeTransformerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,6 +12,9 @@ import XCTest
 @testable import SwiftDocC
 
 class RenderNodeTransformerTests: XCTestCase {
+    // This test uses ``RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation`` which is deprecated.
+    // Deprecating the test silences the deprecation warning when running the tests. It doesn't skip the test.
+    @available(*, deprecated)
     func testRemovesAutomaticallyCuratedSeeAlsoSections() throws {
         let symbolJSON = try String(contentsOf: Bundle.module.url(
             forResource: "symbol-with-automatic-see-also-section", withExtension: "json",
@@ -28,6 +31,9 @@ class RenderNodeTransformerTests: XCTestCase {
         XCTAssertEqual(renderNode.references.count, 11)
     }
     
+    // This test uses ``RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation`` which is deprecated.
+    // Deprecating the test silences the deprecation warning when running the tests. It doesn't skip the test.
+    @available(*, deprecated)
     func testRemovesAutomaticallyCuratedSeeAlsoSectionsPreservingReferences() throws {
         let symbolJSON = try String(contentsOf: Bundle.module.url(
             forResource: "symbol-auto-see-also-fragments-and-relationships", withExtension: "json",


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This deprecates `RemoveAutomaticallyCuratedSeeAlsoSectionsTransformation` so that we can remove it after the next release.

I stumbled upon this unused public type while investigating a bug related to automatic See Also sections. 

## Dependencies

None

## Testing

None

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
