### PR TITLE
rdar://103619334 make the REST and Plist render sections public.

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
@@ -236,13 +236,13 @@ extension RESTResponse {
 
 extension RESTResponseRenderSection {
     public var headings: [String] {
-        return items.flatMap {
+        return responses.flatMap {
             return $0.headings
         }
     }
     
     public func rawIndexableTextContent(references: [String : RenderReference]) -> String {
-        return items.map {
+        return responses.map {
             return $0.rawIndexableTextContent(references: references)
         }.joined(separator: " ")
     }

--- a/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
@@ -326,7 +326,7 @@ extension AttributesRenderSection {
     }
 }
 
-extension PlistDetailsRenderSection {
+extension PropertyListDetailsRenderSection {
     public var headings: [String] {
         if let displayName = details.displayName {
             return [details.rawKey, displayName]

--- a/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
+++ b/Sources/SwiftDocC/Indexing/RenderSection+TextIndexing.swift
@@ -198,13 +198,13 @@ extension TaskGroupRenderSection {
 
 extension RESTParametersRenderSection {
     public var headings: [String] {
-        return items.flatMap {
+        return parameters.flatMap {
             return $0.headings
         }
     }
     
     public func rawIndexableTextContent(references: [String : RenderReference]) -> String {
-        return items.map {
+        return parameters.map {
             return $0.rawIndexableTextContent(references: references)
         }.joined(separator: " ")
     }

--- a/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Diffing/AnyRenderSection.swift
@@ -37,7 +37,7 @@ struct AnyRenderSection: Equatable, Encodable, RenderJSONDiffable {
         case (.parameters, .parameters):
             return (value as! ParametersRenderSection).difference(from: (other.value as! ParametersRenderSection), at: path)
         case (.plistDetails, .plistDetails):
-            return (value as! PlistDetailsRenderSection).difference(from: (other.value as! PlistDetailsRenderSection), at: path)
+            return (value as! PropertyListDetailsRenderSection).difference(from: (other.value as! PropertyListDetailsRenderSection), at: path)
         case (.possibleValues, .possibleValues):
             return (value as! PossibleValuesRenderSection).difference(from: (other.value as! PossibleValuesRenderSection), at: path)
         case (.relationships, .relationships):
@@ -104,7 +104,7 @@ struct AnyRenderSection: Equatable, Encodable, RenderJSONDiffable {
         case (.parameters, .parameters):
             return (lhs.value as! ParametersRenderSection) == (rhs.value as! ParametersRenderSection)
         case (.plistDetails, .plistDetails):
-            return (lhs.value as! PlistDetailsRenderSection) == (rhs.value as! PlistDetailsRenderSection)
+            return (lhs.value as! PropertyListDetailsRenderSection) == (rhs.value as! PropertyListDetailsRenderSection)
         case (.possibleValues, .possibleValues):
             return (lhs.value as! PossibleValuesRenderSection) == (rhs.value as! PossibleValuesRenderSection)
         case (.relationships, .relationships):

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableContentSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/CodableContentSection.swift
@@ -62,7 +62,7 @@ public struct CodableContentSection: Codable, Equatable {
             case .restResponses:
                 section = try RESTResponseRenderSection(from: decoder)
             case .plistDetails:
-                section = try PlistDetailsRenderSection(from: decoder)
+                section = try PropertyListDetailsRenderSection(from: decoder)
             case .possibleValues:
                 section = try PossibleValuesRenderSection(from: decoder)
             case .mentions:

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPParametersSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPParametersSectionTranslator.swift
@@ -29,7 +29,7 @@ struct HTTPParametersSectionTranslator: RenderSectionTranslator {
             
             return RESTParametersRenderSection(
                 title: "\(parameterSource.rawValue.capitalized) Parameters",
-                items: filteredParameters.map { renderNodeTranslator.createRenderProperty(name: $0.name, contents: $0.contents, required: $0.required, symbol: $0.symbol) },
+                parameters: filteredParameters.map { renderNodeTranslator.createRenderProperty(name: $0.name, contents: $0.contents, required: $0.required, symbol: $0.symbol) },
                 source: parameterSource
             )
         }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPResponsesSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/HTTPResponsesSectionTranslator.swift
@@ -27,7 +27,7 @@ struct HTTPResponsesSectionTranslator: RenderSectionTranslator {
             
             return RESTResponseRenderSection(
                 title: HTTPResponsesSection.title,
-                items: filteredResponses.map { translateResponse($0, &renderNodeTranslator) }
+                responses: filteredResponses.map { translateResponse($0, &renderNodeTranslator) }
             )
         }
     }

--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/PlistDetailsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/PlistDetailsSectionTranslator.swift
@@ -14,9 +14,9 @@ import SymbolKit
 /// Translates a symbol's details into a render nodes's details section.
 struct PlistDetailsSectionTranslator: RenderSectionTranslator, Decodable {
     
-    private func generatePlistDetailsRenderSection(_ symbol: Symbol, plistDetails: SymbolGraph.Symbol.PlistDetails) -> PlistDetailsRenderSection {
-        PlistDetailsRenderSection(
-            details: PlistDetailsRenderSection.Details(
+    private func generatePropertyListDetailsRenderSection(_ symbol: Symbol, plistDetails: SymbolGraph.Symbol.PlistDetails) -> PropertyListDetailsRenderSection {
+        PropertyListDetailsRenderSection(
+            details: PropertyListDetailsRenderSection.Details(
                 rawKey: plistDetails.rawKey,
                 value: [TypeDetails(baseType: plistDetails.baseType, arrayMode: plistDetails.arrayMode)],
                 platforms: [],
@@ -33,7 +33,7 @@ struct PlistDetailsSectionTranslator: RenderSectionTranslator, Decodable {
         }) else {
             return nil
         }
-        let section = generatePlistDetailsRenderSection(symbol, plistDetails: plistDetails)
+        let section = generatePropertyListDetailsRenderSection(symbol, plistDetails: plistDetails)
         return VariantCollection(defaultValue: CodableContentSection(section))
     }
     

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PlistDetailsRenderSection.swift
@@ -33,10 +33,10 @@ public enum TitleStyle: String, Codable, Equatable {
 }
 
 /// A section that contains details about a property list key.
-struct PlistDetailsRenderSection: RenderSection, Equatable {
-    var kind: RenderSectionKind = .plistDetails
+public struct PlistDetailsRenderSection: RenderSection, Equatable {
+    public var kind: RenderSectionKind = .plistDetails
     /// A title for the section.
-    var title = "Details"
+    public var title = "Details"
     
     /// Details for a property list key.
     struct Details: Codable, Equatable {

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PropertyListDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PropertyListDetailsRenderSection.swift
@@ -71,8 +71,7 @@ public struct PropertyListDetailsRenderSection: RenderSection, Equatable {
     /// The details of the property key.
     public let details: Details
 
-    public init(kind: RenderSectionKind = .plistDetails, title: String = "Details", details: Details) {
-        self.kind = kind
+    public init(title: String = "Details", details: Details) {
         self.title = title
         self.details = details
     }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/PropertyListDetailsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/PropertyListDetailsRenderSection.swift
@@ -33,24 +33,24 @@ public enum TitleStyle: String, Codable, Equatable {
 }
 
 /// A section that contains details about a property list key.
-public struct PlistDetailsRenderSection: RenderSection, Equatable {
+public struct PropertyListDetailsRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .plistDetails
     /// A title for the section.
     public var title = "Details"
     
     /// Details for a property list key.
-    struct Details: Codable, Equatable {
+    public struct Details: Codable, Equatable {
         /// The name of the key.
-        let rawKey: String
+        public let rawKey: String
         /// A list of types acceptable for this key's value.
-        let value: [TypeDetails]
+        public let value: [TypeDetails]
         /// A list of platforms to which this key applies.
-        let platforms: [String]
+        public let platforms: [String]
         /// An optional, human-friendly name of the key.
-        let displayName: String?
+        public let displayName: String?
         /// A title rendering style.
-        let titleStyle: PropertyListTitleStyle
-        
+        public let titleStyle: PropertyListTitleStyle
+
         enum CodingKeys: String, CodingKey {
             case rawKey = "name"
             case value
@@ -58,16 +58,30 @@ public struct PlistDetailsRenderSection: RenderSection, Equatable {
             case displayName = "ideTitle"
             case titleStyle
         }
+
+        public init(rawKey: String, value: [TypeDetails], platforms: [String], displayName: String?, titleStyle: PropertyListTitleStyle) {
+            self.rawKey = rawKey
+            self.value = value
+            self.platforms = platforms
+            self.displayName = displayName
+            self.titleStyle = titleStyle
+        }
     }
     
     /// The details of the property key.
-    let details: Details
+    public let details: Details
+
+    public init(kind: RenderSectionKind = .plistDetails, title: String = "Details", details: Details) {
+        self.kind = kind
+        self.title = title
+        self.details = details
+    }
 }
 
 // Diffable conformance
-extension PlistDetailsRenderSection: RenderJSONDiffable {
-    /// Returns the differences between this PlistDetailsRenderSection and the given one.
-    func difference(from other: PlistDetailsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
+extension PropertyListDetailsRenderSection: RenderJSONDiffable {
+    /// Returns the differences between this PropertyListDetailsRenderSection and the given one.
+    func difference(from other: PropertyListDetailsRenderSection, at path: CodablePath) -> JSONPatchDifferences {
         var diffBuilder = DifferenceBuilder(current: self, other: other, basePath: path)
 
         diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
@@ -76,8 +90,8 @@ extension PlistDetailsRenderSection: RenderJSONDiffable {
         return diffBuilder.differences
     }
     
-    /// Returns if this PlistDetailsRenderSection is similar enough to the given one.
-    func isSimilar(to other: PlistDetailsRenderSection) -> Bool {
+    /// Returns if this PropertyListDetailsRenderSection is similar enough to the given one.
+    func isSimilar(to other: PropertyListDetailsRenderSection) -> Bool {
         return self.title == other.title
     }
 }

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTBodyRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTBodyRenderSection.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A section that contains a REST request-body details.
-struct RESTBodyRenderSection: RenderSection, Equatable {
+public struct RESTBodyRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .restBody
     /// A title for the section.
     public let title: String

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTParametersRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTParametersRenderSection.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// Parameter sections might describe parameters used in
 /// the URL query, the URL path, HTTP headers, or a multi-part HTTP body.
-enum RESTParameterSource: String, Codable {
+public enum RESTParameterSource: String, Codable {
     /// A named URL query parameter, for example, `?category=90s`.
     case query
     /// A named URL path parameter, for example, `/artists/MyArtist`.
@@ -26,7 +26,7 @@ enum RESTParameterSource: String, Codable {
 }
 
 /// A section that contains a list of REST parameters.
-struct RESTParametersRenderSection: RenderSection, Equatable {
+public struct RESTParametersRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .restParameters
     /// The title for the section.
     public let title: String

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTParametersRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTParametersRenderSection.swift
@@ -31,18 +31,25 @@ public struct RESTParametersRenderSection: RenderSection, Equatable {
     /// The title for the section.
     public let title: String
     /// The list of REST parameters.
-    public let items: [RenderProperty]
+    public let parameters: [RenderProperty]
     /// The kind of listed parameters.
     public let source: RESTParameterSource
-    
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case title
+        case parameters = "items"
+        case source
+    }
+
     /// Creates a new REST parameters section.
     /// - Parameters:
     ///   - title: The title for the section.
-    ///   - items: The list of REST parameters.
+    ///   - parameters: The list of REST parameters.
     ///   - source: The kind of listed parameters.
-    public init(title: String, items: [RenderProperty], source: RESTParameterSource) {
+    public init(title: String, parameters: [RenderProperty], source: RESTParameterSource) {
         self.title = title
-        self.items = items
+        self.parameters = parameters
         self.source = source
     }
 }
@@ -55,7 +62,7 @@ extension RESTParametersRenderSection: RenderJSONDiffable {
 
         diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
         diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
-        diffBuilder.addDifferences(atKeyPath: \.items, forKey: CodingKeys.items)
+        diffBuilder.addDifferences(atKeyPath: \.parameters, forKey: CodingKeys.parameters)
         diffBuilder.addDifferences(atKeyPath: \.source, forKey: CodingKeys.source)
 
         return diffBuilder.differences

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTResponseRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTResponseRenderSection.swift
@@ -16,15 +16,21 @@ public struct RESTResponseRenderSection: RenderSection, Equatable {
     /// The title for the section.
     public let title: String
     /// The list of possible REST responses.
-    public let items: [RESTResponse]
-    
+    public let responses: [RESTResponse]
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case title
+        case responses = "items"
+    }
+
     /// Creates a new REST response section.
     /// - Parameters:
     ///   - title: The title for the section.
-    ///   - items: The list of possible REST responses.
-    public init(title: String, items: [RESTResponse]) {
+    ///   - responses: The list of possible REST responses.
+    public init(title: String, responses: [RESTResponse]) {
         self.title = title
-        self.items = items
+        self.responses = responses
     }
 }
 
@@ -37,14 +43,14 @@ extension RESTResponseRenderSection: RenderJSONDiffable {
 
         diffBuilder.addDifferences(atKeyPath: \.kind, forKey: CodingKeys.kind)
         diffBuilder.addDifferences(atKeyPath: \.title, forKey: CodingKeys.title)
-        diffBuilder.addDifferences(atKeyPath: \.items, forKey: CodingKeys.items)
+        diffBuilder.addDifferences(atKeyPath: \.responses, forKey: CodingKeys.responses)
 
         return diffBuilder.differences
     }
     
     /// Returns if this RESTResponseRenderSection is similar enough to the given one.
     func isSimilar(to other: RESTResponseRenderSection) -> Bool {
-        return self.title == other.title || self.items == other.items
+        return self.title == other.title || self.responses == other.responses
     }
 }
 

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/RESTResponseRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/RESTResponseRenderSection.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A section that displays a list of REST responses.
-struct RESTResponseRenderSection: RenderSection, Equatable {
+public struct RESTResponseRenderSection: RenderSection, Equatable {
     public var kind: RenderSectionKind = .restResponses
     /// The title for the section.
     public let title: String
@@ -54,7 +54,7 @@ extension RESTResponseRenderSection: RenderJSONDiffable {
 /// If the response is a decodable object, a declaration-style `type` property
 /// describes the expected type and can provide an optional link to the expected
 /// documentation symbol.
-struct RESTResponse: Codable, TextIndexing, Equatable {
+public struct RESTResponse: Codable, TextIndexing, Equatable {
     /// The HTTP status code for the response.
     public let status: UInt
     /// An optional plain-text reason for the response.

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeHTTPRequestTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeHTTPRequestTests.swift
@@ -217,7 +217,7 @@ class SemaToRenderNodeHTTPRequestTests: XCTestCase {
         }
         
         // Confirm docs for responses
-        let responses = getArtistRenderNode.primaryContentSections.compactMap { ($0 as? RESTResponseRenderSection)?.items }.flatMap { $0 }
+        let responses = getArtistRenderNode.primaryContentSections.compactMap { ($0 as? RESTResponseRenderSection)?.responses }.flatMap { $0 }
         XCTAssertEqual(2, responses.count)
         if responses.count > 0 {
             let response = responses[0]

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeHTTPRequestTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeHTTPRequestTests.swift
@@ -188,7 +188,7 @@ class SemaToRenderNodeHTTPRequestTests: XCTestCase {
         )
         
         // Confirm docs for parameters
-        let paramItemSets = getArtistRenderNode.primaryContentSections.compactMap { ($0 as? RESTParametersRenderSection)?.items }
+        let paramItemSets = getArtistRenderNode.primaryContentSections.compactMap { ($0 as? RESTParametersRenderSection)?.parameters }
         XCTAssertEqual(2, paramItemSets.count)
         if paramItemSets.count > 0 {
             let items = paramItemSets[0]

--- a/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
@@ -28,7 +28,7 @@ class PlistSymbolTests: XCTestCase {
         
         guard let section = symbol.primaryContentSections.first(where: { section -> Bool in
             return section.kind == .plistDetails
-        }) as? PlistDetailsRenderSection else {
+        }) as? PropertyListDetailsRenderSection else {
             XCTFail("Plist details section not decoded")
             return
         }
@@ -138,7 +138,7 @@ class PlistSymbolTests: XCTestCase {
         
         guard let section = symbol.primaryContentSections.first(where: { section -> Bool in
             return section.kind == .plistDetails
-        }) as? PlistDetailsRenderSection else {
+        }) as? PropertyListDetailsRenderSection else {
             XCTFail("Plist details section not decoded")
             return
         }

--- a/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
@@ -68,7 +68,6 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
         XCTAssertEqual(
             try getPlistDetailsSection(arrayMode: true, baseType: "\"string\"", rawKey: "\"property-list-key\""),
             PropertyListDetailsRenderSection(
-               kind: .plistDetails,
                details: PropertyListDetailsRenderSection.Details(
                    rawKey: "property-list-key",
                    value: [TypeDetails(baseType: "string", arrayMode: true)],
@@ -82,7 +81,6 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
         XCTAssertEqual(
             try getPlistDetailsSection(arrayMode: false, baseType: "\"string\"", rawKey: "\"property-list-key\""),
             PropertyListDetailsRenderSection(
-               kind: .plistDetails,
                details: PropertyListDetailsRenderSection.Details(
                    rawKey: "property-list-key",
                    value: [TypeDetails(baseType: "string", arrayMode: false)],

--- a/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
@@ -14,11 +14,11 @@ import XCTest
 import SymbolKit
 import SwiftDocCTestUtilities
 
-class PlistDetailsRenderSectionTests: XCTestCase {
+class PropertyListDetailsRenderSectionTests: XCTestCase {
 
     func testDecoding() throws {
         
-        func getPlistDetailsSection(arrayMode: CustomStringConvertible, baseType: CustomStringConvertible, rawKey: CustomStringConvertible) throws -> PlistDetailsRenderSection {
+        func getPlistDetailsSection(arrayMode: CustomStringConvertible, baseType: CustomStringConvertible, rawKey: CustomStringConvertible) throws -> PropertyListDetailsRenderSection {
             let symbolJSON = """
             {
               "accessLevel" : "public",
@@ -61,15 +61,15 @@ class PlistDetailsRenderSectionTests: XCTestCase {
             let node = try XCTUnwrap(context.documentationCache["plist:propertylistkey"])
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
             let renderNode = try converter.convert(node)
-            return try XCTUnwrap(renderNode.primaryContentSections.mapFirst(where: { $0 as? PlistDetailsRenderSection }))
+            return try XCTUnwrap(renderNode.primaryContentSections.mapFirst(where: { $0 as? PropertyListDetailsRenderSection }))
         }
         
         // Assert that the Details section is correctly generated when passing valid values into the plistDetails JSON object.
         XCTAssertEqual(
             try getPlistDetailsSection(arrayMode: true, baseType: "\"string\"", rawKey: "\"property-list-key\""),
-            PlistDetailsRenderSection(
+            PropertyListDetailsRenderSection(
                kind: .plistDetails,
-               details: PlistDetailsRenderSection.Details(
+               details: PropertyListDetailsRenderSection.Details(
                    rawKey: "property-list-key",
                    value: [TypeDetails(baseType: "string", arrayMode: true)],
                    platforms: [],
@@ -81,9 +81,9 @@ class PlistDetailsRenderSectionTests: XCTestCase {
         
         XCTAssertEqual(
             try getPlistDetailsSection(arrayMode: false, baseType: "\"string\"", rawKey: "\"property-list-key\""),
-            PlistDetailsRenderSection(
+            PropertyListDetailsRenderSection(
                kind: .plistDetails,
-               details: PlistDetailsRenderSection.Details(
+               details: PropertyListDetailsRenderSection.Details(
                    rawKey: "property-list-key",
                    value: [TypeDetails(baseType: "string", arrayMode: false)],
                    platforms: [],

--- a/Tests/SwiftDocCTests/Rendering/RESTResponseRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RESTResponseRenderSectionTests.swift
@@ -36,7 +36,7 @@ class RESTResponseRenderSectionTests: XCTestCase {
             try value(),
             RESTResponseRenderSection(
                 title: "",
-                items: [
+                responses: [
                     RESTResponse(
                         status: 200,
                         reason: "reason",
@@ -71,7 +71,7 @@ class RESTResponseRenderSectionTests: XCTestCase {
             try valueWithoutReason(),
             RESTResponseRenderSection(
                 title: "",
-                items: [
+                responses: [
                     RESTResponse(
                         status: 200,
                         reason: nil,

--- a/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
@@ -146,18 +146,18 @@ class RESTSymbolsTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(responses.items.count, 1)
-        
-        guard responses.items.count == 1 else { return }
-        
-        XCTAssertEqual(responses.items[0].status, 200)
-        XCTAssertEqual(responses.items[0].reason, "OK")
-        XCTAssertEqual(responses.items[0].mimeType, "application/json")
-        XCTAssertEqual(responses.items[0].type.first?.identifier, "doc://org.swift.docc/applemusicapi/libraryartistresponse")
-        XCTAssertEqual(responses.items[0].content?.firstParagraphText, "The request was successful.")
-        
-        XCTAssertEqual(responses.headings.joined(), responses.items[0].reason)
-        XCTAssertEqual(responses.rawIndexableTextContent(references: [:]), responses.items[0].content?.firstParagraphText)
+        XCTAssertEqual(responses.responses.count, 1)
+
+        guard responses.responses.count == 1 else { return }
+
+        XCTAssertEqual(responses.responses[0].status, 200)
+        XCTAssertEqual(responses.responses[0].reason, "OK")
+        XCTAssertEqual(responses.responses[0].mimeType, "application/json")
+        XCTAssertEqual(responses.responses[0].type.first?.identifier, "doc://org.swift.docc/applemusicapi/libraryartistresponse")
+        XCTAssertEqual(responses.responses[0].content?.firstParagraphText, "The request was successful.")
+
+        XCTAssertEqual(responses.headings.joined(), responses.responses[0].reason)
+        XCTAssertEqual(responses.rawIndexableTextContent(references: [:]), responses.responses[0].content?.firstParagraphText)
         
         // REST mulitpart Body
         

--- a/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
@@ -72,27 +72,27 @@ class RESTSymbolsTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(parameters.items.count, 1)
+        XCTAssertEqual(parameters.parameters.count, 1)
         
-        guard parameters.items.count == 1 else { return }
+        guard parameters.parameters.count == 1 else { return }
         
-        XCTAssertEqual(parameters.items[0].required, true)
-        XCTAssertEqual(parameters.items[0].name, "id")
-        XCTAssertEqual(parameters.items[0].type.first?.text, "string")
+        XCTAssertEqual(parameters.parameters[0].required, true)
+        XCTAssertEqual(parameters.parameters[0].name, "id")
+        XCTAssertEqual(parameters.parameters[0].type.first?.text, "string")
         
-        XCTAssertEqual(parameters.items[0].typeDetails?.count, 2)
-        guard parameters.items[0].typeDetails?.count == 2 else { return }
+        XCTAssertEqual(parameters.parameters[0].typeDetails?.count, 2)
+        guard parameters.parameters[0].typeDetails?.count == 2 else { return }
         
-        XCTAssertNil(parameters.items[0].typeDetails?[0].arrayMode)
-        XCTAssertNil(parameters.items[0].typeDetails?[0].baseType)
-        XCTAssertEqual(parameters.items[0].typeDetails?[1].arrayMode, true)
-        XCTAssertEqual(parameters.items[0].typeDetails?[1].baseType, "string")
+        XCTAssertNil(parameters.parameters[0].typeDetails?[0].arrayMode)
+        XCTAssertNil(parameters.parameters[0].typeDetails?[0].baseType)
+        XCTAssertEqual(parameters.parameters[0].typeDetails?[1].arrayMode, true)
+        XCTAssertEqual(parameters.parameters[0].typeDetails?[1].baseType, "string")
 
-        XCTAssertEqual(parameters.items[0].type.first?.text, "string")
-        XCTAssertEqual(parameters.items[0].content?.firstParagraphText, "The unique identifier for the artist.")
+        XCTAssertEqual(parameters.parameters[0].type.first?.text, "string")
+        XCTAssertEqual(parameters.parameters[0].content?.firstParagraphText, "The unique identifier for the artist.")
         
-        XCTAssertEqual(parameters.headings.joined(), parameters.items[0].name)
-        XCTAssertEqual(parameters.rawIndexableTextContent(references: [:]), parameters.items[0].content?.firstParagraphText)
+        XCTAssertEqual(parameters.headings.joined(), parameters.parameters[0].name)
+        XCTAssertEqual(parameters.rawIndexableTextContent(references: [:]), parameters.parameters[0].content?.firstParagraphText)
         
         //
         // REST Query Parameters
@@ -105,15 +105,15 @@ class RESTSymbolsTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(query.items.count, 2)
+        XCTAssertEqual(query.parameters.count, 2)
         
-        guard query.items.count == 2 else { return }
+        guard query.parameters.count == 2 else { return }
         
-        XCTAssertNil(query.items[0].required)
-        XCTAssertEqual(query.items[0].name, "l")
-        XCTAssertEqual(query.items[0].type.first?.text, "string")
+        XCTAssertNil(query.parameters[0].required)
+        XCTAssertEqual(query.parameters[0].name, "l")
+        XCTAssertEqual(query.parameters[0].type.first?.text, "string")
         
-        XCTAssertEqual(query.headings.first, query.items[0].name)
+        XCTAssertEqual(query.headings.first, query.parameters[0].name)
 
         //
         // REST Headers
@@ -125,15 +125,15 @@ class RESTSymbolsTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(headers.items.count, 1)
+        XCTAssertEqual(headers.parameters.count, 1)
         
-        guard headers.items.count == 1 else { return }
+        guard headers.parameters.count == 1 else { return }
         
-        XCTAssertEqual(headers.items[0].name, "X-TotalCount")
-        XCTAssertEqual(headers.items[0].content?.firstParagraphText, "Total amount of results")
+        XCTAssertEqual(headers.parameters[0].name, "X-TotalCount")
+        XCTAssertEqual(headers.parameters[0].content?.firstParagraphText, "Total amount of results")
         
-        XCTAssertEqual(headers.headings.joined(), headers.items[0].name)
-        XCTAssertEqual(headers.rawIndexableTextContent(references: [:]), headers.items[0].content?.firstParagraphText)
+        XCTAssertEqual(headers.headings.joined(), headers.parameters[0].name)
+        XCTAssertEqual(headers.rawIndexableTextContent(references: [:]), headers.parameters[0].content?.firstParagraphText)
 
         //
         // REST Responses

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -125,7 +125,7 @@ extension XCTestCase {
         
         XCTAssertEqual(
             (renderNode.primaryContentSections.compactMap { $0 as? RESTResponseRenderSection })
-                .flatMap(\.items)
+                .flatMap(\.responses)
                 .map(\.status),
             expectedHTTPResponses ?? [], // compactMap gives an empty [], but should treat it as match for nil, too
             failureMessageForField("rest responses"),

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -96,7 +96,7 @@ extension XCTestCase {
         XCTAssertEqual(
             (renderNode.primaryContentSections.compactMap { $0 as? RESTParametersRenderSection })
                 .flatMap { section in
-                    section.items.map { "\($0.name)@\(section.source.rawValue)" }
+                    section.parameters.map { "\($0.name)@\(section.source.rawValue)" }
                 },
             expectedHTTPParameters ?? [], // compactMap gives an empty [], but should treat it as match for nil, too
             failureMessageForField("rest parameters"),


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://103619334

## Summary

The `PlistDetailsRenderSection`, `RESTParametersRenderSection`, `RESTBodyRenderSection`, and `RESTResponseRenderSection` structs are all internal. This appears to be an oversight as they mostly have public properties, and it limits the possibility for writing tools that use the RenderNode code for parsing render JSON.

In this PR I've made those symbols public along with any symbols referenced in their now-public APIs.

## Dependencies

None.

## Testing

No behavior changes, so I checked that the existing tests compile and run successfully.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - no, because no new behavior in the changes.
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
