### PR TITLE
Fix cross language availability inheritance

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -223,6 +223,10 @@ public struct DocumentationNode {
             platformName: platformName
         ) { mixins in
             mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
+                
+                // If the symbol graph doesn't provide availability data for this variant, hardcode it as `[]` so
+                // that it doesn't get inferred from another variant.
+                ?? .init(availability: [])
         }
         
         let endpointVariants = DocumentationDataVariants(

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderNode+Codable.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderNode+Codable.swift
@@ -95,7 +95,7 @@ extension RenderNode: Codable {
         try container.encodeIfPresent(sampleDownload, forKey: .sampleCodeDownload)
         try container.encodeIfPresent(downloadNotAvailableSummary, forKey: .downloadNotAvailableSummary)
         
-        try container.encodeVariantCollection(deprecationSummaryVariants, forKey: .deprecationSummary, encoder: encoder)
+        try container.encodeVariantCollectionIfNotEmpty(deprecationSummaryVariants, forKey: .deprecationSummary, encoder: encoder)
         
         try container.encodeIfPresent(diffAvailability, forKey: .diffAvailability)
         try container.encodeIfPresent(variants, forKey: .variants)

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1652,12 +1652,39 @@ public struct RenderNodeTranslator: SemanticVisitor {
             return seeAlsoSections
         } ?? .init(defaultValue: [])
         
-        node.deprecationSummaryVariants = VariantCollection<[RenderBlockContent]?>(
-            from: symbol.deprecatedSummaryVariants
-        ) { _, deprecatedSummary in
-            // If there is a deprecation summary in a documentation extension file add it to the render node
-            visitMarkupContainer(MarkupContainer(deprecatedSummary.content)) as? [RenderBlockContent]
-        } ?? .init(defaultValue: nil)
+        /// The set of traits in which the symbol is deprecated in at least one platform.
+        let traitsInWhichSymbolsIsDeprecated = documentationNode.availableVariantTraits.filter { trait in
+            guard let platforms = symbol.availabilityVariants[trait]?.availability else {
+                return false
+            }
+            
+            return platforms.contains(where: { platform in
+                platform.deprecatedVersion != nil || platform.isUnconditionallyDeprecated
+            })
+        }
+        
+        node.deprecationSummaryVariants = VariantCollection(
+            from: documentationNode.availableVariantTraits,
+            fallbackDefaultValue: nil,
+            transform: { trait in
+                if traitsInWhichSymbolsIsDeprecated.contains(trait) || traitsInWhichSymbolsIsDeprecated.isEmpty {
+                    // It's possible for a symbol to only be deprecated in _some_ of its language representations
+                    // In this case, only display the deprecation information for those language representations.
+                    //
+                    // Also, previous versions of DocC treated a page as deprecated if it had a custom `@DeprecationSummmary` description,
+                    // even if the symbol wasn't deprecated. We preserve that behavior for backwards compatibility.
+                    // TODO: Warn about using `@DeprecationSummmary` for non-deprecated pages,
+                    // suggesting to use `@Available` to add deprecation information.
+                    guard let deprecatedSummary = symbol.deprecatedSummaryVariants[trait] else {
+                        return nil
+                    }
+                    
+                    return visitMarkupContainer(MarkupContainer(deprecatedSummary.content)) as? [RenderBlockContent]
+                }
+                
+                return []
+            }
+        ) ?? .init(defaultValue: nil)
         
         collectedTopicReferences.append(contentsOf: contentCompiler.collectedTopicReferences)
         node.references = createTopicRenderReferences()

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -1040,6 +1040,25 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
+    /// Tests that APIs don't inherit platform availability from their variant in other languages.
+    ///
+    /// The `DeprecatedInOneLanguageOnly` catalog defines a symbol `MyClass` which has availability
+    /// annotations in Swift but not in Objective-C. This test verifies that the Swift render node for `MyClass` does
+    /// indeed include availability information, but that the Objective-C one doesn't.
+    func testDoesNotInheritAvailabilityFromOtherLanguage() throws {
+        try assertMultiVariantSymbol(
+            bundleName: "DeprecatedInOneLanguageOnly",
+            assertOriginalRenderNode: { renderNode in
+                XCTAssert(renderNode.metadata.platforms?.isEmpty == false)
+            }, assertAfterApplyingVariant: { renderNode in
+                XCTAssertNil(
+                    renderNode.metadata.platforms,
+                    "Unexpectedly inherited documentation from the Swift symbol graph."
+                )
+            }
+        )
+    }
+    
     func testTopicRenderReferenceVariants() throws {
         func myFunctionReference(in renderNode: RenderNode) throws -> TopicRenderReference {
             return try XCTUnwrap(
@@ -1086,6 +1105,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     }
     
     private func assertMultiVariantSymbol(
+        bundleName: String = "TestBundle",
         configureContext: (DocumentationContext, ResolvedTopicReference) throws -> () = { _, _ in },
         configureSymbol: (Symbol) throws -> () = { _ in },
         configureRenderNodeTranslator: (inout RenderNodeTranslator) -> () = { _ in },
@@ -1093,7 +1113,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         assertAfterApplyingVariant: (RenderNode) throws -> () = { _ in },
         assertDataAfterApplyingVariant: (Data) throws -> () = { _ in }
     ) throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle")
+        let (_, bundle, context) = try testBundleAndContext(copying: bundleName)
         
         let identifier = ResolvedTopicReference(
             bundleIdentifier: bundle.identifier,

--- a/Tests/SwiftDocCTests/Test Bundles/DeprecatedInOneLanguageOnly.docc/MyKit-objc.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DeprecatedInOneLanguageOnly.docc/MyKit-objc.symbols.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+      "formatVersion" : {
+          "major" : 1
+      },
+      "generator" : "swift"
+  },
+  "module" : {
+    "name" : "MyKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "vendor" : "apple",
+      "operatingSystem" : {
+        "name" : "ios",
+        "minimumVersion" : {
+          "major" : 13,
+          "minor" : 0,
+          "patch" : 0
+        }
+      }
+    }
+  },
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyClass"
+      },
+      "pathComponents" : [
+        "MyClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC",
+        "interfaceLanguage": "occ"
+      }
+    }
+  ],
+  "relationships" : []
+}

