### PR TITLE
fixes curation of a floating article on API documentation

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/DocC Documentation.md
+++ b/Sources/docc/DocCDocumentation.docc/DocC Documentation.md
@@ -25,6 +25,7 @@ DocC syntax — called _documentation markup_ — is a custom variant of Markdow
 - <doc:writing-symbol-documentation-in-your-source-files>
 - <doc:adding-supplemental-content-to-a-documentation-catalog>
 - <doc:linking-to-symbols-and-other-content>
+- <doc:documenting-api-with-different-language-representations>
 
 ### Structure and Formatting
 


### PR DESCRIPTION
## Summary

Currently, there's a article (Documenting API with Different Language Representations) floating outside the curated structure of top level content at the high level Swift DocC documentation, visible at https://www.swift.org/documentation/docc/

<img width="584" alt="Screenshot 2024-09-13 at 4 57 45 PM" src="https://github.com/user-attachments/assets/69a4ccb4-d6c9-4277-94bb-50ac38ac3c4e">

This change updates the curation to move it inline with the other articles focused on documenting API.

## Dependencies

none

## Testing

visually reviewed the results in Xcode's documentation build of the content

Steps:
1. check out branch
2. build documentation for Swift-docc
3. visually review top-level documentation for Swift-docc

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
