### PR TITLE
Add filter tag and abstract properties to the RenderIndex

### DIFF
--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -140,7 +140,11 @@ extension RenderIndex {
         /// A reference to a custom image for this node.
         public let icon: RenderReferenceIdentifier?
         
+        /// Tags associated with this node that a renderer can use to filter through the index.
         public let filterTags: [String]
+        
+        /// An abstract associated with this node that a renderer can use when filtering through the index.
+        public let abstract: [RenderInlineContent]
 
         enum CodingKeys: String, CodingKey {
             case title
@@ -152,6 +156,7 @@ extension RenderIndex {
             case beta
             case icon
             case tags
+            case abstract
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -181,6 +186,8 @@ extension RenderIndex {
             try container.encodeIfPresent(icon, forKey: .icon)
             
             try container.encodeIfNotEmpty(filterTags, forKey: .tags)
+            
+            try container.encodeIfNotEmpty(abstract, forKey: .abstract)
         }
         
         public init(from decoder: Decoder) throws {
@@ -204,6 +211,8 @@ extension RenderIndex {
             icon = try values.decodeIfPresent(RenderReferenceIdentifier.self, forKey: .icon)
             
             filterTags = try values.decodeIfPresent([String].self, forKey: .tags) ?? []
+            
+            abstract = try values.decodeIfPresent([RenderInlineContent].self, forKey: .abstract) ?? []
         }
         
         /// Creates a new node with the given title, path, type, and children.
@@ -227,7 +236,8 @@ extension RenderIndex {
             isExternal: Bool,
             isBeta: Bool,
             icon: RenderReferenceIdentifier? = nil,
-            filterTags: [String] = []
+            filterTags: [String] = [],
+            abstract: [RenderInlineContent] = []
         ) {
             self.title = title
             self.path = path
@@ -238,6 +248,7 @@ extension RenderIndex {
             self.isBeta = isBeta
             self.icon = nil
             self.filterTags = filterTags
+            self.abstract = abstract
         }
         
         init(
@@ -247,7 +258,8 @@ extension RenderIndex {
             isDeprecated: Bool,
             children: [Node],
             icon: RenderReferenceIdentifier?,
-            filterTags: [String] = []
+            filterTags: [String] = [],
+            abstract: [RenderInlineContent] = []
         ) {
             self.title = title
             self.children = children.isEmpty ? nil : children
@@ -262,6 +274,7 @@ extension RenderIndex {
             self.icon = icon
             
             self.filterTags = filterTags
+            self.abstract = abstract
             
             guard let pageType else {
                 self.type = nil

--- a/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
+++ b/Sources/SwiftDocC/Indexing/RenderIndexJSON/RenderIndex.swift
@@ -139,6 +139,8 @@ extension RenderIndex {
         
         /// A reference to a custom image for this node.
         public let icon: RenderReferenceIdentifier?
+        
+        public let filterTags: [String]
 
         enum CodingKeys: String, CodingKey {
             case title
@@ -149,6 +151,7 @@ extension RenderIndex {
             case external
             case beta
             case icon
+            case tags
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -176,6 +179,8 @@ extension RenderIndex {
             }
             
             try container.encodeIfPresent(icon, forKey: .icon)
+            
+            try container.encodeIfNotEmpty(filterTags, forKey: .tags)
         }
         
         public init(from decoder: Decoder) throws {
@@ -197,6 +202,8 @@ extension RenderIndex {
             isBeta = try values.decodeIfPresent(Bool.self, forKey: .beta) ?? false
             
             icon = try values.decodeIfPresent(RenderReferenceIdentifier.self, forKey: .icon)
+            
+            filterTags = try values.decodeIfPresent([String].self, forKey: .tags) ?? []
         }
         
         /// Creates a new node with the given title, path, type, and children.
@@ -219,7 +226,8 @@ extension RenderIndex {
             isDeprecated: Bool,
             isExternal: Bool,
             isBeta: Bool,
-            icon: RenderReferenceIdentifier? = nil
+            icon: RenderReferenceIdentifier? = nil,
+            filterTags: [String] = []
         ) {
             self.title = title
             self.path = path
@@ -229,6 +237,7 @@ extension RenderIndex {
             self.isExternal = isExternal
             self.isBeta = isBeta
             self.icon = nil
+            self.filterTags = filterTags
         }
         
         init(
@@ -237,7 +246,8 @@ extension RenderIndex {
             pageType: NavigatorIndex.PageType?,
             isDeprecated: Bool,
             children: [Node],
-            icon: RenderReferenceIdentifier?
+            icon: RenderReferenceIdentifier?,
+            filterTags: [String] = []
         ) {
             self.title = title
             self.children = children.isEmpty ? nil : children
@@ -250,6 +260,8 @@ extension RenderIndex {
             
             self.isBeta = false
             self.icon = icon
+            
+            self.filterTags = filterTags
             
             guard let pageType else {
                 self.type = nil

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderContentMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderContentMetadata.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// Additional metadata that might belong to a content element.
-public struct RenderContentMetadata: Equatable, Codable {
+public struct RenderContentMetadata: Equatable, Codable, Hashable {
     /// An optional named anchor to the current element.
     public var anchor: String?
     /// An optional custom title.

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderInlineContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderInlineContent.swift
@@ -29,7 +29,7 @@
 ///
 /// Inline elements can be nested, for example, an inline piece of text can be wrapped in an emphasis element.
 /// Block elements cannot be nested in inline elements.
-public enum RenderInlineContent: Equatable {
+public enum RenderInlineContent: Equatable, Hashable {
     /// A piece of code like a variable name or a single operator.
     case codeVoice(code: String)
     /// An emphasized piece of inline content.

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -110,6 +110,12 @@
                         "type": "string",
                         "format": "reference(ImageRenderReference)"
                     },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "children": {
                         "type": "array",
                         "items": {

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -116,6 +116,12 @@
                             "type": "string"
                         }
                     },
+                    "abstract": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    },
                     "children": {
                         "type": "array",
                         "items": {
@@ -195,7 +201,291 @@
             "RenderReferenceVariantTrait": {
                 "type": "string",
                 "enum": ["1x", "2x", "3x", "light", "dark"]
-            }
+            },
+            "RenderInlineContent": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/Text"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Emphasis"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Strong"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CodeVoice"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Reference"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Image"
+                    },
+                    {
+                        "$ref": "#/components/schemas/InlineHead"
+                    },
+                    {
+                        "$ref": "#/components/schemas/NewTerm"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Superscript"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Link"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Subscript"
+                    }
+                ]
+            },
+            "Text": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "text"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["text"]
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Emphasis": {
+                "required": [
+                    "type",
+                    "inlineContent"
+                ],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "emphasis",
+                            "italic"
+                        ]
+                    },
+                    "inlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "Strong": {
+                "required": [
+                    "type",
+                    "inlineContent"
+                ],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "strong"
+                        ]
+                    },
+                    "inlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "CodeVoice": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "code"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["codeVoice"]
+                    },
+                    "code": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Reference": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "isActive",
+                    "identifier"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["reference"]
+                    },
+                    "isActive": {
+                        "type": "boolean"
+                    },
+                    "identifier": {
+                        "type": "string",
+                        "format": "reference"
+                    },
+                    "overridingTitle": {
+                        "type": "string"
+                    },
+                    "overridingTitleInlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "Image": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "identifier"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["image"]
+                    },
+                    "identifier": {
+                        "type": "string",
+                        "format": "reference(ImageRenderReference)"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/RenderContentMetadata"
+                    }
+                }
+            },
+            "InlineHead": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "inlineContent"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["inlineHead"]
+                    },
+                    "inlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "NewTerm": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "inlineContent"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["newTerm"]
+                    },
+                    "inlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "Superscript": {
+                "required": [
+                    "type",
+                    "inlineContent"
+                ],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "superscript"
+                        ]
+                    },
+                    "inlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "Subscript": {
+                "required": [
+                    "type",
+                    "inlineContent"
+                ],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "subscript"
+                        ]
+                    },
+                    "inlineContent": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    }
+                }
+            },
+            "Link": {
+                "required": [
+                    "type",
+                    "title",
+                    "destination"
+                ],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "link"
+                        ]
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "destination": {
+                        "type": "string"
+                    }
+                }
+            },
+            "RenderContentMetadata" : {
+                "type": "object",
+                "properties": {
+                    "anchor": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "abstract": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RenderInlineContent"
+                        }
+                    },
+                    "deviceFrame": {
+                        "type": "string"
+                    }
+                }
+            },
         },
         "requestBodies": {},
         "securitySchemes": {},


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://136316686

## Summary

@hqhhuang and I are experimenting with filtering in the navigation sidebar using authored filter tags and the page's abstract. I think it would be great to agree in OSS on how these should properties should be represented in the RenderIndex and update the RenderIndex spec.

This PR just adds a `tags` property and an `abstract` property to the RenderIndex, and updates the RenderIndex spec. It does not ever use these properties and does not otherwise modify the behavior of DocC.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