--- a/Tests/SwiftDocCTests/Test Bundles/DeprecatedInOneLanguageOnly.docc/MyKit-swift.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/DeprecatedInOneLanguageOnly.docc/MyKit-swift.symbols.json
@@ -1,0 +1,56 @@
+{
+  "metadata": {
+      "formatVersion" : {
+          "major" : 1
+      },
+      "generator" : "swift"
+  },
+  "module" : {
+    "name" : "MyKit",
+    "platform" : {
+      "architecture" : "x86_64",
+      "vendor" : "apple",
+      "operatingSystem" : {
+        "name" : "ios",
+        "minimumVersion" : {
+          "major" : 13,
+          "minor" : 0,
+          "patch" : 0
+        }
+      }
+    }
+  },
+  "symbols" : [
+    {
+      "accessLevel" : "public",
+      "kind" : {
+        "identifier" : "swift.class",
+        "displayName" : "Class"
+      },
+      "names" : {
+        "title" : "MyClass"
+      },
+      "availability" : [
+        {
+          "domain": "macOS",
+          "introduced": {
+            "major": 10,
+            "minor": 15
+          },
+          "deprecated": {
+            "major": 10,
+            "minor": 16
+          }
+        }
+      ],
+      "pathComponents" : [
+        "MyClass"
+      ],
+      "identifier" : {
+        "precise" : "s:5MyKit0A5ClassC",
+        "interfaceLanguage": "swift"
+      }
+    }
+  ],
+  "relationships" : []
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 131331606

## Summary

Fixes a bug where DocC inherits platform availability information from the Swift variant of an API from its Objective-C variant. Specifically, it's possible for a symbol to be deprecated in Swift but not in Objective-C, in which case we should only show depreciation information for the Swift variant of the page.

The changes are split into two commits:

1. Fixes cross-language availability inheritance. This updates the symbol graph loader and render node translator to not inherit availability information from other language variants of the API.
2. Fixes `@DeprecationSummary` to only be shown on variants of the API that are actually deprecated. For backwards compatibility, if the API is not deprecated in any languages, we'll still show the deprecation summary.

## Dependencies

None.

## Testing

Steps:
1. Build documentation for an API that marked as deprecated in Swift but doesn't have any availability annotations in Objective-C. You can achieve this by defining the API in an Objective-C header and guarding availability annotations within a `#if defined(__swift__)` macro.
2. Verify that the Swift version of the page shows deprecation information, but that the Objective-C version doesn't.
3. Add a `@DeprecationSummary` for the API in a documentation extension and verify that its contents only appears in the Swift variant of the page.
4. Verify that a `@DeprecationSummary` for a non-deprecated API continues being displayed in both Swift and Objective-C variants of a page.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
