### PR TITLE
Make default availability inheritance behaviour customizable.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -64,7 +64,7 @@ struct SymbolGraphLoader {
             guard let defautAvailabilities else { return nil }
             // Check the selected behaviour for inheritance of the default availability and remove the avaialbity
             // version if it's set to  `platformOnly`.
-            if bundle.info.inheritDefaultAvailability == .platformOnly {
+            if !bundle.info.defaultAvailabilityOptions.options.contains(.inheritVersionNumber) {
                 return defautAvailabilities.map { defaultAvailability in
                     var defaultAvailability = defaultAvailability
                     switch defaultAvailability.versionInformation {

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -64,9 +64,7 @@ struct SymbolGraphLoader {
             guard let defautAvailabilities else { return nil }
             // Check the selected behaviour for inheritance of the default availability and remove the avaialbity
             // version if it's set to  `platformOnly`.
-            if
-                let applyDefaultAvailabilityVersionToSymbols = bundle.info.inheritDefaultAvailability,
-                applyDefaultAvailabilityVersionToSymbols == .platformOnly {
+            if bundle.info.inheritDefaultAvailability == .platformOnly {
                 return defautAvailabilities.map { defaultAvailability in
                     var defaultAvailability = defaultAvailability
                     switch defaultAvailability.versionInformation {
@@ -426,7 +424,7 @@ extension SymbolGraph.Symbol.Availability.AvailabilityItem {
     /// platform version that can be parsed as a `SemanticVersion`, returns `nil`.
     init?(_ defaultAvailability: DefaultAvailability.ModuleAvailability) {
         let introducedVersion = defaultAvailability.introducedVersion
-        let platformVersion = (introducedVersion != nil) ? SymbolGraph.SemanticVersion(string: introducedVersion!) : nil
+        let platformVersion = introducedVersion.map { SymbolGraph.SemanticVersion(string: $0) } ?? nil
         let domain = SymbolGraph.Symbol.Availability.Domain(rawValue: defaultAvailability.platformName.rawValue)
         self.init(domain: domain,
                   introducedVersion: platformVersion,

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -59,6 +59,26 @@ struct SymbolGraphLoader {
         let bundle = self.bundle
         let dataProvider = self.dataProvider
         
+        /// Computes the default availbiality based on the `inheritDefaultAvailability` option.
+        let defaultAvailabilities: ([DefaultAvailability.ModuleAvailability]?) -> [DefaultAvailability.ModuleAvailability]? = { defautAvailabilities in
+            guard let defautAvailabilities else { return nil }
+            // Check the selected behaviour for inheritance of the default availability and remove the avaialbity
+            // version if it's set to  `platformOnly`.
+            if
+                let applyDefaultAvailabilityVersionToSymbols = bundle.info.inheritDefaultAvailability,
+                applyDefaultAvailabilityVersionToSymbols == .platformOnly {
+                return defautAvailabilities.map { defaultAvailability in
+                    var defaultAvailability = defaultAvailability
+                    switch defaultAvailability.versionInformation {
+                    case .available(_): defaultAvailability.versionInformation = .available(version: nil)
+                    case .unavailable: ()
+                    }
+                    return defaultAvailability
+                }
+            }
+            return defautAvailabilities
+        }
+        
         let loadGraphAtURL: (URL) -> Void = { symbolGraphURL in
             // Bail out in case a symbol graph has already errored
             guard loadError == nil else { return }
@@ -79,8 +99,9 @@ struct SymbolGraphLoader {
                 configureSymbolGraph?(&symbolGraph)
 
                 let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: symbolGraphURL)
+                let defaultAvailabilities = defaultAvailabilities(bundle.info.defaultAvailability?.modules[moduleName])
                 // If the bundle provides availability defaults add symbol availability data.
-                self.addDefaultAvailability(to: &symbolGraph, moduleName: moduleName)
+                self.addDefaultAvailability(to: &symbolGraph, moduleName: moduleName, defaultAvailabilities: defaultAvailabilities)
 
                 // main symbol graphs are ambiguous
                 var usesExtensionSymbolFormat: Bool? = nil
@@ -153,7 +174,7 @@ struct SymbolGraphLoader {
             var defaultUnavailablePlatforms = [PlatformName]()
             var defaultAvailableInformation = [DefaultAvailability.ModuleAvailability]()
 
-            if let defaultAvailabilities = bundle.info.defaultAvailability?.modules[unifiedGraph.moduleName] {
+            if let defaultAvailabilities = defaultAvailabilities(bundle.info.defaultAvailability?.modules[unifiedGraph.moduleName]) {
                 let (unavailablePlatforms, availablePlatforms) = defaultAvailabilities.categorize(where: { $0.versionInformation == .unavailable })
                 defaultUnavailablePlatforms = unavailablePlatforms.map(\.platformName)
                 defaultAvailableInformation = availablePlatforms
@@ -279,11 +300,11 @@ struct SymbolGraphLoader {
 
     /// If the bundle defines default availability for the symbols in the given symbol graph
     /// this method adds them to each of the symbols in the graph.
-    private func addDefaultAvailability(to symbolGraph: inout SymbolGraph, moduleName: String) {
+    private func addDefaultAvailability(to symbolGraph: inout SymbolGraph, moduleName: String, defaultAvailabilities: [DefaultAvailability.ModuleAvailability]?) {
         let selector = UnifiedSymbolGraph.Selector(forSymbolGraph: symbolGraph)
         // Check if there are defined default availabilities for the current module
-        if let defaultAvailabilities = bundle.info.defaultAvailability?.modules[moduleName],
-            let platformName = symbolGraph.module.platform.name.map(PlatformName.init) {
+        if let defaultAvailabilities = defaultAvailabilities,
+           let platformName = symbolGraph.module.platform.name.map(PlatformName.init) {
 
             // Prepare a default availability versions lookup for this module.
             let defaultAvailabilityVersionByPlatform = defaultAvailabilities
@@ -404,9 +425,8 @@ extension SymbolGraph.Symbol.Availability.AvailabilityItem {
     /// - Note: If the `defaultAvailability` argument doesn't have a valid
     /// platform version that can be parsed as a `SemanticVersion`, returns `nil`.
     init?(_ defaultAvailability: DefaultAvailability.ModuleAvailability) {
-        guard let introducedVersion = defaultAvailability.introducedVersion, let platformVersion = SymbolGraph.SemanticVersion(string: introducedVersion) else {
-            return nil
-        }
+        let introducedVersion = defaultAvailability.introducedVersion
+        let platformVersion = (introducedVersion != nil) ? SymbolGraph.SemanticVersion(string: introducedVersion!) : nil
         let domain = SymbolGraph.Symbol.Availability.Domain(rawValue: defaultAvailability.platformName.rawValue)
         self.init(domain: domain,
                   introducedVersion: platformVersion,

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailability.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailability.swift
@@ -51,7 +51,7 @@ public struct DefaultAvailability: Codable, Equatable {
         /// Unavailable or Available with an introduced version.
         enum VersionInformation: Hashable {
             case unavailable
-            case available(version: String)
+            case available(version: String?)
         }
 
         /// The name of the platform, e.g. "macOS".
@@ -71,7 +71,7 @@ public struct DefaultAvailability: Codable, Equatable {
         public var introducedVersion: String? {
             switch versionInformation {
             case .available(let introduced):
-                return introduced.description
+                return introduced?.description
             case .unavailable:
                 return nil
             }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailailabilityOptions.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailailabilityOptions.swift
@@ -10,60 +10,66 @@
 
 import Foundation
 
-extension DocumentationBundle.Info {
+/// A collection of options that customaise the default availability behaviour.
+///
+/// Default availability options are applied to all the modules contained in the documentation bundle.
+///
+/// This information can be authored in the bundle's Info.plist file, as a dictionary of option name and boolean pairs.
+///
+/// ```
+/// <key>CDDefaultAvailabilityOptions</key>
+/// <dict>
+///     <key>OptionName</key>
+///     <bool/>
+/// </dict>
+/// ```
+public struct DefaultAvailabilityOptions: Codable, Equatable {
     
-    /// A collection of options that customaise the default availability behaviour.
-    ///
-    /// Default availability options are applied to all the modules contained in the documentation bundle.
-    ///
-    /// This information can be authored in the bundle's Info.plist file, as a dictionary of option name and boolean pairs.
-    ///
-    /// ```
-    /// <key>CDDefaultAvailabilityOptions</key>
-    /// <dict>
-    ///     <key>OptionName</key>
-    ///     <bool/>
-    /// </dict>
-    /// ```
-    public struct DefaultAvailabilityOptions: Codable, Equatable {
-        
-        /// A set of non-standard behaviors that apply to this node.
-        fileprivate(set) var options: Options
-        
-        /// Options that specify behaviors of the default availability logic.
-        struct Options: OptionSet {
+    /// A set of non-standard behaviors that apply to this node.
+    fileprivate(set) var options: Options
+    
+    /// Options that specify behaviors of the default availability logic.
+    struct Options: OptionSet {
 
-            let rawValue: Int
-            
-            /// Enable or disable symbol availability version inference from the module default availability.
-            static let inheritVersionNumber = Options(rawValue: 1 << 0)
-        }
+        let rawValue: Int
         
-        /// String representation of the default availability options.
-        private enum CodingKeys: String, CodingKey {
-            case inheritVersionNumber = "InheritVersionNumber"
-        }
+        /// Enable or disable symbol availability version inference from the module default availability.
+        static let inheritVersionNumber = Options(rawValue: 1 << 0)
+    }
+    
+    /// String representation of the default availability options.
+    private enum CodingKeys: String, CodingKey {
+        case inheritVersionNumber = "InheritVersionNumber"
+    }
+    
+    public init() {
+        self.options = .inheritVersionNumber
+    }
 
-        public init(from decoder: any Decoder) throws {
-            self.init()
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            if try values.decodeIfPresent(Bool.self, forKey: .inheritVersionNumber) == false {
-                options.remove(.inheritVersionNumber)
-            }
+    public init(from decoder: any Decoder) throws {
+        self.init()
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        if try values.decodeIfPresent(Bool.self, forKey: .inheritVersionNumber) == false {
+            options.remove(.inheritVersionNumber)
         }
-        
-        public func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            if !options.contains(.inheritVersionNumber) {
-                try container.encode(false, forKey: .inheritVersionNumber)
-            }
-            
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if !options.contains(.inheritVersionNumber) {
+            try container.encode(false, forKey: .inheritVersionNumber)
         }
-        
-        public init() {
-            self.options = .inheritVersionNumber
+    }
+    
+    /// Convenient method to determine if an option has to be applied depending
+    /// on it's exsistence inside the options set.
+    func shouldApplyOption(_ option: Options) -> Bool {
+        switch option {
+        case .inheritVersionNumber:
+            return options.contains(.inheritVersionNumber)
+        default:
+            return false
         }
-
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailailabilityOptions.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DefaultAvailailabilityOptions.swift
@@ -1,0 +1,69 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension DocumentationBundle.Info {
+    
+    /// A collection of options that customaise the default availability behaviour.
+    ///
+    /// Default availability options are applied to all the modules contained in the documentation bundle.
+    ///
+    /// This information can be authored in the bundle's Info.plist file, as a dictionary of option name and boolean pairs.
+    ///
+    /// ```
+    /// <key>CDDefaultAvailabilityOptions</key>
+    /// <dict>
+    ///     <key>OptionName</key>
+    ///     <bool/>
+    /// </dict>
+    /// ```
+    public struct DefaultAvailabilityOptions: Codable, Equatable {
+        
+        /// A set of non-standard behaviors that apply to this node.
+        fileprivate(set) var options: Options
+        
+        /// Options that specify behaviors of the default availability logic.
+        struct Options: OptionSet {
+
+            let rawValue: Int
+            
+            /// Enable or disable symbol availability version inference from the module default availability.
+            static let inheritVersionNumber = Options(rawValue: 1 << 0)
+        }
+        
+        /// String representation of the default availability options.
+        private enum CodingKeys: String, CodingKey {
+            case inheritVersionNumber = "InheritVersionNumber"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            self.init()
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            if try values.decodeIfPresent(Bool.self, forKey: .inheritVersionNumber) == false {
+                options.remove(.inheritVersionNumber)
+            }
+        }
+        
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            if !options.contains(.inheritVersionNumber) {
+                try container.encode(false, forKey: .inheritVersionNumber)
+            }
+            
+        }
+        
+        public init() {
+            self.options = .inheritVersionNumber
+        }
+
+    }
+}
+

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -253,29 +253,8 @@ extension DocumentationBundle {
             self.defaultCodeListingLanguage = try decodeOrFallbackIfPresent(String.self, with: .defaultCodeListingLanguage)
             self.defaultModuleKind = try decodeOrFallbackIfPresent(String.self, with: .defaultModuleKind)
             self.defaultAvailabilityOptions = try decodeOrFallbackIfPresent(DefaultAvailabilityOptions.self, with: .defaultAvailabilityOptions)
-            var defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
-            
-            // Apply default availability options mutations.
-            if let defaultAvailabilityOptions {
-                // Remove the availability version if `inheritVersionNumber` is not part
-                // of the default availability options.
-                if !defaultAvailabilityOptions.shouldApplyOption(.inheritVersionNumber) {
-                    for (key, var moduleAvailability) in defaultAvailability?.modules ?? [:] {
-                        moduleAvailability = moduleAvailability.map { moduleAvailability in
-                            var moduleAvailability = moduleAvailability
-                            moduleAvailability.versionInformation = {
-                                switch moduleAvailability.versionInformation {
-                                case .available(_): return .available(version: nil)
-                                default: return moduleAvailability.versionInformation
-                                }
-                            }()
-                            return moduleAvailability
-                        }
-                        defaultAvailability?.modules[key] = moduleAvailability
-                    }
-                }
-            }
-            self.defaultAvailability = defaultAvailability
+            self.defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
+            self.defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
             self.featureFlags = try decodeOrFallbackIfPresent(BundleFeatureFlags.self, with: .featureFlags)
         }
         

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -13,7 +13,7 @@ import Foundation
 extension DocumentationBundle {
     
     /// Options to define the inherit default availability behaviour.
-    public enum InheritDefaultAvailabilityOptions: String, Encodable {
+    public enum InheritDefaultAvailabilityOptions: String, Codable {
         /// The platforms with the designated versions defined in the default availability will be used by the symbols as availability information.
         /// This is the default behaviour.
         case platformAndVersion
@@ -108,7 +108,7 @@ extension DocumentationBundle {
         ///   - defaultCodeListingLanguage: The default language identifier for code listings in the bundle.
         ///   - defaultAvailability: The default availability for the various modules in the bundle.
         ///   - defaultModuleKind: The default kind for the various modules in the bundle.
-        ///   -  inheritDefaultAvailability: The option to enable or disable symbol availability inheritance from the module default availability.
+        ///   - inheritDefaultAvailability: The option to enable or disable symbol availability inheritance from the module default availability.
         public init(
             displayName: String,
             identifier: String,

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1243,8 +1243,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 .compactMap { availability -> AvailabilityRenderItem? in
                     // Filter items with insufficient availability data unless the default availability behaviour
                     // allows availability withound version information.
-                    let applyDefaultAvailabilityVersionToSymbols = !bundle.info.defaultAvailabilityOptions.options.contains(.inheritVersionNumber)
-                    guard availability.introducedVersion != nil || applyDefaultAvailabilityVersionToSymbols else {
+                    let omitDefaultAvailabilityVersionFromSymbols = bundle.info.defaultAvailabilityOptions?.shouldApplyOption(.inheritVersionNumber) == false
+                    guard availability.introducedVersion != nil || omitDefaultAvailabilityVersionFromSymbols else {
                         return nil
                     }
                     guard let name = availability.domain.map({ PlatformName(operatingSystemName: $0.rawValue) }),

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1243,8 +1243,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
                 .compactMap { availability -> AvailabilityRenderItem? in
                     // Filter items with insufficient availability data unless the default availability behaviour
                     // allows availability withound version information.
-                    let applyDefaultAvailabilityVersionToSymbols = bundle.info.inheritDefaultAvailability
-                    guard availability.introducedVersion != nil || applyDefaultAvailabilityVersionToSymbols == .platformOnly else {
+                    let applyDefaultAvailabilityVersionToSymbols = !bundle.info.defaultAvailabilityOptions.options.contains(.inheritVersionNumber)
+                    guard availability.introducedVersion != nil || applyDefaultAvailabilityVersionToSymbols else {
                         return nil
                     }
                     guard let name = availability.domain.map({ PlatformName(operatingSystemName: $0.rawValue) }),

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1241,8 +1241,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.metadata.platformsVariants = VariantCollection<[AvailabilityRenderItem]?>(from: symbol.availabilityVariants) { _, availability in
             availability.availability
                 .compactMap { availability -> AvailabilityRenderItem? in
-                    // Filter items with insufficient availability data
-                    guard availability.introducedVersion != nil else {
+                    // Filter items with insufficient availability data unless the default availability behaviour
+                    // allows availability withound version information.
+                    let applyDefaultAvailabilityVersionToSymbols = bundle.info.inheritDefaultAvailability
+                    guard availability.introducedVersion != nil || applyDefaultAvailabilityVersionToSymbols == .platformOnly else {
                         return nil
                     }
                     guard let name = availability.domain.map({ PlatformName(operatingSystemName: $0.rawValue) }),

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -687,8 +687,11 @@ class DefaultAvailabilityTests: XCTestCase {
         // Don't use default availability version for symbols.
         
         var context = try setupContext(inheritDefaultAvailability: """
-        <key>CDInheritDefaultAvailability</key>
-        <string>platformOnly</string>
+        <key>CDDefaultAvailabilityOptions</key>
+        <dict>
+            <key>InheritVersionNumber</key>
+            <false/>
+        </dict>
         """)
         
         // Verify we add the version number into the symbols that have availability annotation.
@@ -710,8 +713,11 @@ class DefaultAvailabilityTests: XCTestCase {
         // Add an extra default availability to test behaviour when mixin in source with default behaviour.
         context = try setupContext(
             inheritDefaultAvailability: """
-            <key>CDInheritDefaultAvailability</key>
-            <string>platformOnly</string>
+            <key>CDDefaultAvailabilityOptions</key>
+            <dict>
+                <key>InheritVersionNumber</key>
+                <false/>
+            </dict>
             """,
             defaultAvailability: """
             <dict>
@@ -742,8 +748,11 @@ class DefaultAvailabilityTests: XCTestCase {
         // Use default availability version for symbols.
         
         context = try setupContext(inheritDefaultAvailability: """
-        <key>CDInheritDefaultAvailability</key>
-        <string>platformAndVersion</string>
+        <key>CDDefaultAvailabilityOptions</key>
+        <dict>
+            <key>InheritVersionNumber</key>
+            <true/>
+        </dict>
         """)
         
         // Verify we add the version number into the symbols that have availability annotation.


### PR DESCRIPTION
Bug/issue #, if applicable:  132980711

## Summary

Introduced a new Info.plist key, `CDDefaultAvailabilityOptions`, which enables customization of DocC's logic when applying default availability to symbols availability information. 

`CDDefaultAvailabilityOptions` is a dictionary that allows an inner key `InheritVersionNumber`. 

`InheritVersionNumber` is a boolean that allows the removal of the symbol default availability version on symbols that don't define an explicit availability annotation for the given platform.

## Dependencies

N/A

## Testing

Use the attached doc catalog.
[Availability.docc.zip](https://github.com/user-attachments/files/17051273/Availability.docc.zip)


Steps:
1. Preview the attached catalog and got to the symbol `Bar`
2. Check that the symbol `Bar` shows the platforms from the default availability but not the versions.
3. Check that `Foo` shows iOS with the version and the rest of the platforms without version.
4. Check that the framework page shows the default availability information.
5. Change the info plist `InheritVersionNumber ` to true and assert that the availability renders as expected.
6. Remove the key from the Info.plist and assert that the availability renders as expected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
