### PR TITLE
Rename "Technology" to "Tutorial Table of Contents"

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -128,8 +128,8 @@ public struct DocumentationBundle {
         self.themeSettings = themeSettings
         self.rootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: "/", sourceLanguage: .swift)
         self.documentationRootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.documentationFolder, sourceLanguage: .swift)
-        self.tutorialsRootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
-        self.technologyTutorialsRootReference = tutorialsRootReference.appendingPath(urlReadablePath(info.displayName))
+        self.tutorialTableOfContentsContainer = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
+        self.tutorialsContainerReference = tutorialTableOfContentsContainer.appendingPath(urlReadablePath(info.displayName))
         self.articlesDocumentationRootReference = documentationRootReference.appendingPath(urlReadablePath(info.displayName))
     }
     
@@ -154,12 +154,22 @@ public struct DocumentationBundle {
     /// Default path to resolve symbol links.
     public private(set) var documentationRootReference: ResolvedTopicReference
 
-    /// Default path to resolve technology links.
-    public var tutorialsRootReference: ResolvedTopicReference
+    @available(*, deprecated, renamed: "tutorialTableOfContentsContainer", message: "Use 'tutorialTableOfContentsContainer' instead. This deprecated API will be removed after 6.2 is released")
+    public var tutorialsRootReference: ResolvedTopicReference {
+        tutorialTableOfContentsContainer
+    }
 
-    /// Default path to resolve tutorials.
-    public var technologyTutorialsRootReference: ResolvedTopicReference
-    
+    /// Default path to resolve tutorial table-of-contents links.
+    public var tutorialTableOfContentsContainer: ResolvedTopicReference
+
+    @available(*, deprecated, renamed: "tutorialsContainerReference", message: "Use 'tutorialsContainerReference' instead. This deprecated API will be removed after 6.2 is released")
+    public var technologyTutorialsRootReference: ResolvedTopicReference {
+        tutorialsContainerReference
+    }
+
+    /// Default path to resolve tutorial links.
+    public var tutorialsContainerReference: ResolvedTopicReference
+
     /// Default path to resolve articles.
     public var articlesDocumentationRootReference: ResolvedTopicReference
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -13,8 +13,8 @@ extension DocumentationContext {
     struct PathOptions: OptionSet {
         let rawValue: Int
         
-        /// Prefer a technology as the canonical path over a shorter path.
-        static let preferTechnologyRoot = PathOptions(rawValue: 1 << 0)
+        /// Prefer a tutorial table-of-contents page as the canonical path over a shorter path.
+        static let preferTutorialTableOfContentsRoot = PathOptions(rawValue: 1 << 0)
     }
     
     /// Finds all finite (acyclic) paths, also called "breadcrumbs", to the given reference in the topic graph.
@@ -39,7 +39,7 @@ extension DocumentationContext {
             .map { $0.dropFirst().reversed() }
             .sorted { (lhs, rhs) -> Bool in
                 // Order a path rooted in a tutorial table-of-contents as the canonical one.
-                if options.contains(.preferTechnologyRoot), let first = lhs.first {
+                if options.contains(.preferTutorialTableOfContentsRoot), let first = lhs.first {
                     return try! entity(with: first).semantic is TutorialTableOfContents
                 }
                 

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -40,7 +40,7 @@ extension DocumentationContext {
             .sorted { (lhs, rhs) -> Bool in
                 // Order a path rooted in a technology as the canonical one.
                 if options.contains(.preferTechnologyRoot), let first = lhs.first {
-                    return try! entity(with: first).semantic is Technology
+                    return try! entity(with: first).semantic is TutorialTableOfContents
                 }
                 
                 return breadcrumbsAreInIncreasingOrder(lhs, rhs)

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext+Breadcrumbs.swift
@@ -38,7 +38,7 @@ extension DocumentationContext {
             // To match the caller's expectations we remove the starting point and then flip the paths.
             .map { $0.dropFirst().reversed() }
             .sorted { (lhs, rhs) -> Bool in
-                // Order a path rooted in a technology as the canonical one.
+                // Order a path rooted in a tutorial table-of-contents as the canonical one.
                 if options.contains(.preferTechnologyRoot), let first = lhs.first {
                     return try! entity(with: first).semantic is TutorialTableOfContents
                 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -610,7 +610,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///   - tutorials: The list of temporary 'tutorial' pages.
     ///   - tutorialArticles: The list of temporary 'tutorialArticle' pages.
     ///   - bundle: The bundle to resolve links against.
-    private func resolveLinks(technologies: [SemanticResult<Technology>],
+    private func resolveLinks(technologies: [SemanticResult<TutorialTableOfContents>],
                               tutorials: [SemanticResult<Tutorial>],
                               tutorialArticles: [SemanticResult<TutorialArticle>],
                               bundle: DocumentationBundle) {
@@ -624,7 +624,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 let url = technologyResult.source
                 let unresolvedTechnology = technologyResult.value
                 var resolver = ReferenceResolver(context: self, bundle: bundle)
-                let technology = resolver.visit(unresolvedTechnology) as! Technology
+                let technology = resolver.visit(unresolvedTechnology) as! TutorialTableOfContents
                 diagnosticEngine.emit(resolver.problems)
                 
                 // Add to document map
@@ -761,7 +761,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
     
     private func registerDocuments(from bundle: DocumentationBundle) throws -> (
-        technologies: [SemanticResult<Technology>],
+        technologies: [SemanticResult<TutorialTableOfContents>],
         tutorials: [SemanticResult<Tutorial>],
         tutorialArticles: [SemanticResult<TutorialArticle>],
         articles: [SemanticResult<Article>],
@@ -769,7 +769,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ) {
         // First, try to understand the basic structure of the document by
         // analyzing it and putting references in as "unresolved".
-        var technologies = [SemanticResult<Technology>]()
+        var technologies = [SemanticResult<TutorialTableOfContents>]()
         var tutorials = [SemanticResult<Tutorial>]()
         var tutorialArticles = [SemanticResult<TutorialArticle>]()
         var articles = [SemanticResult<Article>]()
@@ -857,7 +857,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
              Add all topic graph nodes up front before resolution starts, because
              there may be circular linking.
              */
-            if let technology = analyzed as? Technology {
+            if let technology = analyzed as? TutorialTableOfContents {
                 let topicGraphNode = TopicGraph.Node(reference: reference, kind: .technology, source: .file(url: url), title: technology.intro.title)
                 topicGraph.addNode(topicGraphNode)
                 let result = SemanticResult(value: technology, source: url, topicGraphNode: topicGraphNode)
@@ -2098,7 +2098,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         //       symbols or attempt to resolve links/references since the topic graph may not contain all documents
         //       or all symbols yet.
         var result: (
-            technologies: [SemanticResult<Technology>],
+            technologies: [SemanticResult<TutorialTableOfContents>],
             tutorials: [SemanticResult<Tutorial>],
             tutorialArticles: [SemanticResult<TutorialArticle>],
             articles: [SemanticResult<Article>],

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -611,12 +611,12 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// up in the context, not from the arrays that was passed as arguments.
     ///
     /// - Parameters:
-    ///   - tutorialTableOfContents: The list of temporary 'tutorial table-of-contents' pages.
+    ///   - tutorialTableOfContentsResults: The list of temporary 'tutorial table-of-contents' pages.
     ///   - tutorials: The list of temporary 'tutorial' pages.
     ///   - tutorialArticles: The list of temporary 'tutorialArticle' pages.
     ///   - bundle: The bundle to resolve links against.
     private func resolveLinks(
-        tutorialTableOfContents: [SemanticResult<TutorialTableOfContents>],
+        tutorialTableOfContents tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
         tutorials: [SemanticResult<Tutorial>],
         tutorialArticles: [SemanticResult<TutorialArticle>],
         bundle: DocumentationBundle
@@ -625,7 +625,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
 
         // Tutorial table-of-contents
 
-        for tableOfContentsResult in tutorialTableOfContents {
+        for tableOfContentsResult in tutorialTableOfContentsResults {
             autoreleasepool {
                 let url = tableOfContentsResult.source
                 var resolver = ReferenceResolver(context: self, bundle: bundle)
@@ -766,7 +766,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
     
     private func registerDocuments(from bundle: DocumentationBundle) throws -> (
-        tutorialTableOfContents: [SemanticResult<TutorialTableOfContents>],
+        tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
         tutorials: [SemanticResult<Tutorial>],
         tutorialArticles: [SemanticResult<TutorialArticle>],
         articles: [SemanticResult<Article>],
@@ -774,7 +774,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ) {
         // First, try to understand the basic structure of the document by
         // analyzing it and putting references in as "unresolved".
-        var tutorialTableOfContents = [SemanticResult<TutorialTableOfContents>]()
+        var tutorialTableOfContentsResults = [SemanticResult<TutorialTableOfContents>]()
         var tutorials = [SemanticResult<Tutorial>]()
         var tutorialArticles = [SemanticResult<TutorialArticle>]()
         var articles = [SemanticResult<Article>]()
@@ -866,7 +866,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 let topicGraphNode = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: url), title: tableOfContents.intro.title)
                 topicGraph.addNode(topicGraphNode)
                 let result = SemanticResult(value: tableOfContents, source: url, topicGraphNode: topicGraphNode)
-                tutorialTableOfContents.append(result)
+                tutorialTableOfContentsResults.append(result)
             } else if let tutorial = analyzed as? Tutorial {
                 let topicGraphNode = TopicGraph.Node(reference: reference, kind: .tutorial, source: .file(url: url), title: tutorial.title ?? "")
                 topicGraph.addNode(topicGraphNode)
@@ -925,7 +925,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             }
         }
         
-        return (tutorialTableOfContents, tutorials, tutorialArticles, articles, documentationExtensions)
+        return (tutorialTableOfContentsResults, tutorials, tutorialArticles, articles, documentationExtensions)
     }
     
     private func insertLandmarks(_ landmarks: some Sequence<Landmark>, from topicGraphNode: TopicGraph.Node, source url: URL) {
@@ -2103,7 +2103,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         //       symbols or attempt to resolve links/references since the topic graph may not contain all documents
         //       or all symbols yet.
         var result: (
-            tutorialTableOfContents: [SemanticResult<TutorialTableOfContents>],
+            tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
             tutorials: [SemanticResult<Tutorial>],
             tutorialArticles: [SemanticResult<TutorialArticle>],
             articles: [SemanticResult<Article>],
@@ -2142,7 +2142,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
         
         // All discovery went well, process the inputs.
-        let (tutorialTableOfContents, tutorials, tutorialArticles, allArticles, documentationExtensions) = result
+        let (tutorialTableOfContentsResults, tutorials, tutorialArticles, allArticles, documentationExtensions) = result
         var (otherArticles, rootPageArticles) = splitArticles(allArticles)
         
         let globalOptions = (allArticles + documentationExtensions).compactMap { article in
@@ -2190,7 +2190,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for article in tutorialArticles {
             hierarchyBasedResolver.addTutorialArticle(article)
         }
-        for tutorialTableOfContents in tutorialTableOfContents {
+        for tutorialTableOfContents in tutorialTableOfContentsResults {
             hierarchyBasedResolver.addTutorialTableOfContents(tutorialTableOfContents)
         }
         
@@ -2226,13 +2226,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Third, any processing that relies on resolving other content is done, mainly resolving links.
         preResolveExternalLinks(semanticObjects:
-            tutorialTableOfContents.map(referencedSemanticObject) +
+            tutorialTableOfContentsResults.map(referencedSemanticObject) +
             tutorials.map(referencedSemanticObject) +
             tutorialArticles.map(referencedSemanticObject),
             localBundleID: bundle.identifier)
         
         resolveLinks(
-            tutorialTableOfContents: tutorialTableOfContents,
+            tutorialTableOfContents: tutorialTableOfContentsResults,
             tutorials: tutorials,
             tutorialArticles: tutorialArticles,
             bundle: bundle

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -606,15 +606,16 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     /// up in the context, not from the arrays that was passed as arguments.
     ///
     /// - Parameters:
-    ///   - technologies: The list of temporary 'technology' pages.
+    ///   - TutorialTableOfContents: The list of temporary 'tutorial table-of-contents' pages.
     ///   - tutorials: The list of temporary 'tutorial' pages.
     ///   - tutorialArticles: The list of temporary 'tutorialArticle' pages.
     ///   - bundle: The bundle to resolve links against.
-    private func resolveLinks(technologies: [SemanticResult<TutorialTableOfContents>],
-                              tutorials: [SemanticResult<Tutorial>],
-                              tutorialArticles: [SemanticResult<TutorialArticle>],
-                              bundle: DocumentationBundle) {
-        
+    private func resolveLinks(
+        tutorialTableOfContents technologies: [SemanticResult<TutorialTableOfContents>],
+        tutorials: [SemanticResult<Tutorial>],
+        tutorialArticles: [SemanticResult<TutorialArticle>],
+        bundle: DocumentationBundle
+    ) {
         let sourceLanguages = soleRootModuleReference.map { self.sourceLanguages(for: $0) } ?? [.swift]
 
         // Technologies
@@ -761,7 +762,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
     
     private func registerDocuments(from bundle: DocumentationBundle) throws -> (
-        technologies: [SemanticResult<TutorialTableOfContents>],
+        tutorialTableOfContents: [SemanticResult<TutorialTableOfContents>],
         tutorials: [SemanticResult<Tutorial>],
         tutorialArticles: [SemanticResult<TutorialArticle>],
         articles: [SemanticResult<Article>],
@@ -769,7 +770,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ) {
         // First, try to understand the basic structure of the document by
         // analyzing it and putting references in as "unresolved".
-        var technologies = [SemanticResult<TutorialTableOfContents>]()
+        var tutorialTableOfContents = [SemanticResult<TutorialTableOfContents>]()
         var tutorials = [SemanticResult<Tutorial>]()
         var tutorialArticles = [SemanticResult<TutorialArticle>]()
         var articles = [SemanticResult<Article>]()
@@ -861,7 +862,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
                 let topicGraphNode = TopicGraph.Node(reference: reference, kind: .technology, source: .file(url: url), title: technology.intro.title)
                 topicGraph.addNode(topicGraphNode)
                 let result = SemanticResult(value: technology, source: url, topicGraphNode: topicGraphNode)
-                technologies.append(result)
+                tutorialTableOfContents.append(result)
             } else if let tutorial = analyzed as? Tutorial {
                 let topicGraphNode = TopicGraph.Node(reference: reference, kind: .tutorial, source: .file(url: url), title: tutorial.title ?? "")
                 topicGraph.addNode(topicGraphNode)
@@ -920,7 +921,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
             }
         }
         
-        return (technologies, tutorials, tutorialArticles, articles, documentationExtensions)
+        return (tutorialTableOfContents, tutorials, tutorialArticles, articles, documentationExtensions)
     }
     
     private func insertLandmarks(_ landmarks: some Sequence<Landmark>, from topicGraphNode: TopicGraph.Node, source url: URL) {
@@ -2098,7 +2099,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         //       symbols or attempt to resolve links/references since the topic graph may not contain all documents
         //       or all symbols yet.
         var result: (
-            technologies: [SemanticResult<TutorialTableOfContents>],
+            tutorialTableOfContents: [SemanticResult<TutorialTableOfContents>],
             tutorials: [SemanticResult<Tutorial>],
             tutorialArticles: [SemanticResult<TutorialArticle>],
             articles: [SemanticResult<Article>],
@@ -2137,7 +2138,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         }
         
         // All discovery went well, process the inputs.
-        let (technologies, tutorials, tutorialArticles, allArticles, documentationExtensions) = result
+        let (tutorialTableOfContents, tutorials, tutorialArticles, allArticles, documentationExtensions) = result
         var (otherArticles, rootPageArticles) = splitArticles(allArticles)
         
         let globalOptions = (allArticles + documentationExtensions).compactMap { article in
@@ -2185,8 +2186,8 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         for article in tutorialArticles {
             hierarchyBasedResolver.addTutorialArticle(article)
         }
-        for technology in technologies {
-            hierarchyBasedResolver.addTechnology(technology)
+        for tutorialTableOfContents in tutorialTableOfContents {
+            hierarchyBasedResolver.addTutorialTableOfContents(tutorialTableOfContents)
         }
         
         registerRootPages(from: rootPageArticles, in: bundle)
@@ -2221,13 +2222,13 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
         
         // Third, any processing that relies on resolving other content is done, mainly resolving links.
         preResolveExternalLinks(semanticObjects:
-            technologies.map(referencedSemanticObject) +
+            tutorialTableOfContents.map(referencedSemanticObject) +
             tutorials.map(referencedSemanticObject) +
             tutorialArticles.map(referencedSemanticObject),
             localBundleID: bundle.identifier)
         
         resolveLinks(
-            technologies: technologies,
+            tutorialTableOfContents: tutorialTableOfContents,
             tutorials: tutorials,
             tutorialArticles: tutorialArticles,
             bundle: bundle

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
@@ -193,9 +193,9 @@ private final class FallbackResolverBasedLinkResolver {
                 // First look up articles path
                 currentBundle.articlesDocumentationRootReference.url.appendingPathComponent(unresolvedReference.path),
                 // Then technology tutorials root path (for individual tutorial pages)
-                currentBundle.technologyTutorialsRootReference.url.appendingPathComponent(unresolvedReference.path),
+                currentBundle.tutorialsContainerReference.url.appendingPathComponent(unresolvedReference.path),
                 // Then tutorials root path (for tutorial table of contents pages)
-                currentBundle.tutorialsRootReference.url.appendingPathComponent(unresolvedReference.path),
+                currentBundle.tutorialTableOfContentsContainer.url.appendingPathComponent(unresolvedReference.path),
             ])
         }
         // Try resolving in the local context (as child)

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -419,7 +419,7 @@ struct PathHierarchy {
     /// - Parameter name: The path component name of the tutorial overview (the file name without the file extension).
     /// - Returns: The new unique identifier that represent this tutorial overview.
     mutating func addTutorialOverview(name: String) -> ResolvedIdentifier {
-        return addNonSymbolChild(parent: tutorialOverviewContainer.identifier, name: name, kind: "technology")
+        return addNonSymbolChild(parent: tutorialOverviewContainer.identifier, name: name, kind: "tutorial-toc")
     }
     
     /// Adds a non-symbol child element to an existing element in the path hierarchy.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -161,29 +161,29 @@ final class PathHierarchyBasedLinkResolver {
     func addTutorialTableOfContents(_ tutorialTableOfContents: DocumentationContext.SemanticResult<TutorialTableOfContents>) {
         let reference = tutorialTableOfContents.topicGraphNode.reference
 
-        let technologyID = pathHierarchy.addTutorialOverview(name: linkName(filename: tutorialTableOfContents.source.deletingPathExtension().lastPathComponent))
-        resolvedReferenceMap[technologyID] = reference
+        let tutorialTableOfContentsID = pathHierarchy.addTutorialOverview(name: linkName(filename: tutorialTableOfContents.source.deletingPathExtension().lastPathComponent))
+        resolvedReferenceMap[tutorialTableOfContentsID] = reference
 
         var anonymousVolumeID: ResolvedIdentifier?
         for volume in tutorialTableOfContents.value.volumes {
             if anonymousVolumeID == nil, volume.name == nil {
-                anonymousVolumeID = pathHierarchy.addNonSymbolChild(parent: technologyID, name: "$volume", kind: "volume")
+                anonymousVolumeID = pathHierarchy.addNonSymbolChild(parent: tutorialTableOfContentsID, name: "$volume", kind: "volume")
                 resolvedReferenceMap[anonymousVolumeID!] = reference.appendingPath("$volume")
             }
             
             let chapterParentID: ResolvedIdentifier
             let chapterParentReference: ResolvedTopicReference
             if let name = volume.name {
-                chapterParentID = pathHierarchy.addNonSymbolChild(parent: technologyID, name: name, kind: "volume")
+                chapterParentID = pathHierarchy.addNonSymbolChild(parent: tutorialTableOfContentsID, name: name, kind: "volume")
                 chapterParentReference = reference.appendingPath(name)
                 resolvedReferenceMap[chapterParentID] = chapterParentReference
             } else {
-                chapterParentID = technologyID
+                chapterParentID = tutorialTableOfContentsID
                 chapterParentReference = reference
             }
             
             for chapter in volume.chapters {
-                let chapterID = pathHierarchy.addNonSymbolChild(parent: technologyID, name: chapter.name, kind: "volume")
+                let chapterID = pathHierarchy.addNonSymbolChild(parent: tutorialTableOfContentsID, name: chapter.name, kind: "volume")
                 resolvedReferenceMap[chapterID] = chapterParentReference.appendingPath(chapter.name)
             }
         }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -157,15 +157,15 @@ final class PathHierarchyBasedLinkResolver {
         }
     }
     
-    /// Adds a technology and its volumes and chapters to the path hierarchy.
-    func addTechnology(_ technology: DocumentationContext.SemanticResult<TutorialTableOfContents>) {
-        let reference = technology.topicGraphNode.reference
+    /// Adds a tutorial table-of-contents page and its volumes and chapters to the path hierarchy.
+    func addTutorialTableOfContents(_ tutorialTableOfContents: DocumentationContext.SemanticResult<TutorialTableOfContents>) {
+        let reference = tutorialTableOfContents.topicGraphNode.reference
 
-        let technologyID = pathHierarchy.addTutorialOverview(name: linkName(filename: technology.source.deletingPathExtension().lastPathComponent))
+        let technologyID = pathHierarchy.addTutorialOverview(name: linkName(filename: tutorialTableOfContents.source.deletingPathExtension().lastPathComponent))
         resolvedReferenceMap[technologyID] = reference
-        
+
         var anonymousVolumeID: ResolvedIdentifier?
-        for volume in technology.value.volumes {
+        for volume in tutorialTableOfContents.value.volumes {
             if anonymousVolumeID == nil, volume.name == nil {
                 anonymousVolumeID = pathHierarchy.addNonSymbolChild(parent: technologyID, name: "$volume", kind: "volume")
                 resolvedReferenceMap[anonymousVolumeID!] = reference.appendingPath("$volume")

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -113,9 +113,9 @@ final class PathHierarchyBasedLinkResolver {
     
     /// Map the resolved identifiers to resolved topic references for a given bundle's article, tutorial, and technology root pages.
     func addMappingForRoots(bundle: DocumentationBundle) {
-        resolvedReferenceMap[pathHierarchy.tutorialContainer.identifier] = bundle.technologyTutorialsRootReference
+        resolvedReferenceMap[pathHierarchy.tutorialContainer.identifier] = bundle.tutorialsContainerReference
         resolvedReferenceMap[pathHierarchy.articlesContainer.identifier] = bundle.articlesDocumentationRootReference
-        resolvedReferenceMap[pathHierarchy.tutorialOverviewContainer.identifier] = bundle.tutorialsRootReference
+        resolvedReferenceMap[pathHierarchy.tutorialOverviewContainer.identifier] = bundle.tutorialTableOfContentsContainer
     }
     
     /// Map the resolved identifiers to resolved topic references for all symbols in the given symbol index.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -158,7 +158,7 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     /// Adds a technology and its volumes and chapters to the path hierarchy.
-    func addTechnology(_ technology: DocumentationContext.SemanticResult<Technology>) {
+    func addTechnology(_ technology: DocumentationContext.SemanticResult<TutorialTableOfContents>) {
         let reference = technology.topicGraphNode.reference
 
         let technologyID = pathHierarchy.addTutorialOverview(name: linkName(filename: technology.source.deletingPathExtension().lastPathComponent))

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -54,6 +54,8 @@ public struct NodeURLGenerator {
         case documentation(path: String)
         case documentationCuration(parentPath: String, articleName: String)
         case article(bundleName: String, articleName: String)
+        case tutorialTableOfContents(name: String)
+        @available(*, deprecated, renamed: "tutorialTableOfContents(name:)", message: "Use 'tutorialTableOfContents(name:)' instead. This deprecated API will be removed after 6.2 is released")
         case technology(technologyName: String)
         case tutorial(bundleName: String, tutorialName: String)
         
@@ -92,11 +94,12 @@ public struct NodeURLGenerator {
                         isDirectory: false
                     )
                     .path
-            case .technology(let technologyName):
-                // Format: "/tutorials/MyTechnology"
+            case .technology(let name),
+                 .tutorialTableOfContents(let name):
+                // Format: "/tutorials/Name"
                 return Self.tutorialsFolderURL
                     .appendingPathComponent(
-                        urlReadablePath(technologyName),
+                        urlReadablePath(name),
                         isDirectory: false
                     )
                     .path
@@ -122,7 +125,7 @@ public struct NodeURLGenerator {
         
         switch semantic {
         case is TutorialTableOfContents:
-            return Path.technology(technologyName: fileName).stringValue
+            return Path.tutorialTableOfContents(name: fileName).stringValue
         case is Tutorial, is TutorialArticle:
             return Path.tutorial(bundleName: bundle.displayName, tutorialName: fileName).stringValue
         case let article as Article:

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -121,7 +121,7 @@ public struct NodeURLGenerator {
         let fileName = source.deletingPathExtension().lastPathComponent
         
         switch semantic {
-        case is Technology:
+        case is TutorialTableOfContents:
             return Path.technology(technologyName: fileName).stringValue
         case is Tutorial, is TutorialArticle:
             return Path.tutorial(bundleName: bundle.displayName, tutorialName: fileName).stringValue

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -330,7 +330,7 @@ public extension DocumentationNode {
         let taskGroups: [LinkDestinationSummary.TaskGroup]?
         if includeTaskGroups {
             switch kind {
-            case .tutorial, .tutorialArticle, .technology, .technologyOverview, .chapter, .volume, .onPageLandmark:
+            case .tutorial, .tutorialArticle, .tutorialTableOfContents, .chapter, .volume, .onPageLandmark:
                 taskGroups = [.init(title: nil, identifiers: context.children(of: reference).map { $0.reference.absoluteString })]
             default:
                 var topicSectionGroups: [LinkDestinationSummary.TaskGroup] = renderNode.topicSections.map { group in .init(title: group.title, identifiers: group.identifiers) }

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -330,6 +330,7 @@ public extension DocumentationNode {
         let taskGroups: [LinkDestinationSummary.TaskGroup]?
         if includeTaskGroups {
             switch kind {
+            case ._technologyOverview: fallthrough // This case is deprecated and will be removed after 6.2 is released.
             case .tutorial, .tutorialArticle, .tutorialTableOfContents, .chapter, .volume, .onPageLandmark:
                 taskGroups = [.init(title: nil, identifiers: context.children(of: reference).map { $0.reference.absoluteString })]
             default:

--- a/Sources/SwiftDocC/Model/Kind.swift
+++ b/Sources/SwiftDocC/Model/Kind.swift
@@ -64,7 +64,7 @@ extension DocumentationNode.Kind {
     public static let article = DocumentationNode.Kind(name: "Article", id: "org.swift.docc.kind.article", isSymbol: false)
     /// A sample code project.
     public static let sampleCode = DocumentationNode.Kind(name: "Sample Code", id: "org.swift.docc.kind.sampleCode", isSymbol: false)
-    /// A volume of documentation within a technology.
+    /// A volume of documentation within a tutorial table-of-contents.
     public static let volume = DocumentationNode.Kind(name: "Volume", id: "org.swift.docc.kind.technology.volume", isSymbol: false)
     /// A chapter of documentation within a volume.
     public static let chapter = DocumentationNode.Kind(name: "Chapter", id: "org.swift.docc.kind.chapter", isSymbol: false)
@@ -85,7 +85,7 @@ extension DocumentationNode.Kind {
     public static let enumeration = DocumentationNode.Kind(name: "Enumeration", id: "org.swift.docc.kind.enumeration", isSymbol: true)
     /// Documentation about a protocol.
     public static let `protocol` = DocumentationNode.Kind(name: "Protocol", id: "org.swift.docc.kind.protocol", isSymbol: true)
-    /// Documentation about a technology.
+    /// Documentation about a tutorial table-of-contents.
     public static let tutorialTableOfContents = DocumentationNode.Kind(name: "Tutorial Table of Contents", id: "org.swift.docc.kind.technology", isSymbol: false)
     /// Documentation about an extension.
     public static let `extension` = DocumentationNode.Kind(name: "Extension", id: "org.swift.docc.kind.extension", isSymbol: true)

--- a/Sources/SwiftDocC/Model/Kind.swift
+++ b/Sources/SwiftDocC/Model/Kind.swift
@@ -225,5 +225,5 @@ extension DocumentationNode.Kind {
     
     @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
     public static var technologyOverview: Self { _technologyOverview }
-    private static let _technologyOverview = DocumentationNode.Kind(name: "Technology (Overview)", id: "org.swift.docc.kind.technology.overview", isSymbol: false)
+    static let _technologyOverview = DocumentationNode.Kind(name: "Technology (Overview)", id: "org.swift.docc.kind.technology.overview", isSymbol: false)
 }

--- a/Sources/SwiftDocC/Model/Kind.swift
+++ b/Sources/SwiftDocC/Model/Kind.swift
@@ -64,8 +64,6 @@ extension DocumentationNode.Kind {
     public static let article = DocumentationNode.Kind(name: "Article", id: "org.swift.docc.kind.article", isSymbol: false)
     /// A sample code project.
     public static let sampleCode = DocumentationNode.Kind(name: "Sample Code", id: "org.swift.docc.kind.sampleCode", isSymbol: false)
-    /// A technology overview.
-    public static let technologyOverview = DocumentationNode.Kind(name: "Technology (Overview)", id: "org.swift.docc.kind.technology.overview", isSymbol: false)
     /// A volume of documentation within a technology.
     public static let volume = DocumentationNode.Kind(name: "Volume", id: "org.swift.docc.kind.technology.volume", isSymbol: false)
     /// A chapter of documentation within a volume.
@@ -88,7 +86,7 @@ extension DocumentationNode.Kind {
     /// Documentation about a protocol.
     public static let `protocol` = DocumentationNode.Kind(name: "Protocol", id: "org.swift.docc.kind.protocol", isSymbol: true)
     /// Documentation about a technology.
-    public static let technology = DocumentationNode.Kind(name: "Technology", id: "org.swift.docc.kind.technology", isSymbol: false)
+    public static let tutorialTableOfContents = DocumentationNode.Kind(name: "Tutorial Table of Contents", id: "org.swift.docc.kind.technology", isSymbol: false)
     /// Documentation about an extension.
     public static let `extension` = DocumentationNode.Kind(name: "Extension", id: "org.swift.docc.kind.extension", isSymbol: true)
     /// Documentation about a dictionary.
@@ -192,9 +190,9 @@ extension DocumentationNode.Kind {
         // Grouping
         .landingPage, .collection, .collectionGroup,
         // Conceptual
-        .root, .module, .article, .sampleCode, .technologyOverview, .volume, .chapter, .tutorial, .tutorialArticle, .onPageLandmark,
+        .root, .module, .article, .sampleCode, .volume, .chapter, .tutorial, .tutorialArticle, .onPageLandmark,
         // Containers
-        .class, .structure, .enumeration, .protocol, .technology, .extension, .dictionary, .httpRequest, .namespace,
+        .class, .structure, .enumeration, .protocol, .tutorialTableOfContents, .extension, .dictionary, .httpRequest, .namespace,
         // Leaves
         .localVariable, .globalVariable, .typeAlias, .typeDef, .typeConstant, .associatedType, .function, .operator, .macro, .union,
         // Member-only leaves
@@ -205,6 +203,9 @@ extension DocumentationNode.Kind {
         .extendedModule, .extendedStructure, .extendedClass, .extendedEnumeration, .extendedProtocol, .unknownExtendedType,
         // Other
         .keyword, .restAPI, .tag, .propertyList, .object
+        
+        // Deprecated, to be removed after 6.2 is released.
+        , _technologyOverview,
     ]
 
     /// Returns whether this symbol kind is a synthetic "Extended Symbol" symbol kind.
@@ -216,4 +217,13 @@ extension DocumentationNode.Kind {
             return false
         }
     }
+}
+
+extension DocumentationNode.Kind {
+    @available(*, deprecated, renamed: "tutorialTableOfContents", message: "Use 'tutorialTableOfContents' This deprecated API will be removed after 6.2 is released")
+    public static var technology: Self { tutorialTableOfContents }
+    
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
+    public static var technologyOverview: Self { _technologyOverview }
+    private static let _technologyOverview = DocumentationNode.Kind(name: "Technology (Overview)", id: "org.swift.docc.kind.technology.overview", isSymbol: false)
 }

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -154,6 +154,7 @@ public class DocumentationContentRenderer {
         case .chapter: return .collectionGroup
         case .collection: return .collection
         case .collectionGroup: return .collectionGroup
+        case ._technologyOverview: fallthrough // This case is deprecated and will be removed after 6.2 is released.
         case .tutorialTableOfContents: return .overview
         case .landingPage: return .article
         case .module, .extendedModule: return .collection

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -154,7 +154,7 @@ public class DocumentationContentRenderer {
         case .chapter: return .collectionGroup
         case .collection: return .collection
         case .collectionGroup: return .collectionGroup
-        case .technology, .technologyOverview: return .overview
+        case .tutorialTableOfContents: return .overview
         case .landingPage: return .article
         case .module, .extendedModule: return .collection
         case .onPageLandmark: return .pseudoSymbol
@@ -253,7 +253,7 @@ public class DocumentationContentRenderer {
             return (.tutorial, role)
         case .tutorialArticle:
             return (.article, role)
-        case .technology:
+        case .tutorialTableOfContents:
             return (.overview, role)
         case .onPageLandmark:
             return (.section, role)

--- a/Sources/SwiftDocC/Model/Rendering/LinkTitleResolver.swift
+++ b/Sources/SwiftDocC/Model/Rendering/LinkTitleResolver.swift
@@ -36,8 +36,8 @@ struct LinkTitleResolver {
                 if let tutorial = Tutorial(from: directive, source: source, for: bundle, in: context, problems: &problems) {
                     return .init(defaultVariantValue: tutorial.intro.title)
                 }
-            case Technology.directiveName:
-                if let overview = Technology(from: directive, source: source, for: bundle, in: context, problems: &problems) {
+            case TutorialTableOfContents.directiveName:
+                if let overview = TutorialTableOfContents(from: directive, source: source, for: bundle, in: context, problems: &problems) {
                     return .init(defaultVariantValue: overview.name)
                 }
             default: break

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
@@ -40,14 +40,14 @@ struct RenderHierarchyTranslator {
         let paths = context.finitePaths(to: reference, options: [.preferTechnologyRoot])
         
         // If the node is a technology return immediately without generating breadcrumbs
-        if let _ = (try? context.entity(with: reference))?.semantic as? Technology {
+        if let _ = (try? context.entity(with: reference))?.semantic as? TutorialTableOfContents {
             let hierarchy = visitTechnology(reference, omittingChapters: omittingChapters)
             return (hierarchy: .tutorials(hierarchy), technology: reference)
         }
         
         guard let technologyPath = paths.mapFirst(where: { path -> [ResolvedTopicReference]? in
             guard let rootReference = path.first,
-                let _ = try! context.entity(with: rootReference).semantic as? Technology else { return nil }
+                let _ = try! context.entity(with: rootReference).semantic as? TutorialTableOfContents else { return nil }
             return path
         }) else {
             // If there are no tutorials, return `nil`. We've already warned about uncurated tutorials.

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
@@ -36,7 +36,7 @@ struct RenderHierarchyTranslator {
     ///   - omittingChapters: If `true`, don't include chapters in the returned hierarchy.
     /// - Returns: A tuple of 1) a tutorials hierarchy and 2) the root reference of the tutorials hierarchy.
     mutating func visitTutorialTableOfContentsNode(_ reference: ResolvedTopicReference, omittingChapters: Bool = false) -> (hierarchy: RenderHierarchy, tutorialTableOfContents: ResolvedTopicReference)? {
-        let paths = context.finitePaths(to: reference, options: [.preferTechnologyRoot])
+        let paths = context.finitePaths(to: reference, options: [.preferTutorialTableOfContentsRoot])
         
         // If the node is a tutorial table-of-contents page, return immediately without generating breadcrumbs
         if let _ = (try? context.entity(with: reference))?.semantic as? TutorialTableOfContents {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -195,7 +195,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         // We guarantee there will be at least 1 path with at least 4 nodes in that path if the tutorial is curated.
         // The way to curate tutorials is to link them from a tutorial table-of-contents page and that generates the following hierarchy:
         // table-of-contents -> volume -> chapter -> tutorial.
-        let tutorialPath = context.finitePaths(to: identifier, options: [.preferTechnologyRoot])[0]
+        let tutorialPath = context.finitePaths(to: identifier, options: [.preferTutorialTableOfContentsRoot])[0]
 
         if tutorialPath.count >= 2 {
             let volume = tutorialPath[tutorialPath.count - 2]
@@ -916,7 +916,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         // Guaranteed to have at least one path
-        let technologyPath = context.finitePaths(to: identifier, options: [.preferTechnologyRoot])[0]
+        let technologyPath = context.finitePaths(to: identifier, options: [.preferTutorialTableOfContentsRoot])[0]
                 
         node.sections.append(intro)
         

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -384,7 +384,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         node.metadata.category = technology.name
         node.metadata.categoryPathComponent = identifier.url.lastPathComponent
         node.metadata.estimatedTime = totalEstimatedDuration()
-        node.metadata.role = DocumentationContentRenderer.role(for: .technology).rawValue
+        node.metadata.role = DocumentationContentRenderer.role(for: .tutorialTableOfContents).rawValue
         
         let documentationNode = try! context.entity(with: identifier)
         node.variants = variants(for: documentationNode)

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -137,7 +137,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         var hierarchyTranslator = RenderHierarchyTranslator(context: context, bundle: bundle)
         
         if let hierarchy = hierarchyTranslator.visitTechnologyNode(identifier) {
-            let technology = try! context.entity(with: hierarchy.technology).semantic as! Technology
+            let technology = try! context.entity(with: hierarchy.technology).semantic as! TutorialTableOfContents
             node.hierarchy = hierarchy.hierarchy
             node.metadata.category = technology.name
             node.metadata.categoryPathComponent = hierarchy.technology.url.lastPathComponent
@@ -372,7 +372,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         return totalDurationMinutes.flatMap(contentRenderer.formatEstimatedDuration(minutes:))
     }
 
-    public mutating func visitTechnology(_ technology: Technology) -> RenderTree? {
+    public mutating func visitTechnology(_ technology: TutorialTableOfContents) -> RenderTree? {
         var node = RenderNode(identifier: identifier, kind: .overview)
         
         node.metadata.title = technology.intro.title
@@ -881,7 +881,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
             return nil
         }
         
-        let technology = try! context.entity(with: hierarchy.technology).semantic as! Technology
+        let technology = try! context.entity(with: hierarchy.technology).semantic as! TutorialTableOfContents
         
         node.metadata.title = article.title
         

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -377,11 +377,11 @@ public struct RenderNodeTranslator: SemanticVisitor {
         visitTutorialTableOfContents(technology)
     }
 
-    public mutating func visitTutorialTableOfContents(_ technology: TutorialTableOfContents) -> (any RenderTree)? {
+    public mutating func visitTutorialTableOfContents(_ tableOfContents: TutorialTableOfContents) -> (any RenderTree)? {
         var node = RenderNode(identifier: identifier, kind: .overview)
         
-        node.metadata.title = technology.intro.title
-        node.metadata.category = technology.name
+        node.metadata.title = tableOfContents.intro.title
+        node.metadata.category = tableOfContents.name
         node.metadata.categoryPathComponent = identifier.url.lastPathComponent
         node.metadata.estimatedTime = totalEstimatedDuration()
         node.metadata.role = DocumentationContentRenderer.role(for: .tutorialTableOfContents).rawValue
@@ -389,15 +389,15 @@ public struct RenderNodeTranslator: SemanticVisitor {
         let documentationNode = try! context.entity(with: identifier)
         node.variants = variants(for: documentationNode)
 
-        var intro = visitIntro(technology.intro) as! IntroRenderSection
+        var intro = visitIntro(tableOfContents.intro) as! IntroRenderSection
         if let firstTutorial = self.firstTutorial(ofTechnology: identifier) {
             intro.action = visitLink(firstTutorial.reference.url, defaultTitle: "Get started")
         }
         node.sections.append(intro)
                 
-        node.sections.append(contentsOf: technology.volumes.map { visitVolume($0) as! VolumeRenderSection })
+        node.sections.append(contentsOf: tableOfContents.volumes.map { visitVolume($0) as! VolumeRenderSection })
         
-        if let resources = technology.resources {
+        if let resources = tableOfContents.resources {
             node.sections.append(visitResources(resources) as! ResourcesRenderSection)
         }
         
@@ -916,7 +916,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         // Guaranteed to have at least one path
-        let technologyPath = context.finitePaths(to: identifier, options: [.preferTutorialTableOfContentsRoot])[0]
+        let tutorialPath = context.finitePaths(to: identifier, options: [.preferTutorialTableOfContentsRoot])[0]
                 
         node.sections.append(intro)
         
@@ -930,8 +930,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
             node.sections.append(visitAssessments(assessments) as! TutorialAssessmentsRenderSection)
         }
         
-        if technologyPath.count >= 2 {
-            let volume = technologyPath[technologyPath.count - 2]
+        if tutorialPath.count >= 2 {
+            let volume = tutorialPath[tutorialPath.count - 2]
             
             if let cta = callToAction(with: article.callToActionImage, volume: volume) {
                 node.sections.append(cta)

--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
@@ -109,11 +109,16 @@ struct ExternalReferenceWalker: SemanticVisitor {
     mutating func visitMarkup(_ markup: Markup) {
         visitMarkupContainer(MarkupContainer(markup))
     }
-    
+
+    @available(*, deprecated) // This is a deprecated protocol requirement
     mutating func visitTechnology(_ technology: TutorialTableOfContents) {
-        visit(technology.intro)
-        technology.volumes.forEach { visit($0) }
-        technology.resources.unwrap { visit($0) }
+        visitTutorialTableOfContents(technology)
+    }
+    
+    mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) -> Void {
+        visit(tutorialTableOfContents.intro)
+        tutorialTableOfContents.volumes.forEach { visit($0) }
+        tutorialTableOfContents.resources.unwrap { visit($0) }
     }
     
     mutating func visitImageMedia(_ imageMedia: ImageMedia) { }

--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
@@ -110,7 +110,7 @@ struct ExternalReferenceWalker: SemanticVisitor {
         visitMarkupContainer(MarkupContainer(markup))
     }
 
-    @available(*, deprecated) // This is a deprecated protocol requirement
+    @available(*, deprecated) // This is a deprecated protocol requirement. Remove after 6.2 is released
     mutating func visitTechnology(_ technology: TutorialTableOfContents) {
         visitTutorialTableOfContents(technology)
     }

--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
@@ -110,7 +110,7 @@ struct ExternalReferenceWalker: SemanticVisitor {
         visitMarkupContainer(MarkupContainer(markup))
     }
     
-    mutating func visitTechnology(_ technology: Technology) {
+    mutating func visitTechnology(_ technology: TutorialTableOfContents) {
         visit(technology.intro)
         technology.volumes.forEach { visit($0) }
         technology.resources.unwrap { visit($0) }

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -246,7 +246,7 @@ struct ReferenceResolver: SemanticVisitor {
         return (visitMarkupContainer(MarkupContainer(markup)) as! MarkupContainer).elements.first!
     }
 
-    @available(*, deprecated) // This is a deprecated protocol requirement
+    @available(*, deprecated) // This is a deprecated protocol requirement. Remove after 6.2 is released.
     mutating func visitTechnology(_ technology: TutorialTableOfContents) -> Semantic {
         visitTutorialTableOfContents(technology)
     }

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -245,12 +245,17 @@ struct ReferenceResolver: SemanticVisitor {
         // Wrap in a markup container and the first child of the result.
         return (visitMarkupContainer(MarkupContainer(markup)) as! MarkupContainer).elements.first!
     }
-    
+
+    @available(*, deprecated) // This is a deprecated protocol requirement
     mutating func visitTechnology(_ technology: TutorialTableOfContents) -> Semantic {
-        let newIntro = visit(technology.intro) as! Intro
-        let newVolumes = technology.volumes.map { visit($0) } as! [Volume]
-        let newResources = technology.resources.map { visit($0) as! Resources }
-        return TutorialTableOfContents(originalMarkup: technology.originalMarkup, name: technology.name, intro: newIntro, volumes: newVolumes, resources: newResources, redirects: technology.redirects)
+        visitTutorialTableOfContents(technology)
+    }
+
+    mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) -> Semantic {
+        let newIntro = visit(tutorialTableOfContents.intro) as! Intro
+        let newVolumes = tutorialTableOfContents.volumes.map { visit($0) } as! [Volume]
+        let newResources = tutorialTableOfContents.resources.map { visit($0) as! Resources }
+        return TutorialTableOfContents(originalMarkup: tutorialTableOfContents.originalMarkup, name: tutorialTableOfContents.name, intro: newIntro, volumes: newVolumes, resources: newResources, redirects: tutorialTableOfContents.redirects)
     }
     
     mutating func visitImageMedia(_ imageMedia: ImageMedia) -> Semantic {

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -314,7 +314,7 @@ struct ReferenceResolver: SemanticVisitor {
         // i.e. doc:/${SOME_TECHNOLOGY}/${PROJECT} or doc://${BUNDLE_ID}/${SOME_TECHNOLOGY}/${PROJECT}
         switch tutorialReference.topic {
         case .unresolved:
-            let maybeResolved = resolve(tutorialReference.topic, in: bundle.technologyTutorialsRootReference,
+            let maybeResolved = resolve(tutorialReference.topic, in: bundle.tutorialsContainerReference,
                                         range: tutorialReference.originalMarkup.range,
                                         severity: .warning)
             return TutorialReference(originalMarkup: tutorialReference.originalMarkup, tutorial: .resolved(maybeResolved))

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -246,11 +246,11 @@ struct ReferenceResolver: SemanticVisitor {
         return (visitMarkupContainer(MarkupContainer(markup)) as! MarkupContainer).elements.first!
     }
     
-    mutating func visitTechnology(_ technology: Technology) -> Semantic {
+    mutating func visitTechnology(_ technology: TutorialTableOfContents) -> Semantic {
         let newIntro = visit(technology.intro) as! Intro
         let newVolumes = technology.volumes.map { visit($0) } as! [Volume]
         let newResources = technology.resources.map { visit($0) as! Resources }
-        return Technology(originalMarkup: technology.originalMarkup, name: technology.name, intro: newIntro, volumes: newVolumes, resources: newResources, redirects: technology.redirects)
+        return TutorialTableOfContents(originalMarkup: technology.originalMarkup, name: technology.name, intro: newIntro, volumes: newVolumes, resources: newResources, redirects: technology.redirects)
     }
     
     mutating func visitImageMedia(_ imageMedia: ImageMedia) -> Semantic {

--- a/Sources/SwiftDocC/Semantics/SemanticAnalyzer.swift
+++ b/Sources/SwiftDocC/Semantics/SemanticAnalyzer.swift
@@ -43,7 +43,7 @@ struct SemanticAnalyzer: MarkupVisitor {
         
         let semanticChildren = analyzeChildren(of: document)
         let topLevelChildren = semanticChildren.filter {
-            return $0 is Technology ||
+            return $0 is TutorialTableOfContents ||
             $0 is Tutorial ||
             $0 is TutorialArticle
         }
@@ -101,8 +101,8 @@ struct SemanticAnalyzer: MarkupVisitor {
 
     mutating func visitBlockDirective(_ blockDirective: BlockDirective) -> Semantic? {
         switch blockDirective.name {
-        case Technology.directiveName:
-            return Technology(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+        case TutorialTableOfContents.directiveName:
+            return TutorialTableOfContents(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
         case Volume.directiveName:
             return Volume(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
         case Chapter.directiveName:

--- a/Sources/SwiftDocC/Semantics/Technology/TutorialTableOfContents.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/TutorialTableOfContents.swift
@@ -111,13 +111,13 @@ public final class TutorialTableOfContents: Semantic, DirectiveConvertible, Abst
             source: source,
             severity: .warning,
             range: range,
-            identifier: "org.swift.docc.Technology.IsolatedChapter",
+            identifier: "org.swift.docc.TutorialTableOfContents.IsolatedChapter",
             summary: "Chapter should be in a \(Volume.directiveName.singleQuoted); either organize all Chapters in Volumes, or place them directly under your \(TutorialTableOfContents.directiveName.singleQuoted)"
         )
     }
     
     public override func accept<V: SemanticVisitor>(_ visitor: inout V) -> V.Result {
-        return visitor.visitTechnology(self)
+        return visitor.visitTutorialTableOfContents(self)
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/TechnologyBound.swift
+++ b/Sources/SwiftDocC/Semantics/TechnologyBound.swift
@@ -9,7 +9,8 @@
 */
 
 /// An entity directly referring to the technology it belongs to.
+@available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
 public protocol TechnologyBound {
-    /// The `name` of the ``Technology`` this section refers to.
+    /// The `name` of the ``TutorialTableOfContents`` this section refers to.
     var technology: TopicReference { get }
 }

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,9 +11,7 @@
 import Foundation
 import Markdown
 
-/**
- A tutorial to complete in order to gain knowledge of a ``Technology``.
- */
+/// A tutorial to complete in order to gain knowledge of a technology.
 public final class Tutorial: Semantic, AutomaticDirectiveConvertible, Abstracted, Titled, Timed, Redirected {
     public static let introducedVersion = "5.5"
     public let originalMarkup: BlockDirective

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -149,10 +149,10 @@ extension Tutorial {
             }
         }
         
-        let technologyParent = context.parents(of: node.reference)
+        let tutorialTableOfContentsParent = context.parents(of: node.reference)
             .compactMap({ context.topicGraph.nodeWithReference($0) })
-            .first(where: { $0.kind == .technology || $0.kind == .chapter || $0.kind == .volume })
-        guard technologyParent != nil else {
+            .first(where: { $0.kind == .tutorialTableOfContents || $0.kind == .chapter || $0.kind == .volume })
+        guard tutorialTableOfContentsParent != nil else {
             engine.emit(.init(
                 diagnostic: Diagnostic(source: url, severity: .warning, range: nil, identifier: "org.swift.docc.Unreferenced\(Tutorial.self)", summary: "The tutorial \(node.reference.path.components(separatedBy: "/").last!.singleQuoted) must be referenced from a Tutorial Table of Contents"),
                 possibleSolutions: [

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -158,7 +158,7 @@ extension Tutorial {
             engine.emit(.init(
                 diagnostic: Diagnostic(source: url, severity: .warning, range: nil, identifier: "org.swift.docc.Unreferenced\(Tutorial.self)", summary: "The tutorial \(node.reference.path.components(separatedBy: "/").last!.singleQuoted) must be referenced from a Tutorial Table of Contents"),
                 possibleSolutions: [
-                    Solution(summary: "Use a \(TutorialReference.directiveName.singleQuoted) directive inside \(Technology.directiveName.singleQuoted) to reference the tutorial.", replacements: [])
+                    Solution(summary: "Use a \(TutorialReference.directiveName.singleQuoted) directive inside \(TutorialTableOfContents.directiveName.singleQuoted) to reference the tutorial.", replacements: [])
                 ]
             ))
             return

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
@@ -126,7 +126,7 @@ public final class TutorialArticle: Semantic, DirectiveConvertible, Abstracted, 
         (optionalAssessments, remainder) = Semantic.Analyses.HasAtMostOne<Tutorial, Assessments>().analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
         
         let optionalCallToActionImage: ImageMedia?
-        (optionalCallToActionImage, remainder) = Semantic.Analyses.HasExactlyOne<Technology, ImageMedia>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (optionalCallToActionImage, remainder) = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, ImageMedia>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
         
         let redirects: [Redirect]
             (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
@@ -183,7 +183,7 @@ extension TutorialArticle {
             engine.emit(.init(
                 diagnostic: Diagnostic(source: url, severity: .warning, range: nil, identifier: "org.swift.docc.Unreferenced\(TutorialArticle.self)", summary: "The article \(node.reference.path.components(separatedBy: "/").last!.singleQuoted) must be referenced from a Tutorial Table of Contents"),
                 possibleSolutions: [
-                    Solution(summary: "Use a \(TutorialReference.directiveName.singleQuoted) directive inside \(Technology.directiveName.singleQuoted) to reference the article.", replacements: [])
+                    Solution(summary: "Use a \(TutorialReference.directiveName.singleQuoted) directive inside \(TutorialTableOfContents.directiveName.singleQuoted) to reference the article.", replacements: [])
                 ]
             ))
             return

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
@@ -175,10 +175,10 @@ struct StackedContentParser {
 
 extension TutorialArticle {
     static func analyze(_ node: TopicGraph.Node, completedContext context: DocumentationContext, engine: DiagnosticEngine) {
-        let technologyParent = context.parents(of: node.reference)
+        let tutorialTableOfContentsParent = context.parents(of: node.reference)
             .compactMap({ context.topicGraph.nodeWithReference($0) })
-            .first(where: { $0.kind == .technology || $0.kind == .chapter || $0.kind == .volume })
-        guard technologyParent != nil else {
+            .first(where: { $0.kind == .tutorialTableOfContents || $0.kind == .chapter || $0.kind == .volume })
+        guard tutorialTableOfContentsParent != nil else {
             let url = context.documentURL(for: node.reference)
             engine.emit(.init(
                 diagnostic: Diagnostic(source: url, severity: .warning, range: nil, identifier: "org.swift.docc.Unreferenced\(TutorialArticle.self)", summary: "The article \(node.reference.path.components(separatedBy: "/").last!.singleQuoted) must be referenced from a Tutorial Table of Contents"),

--- a/Sources/SwiftDocC/Semantics/Visitor/SemanticVisitor.swift
+++ b/Sources/SwiftDocC/Semantics/Visitor/SemanticVisitor.swift
@@ -85,7 +85,7 @@ public protocol SemanticVisitor {
     /**
      Visit a ``Technology`` and return the result.
      */
-    mutating func visitTechnology(_ technology: Technology) -> Result
+    mutating func visitTechnology(_ technology: TutorialTableOfContents) -> Result
     
     /**
      Visit an ``ImageMedia`` and return the result.

--- a/Sources/SwiftDocC/Semantics/Visitor/SemanticVisitor.swift
+++ b/Sources/SwiftDocC/Semantics/Visitor/SemanticVisitor.swift
@@ -83,8 +83,11 @@ public protocol SemanticVisitor {
     mutating func visitMarkupContainer(_ markupContainer: MarkupContainer) -> Result
         
     /**
-     Visit a ``Technology`` and return the result.
+     Visit a ``TutorialTableOfContents`` and return the result.
      */
+    mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) -> Result
+
+    @available(*, deprecated, renamed: "visitTutorialTableOfContents(_:)", message: "Use 'visitTutorialTableOfContents(_:)' instead. This deprecated API will be removed after 6.2 is released")
     mutating func visitTechnology(_ technology: TutorialTableOfContents) -> Result
     
     /**
@@ -146,5 +149,13 @@ public protocol SemanticVisitor {
 extension SemanticVisitor {
     public mutating func visit(_ semantic: Semantic) -> Result {
         return semantic.accept(&self)
+    }
+}
+
+@available(*, deprecated)
+extension SemanticVisitor {
+    // We need to provide a default implementation to avoid the breaking change of a new protocol requirement.
+    mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) -> Result {
+        self.visitTechnology(tutorialTableOfContents)
     }
 }

--- a/Sources/SwiftDocC/Semantics/Visitor/SemanticVisitor.swift
+++ b/Sources/SwiftDocC/Semantics/Visitor/SemanticVisitor.swift
@@ -152,7 +152,7 @@ extension SemanticVisitor {
     }
 }
 
-@available(*, deprecated)
+@available(*, deprecated) // Remove this default implementation after 6.2 is released.
 extension SemanticVisitor {
     // We need to provide a default implementation to avoid the breaking change of a new protocol requirement.
     mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) -> Result {

--- a/Sources/SwiftDocC/Semantics/Walker/SemanticWalker.swift
+++ b/Sources/SwiftDocC/Semantics/Walker/SemanticWalker.swift
@@ -50,7 +50,7 @@ extension SemanticWalker {
     mutating func visitTile(_ tile: Tile) { descendIntoChildren(of: tile) }
     /// Visits a comment node.
     mutating func visitComment(_ comment: Comment) { descendIntoChildren(of: comment) }
-    @available(*, deprecated) // This is a deprecated protocol requirement
+    @available(*, deprecated) // This is a deprecated protocol requirement. Remove after 6.2 is released.
     mutating func visitTechnology(_ technology: TutorialTableOfContents) { descendIntoChildren(of: technology) }
     /// Visits a tutorials table-of-contents page.
     mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) { descendIntoChildren(of: tutorialTableOfContents) }

--- a/Sources/SwiftDocC/Semantics/Walker/SemanticWalker.swift
+++ b/Sources/SwiftDocC/Semantics/Walker/SemanticWalker.swift
@@ -51,7 +51,7 @@ extension SemanticWalker {
     /// Visits a comment node.
     mutating func visitComment(_ comment: Comment) { descendIntoChildren(of: comment) }
     /// Visits a tutorials technology.
-    mutating func visitTechnology(_ technology: Technology) { descendIntoChildren(of: technology) }
+    mutating func visitTechnology(_ technology: TutorialTableOfContents) { descendIntoChildren(of: technology) }
     /// Visits an image node.
     mutating func visitImageMedia(_ imageMedia: ImageMedia) { descendIntoChildren(of: imageMedia) }
     /// Visits a video node.

--- a/Sources/SwiftDocC/Semantics/Walker/SemanticWalker.swift
+++ b/Sources/SwiftDocC/Semantics/Walker/SemanticWalker.swift
@@ -50,8 +50,10 @@ extension SemanticWalker {
     mutating func visitTile(_ tile: Tile) { descendIntoChildren(of: tile) }
     /// Visits a comment node.
     mutating func visitComment(_ comment: Comment) { descendIntoChildren(of: comment) }
-    /// Visits a tutorials technology.
+    @available(*, deprecated) // This is a deprecated protocol requirement
     mutating func visitTechnology(_ technology: TutorialTableOfContents) { descendIntoChildren(of: technology) }
+    /// Visits a tutorials table-of-contents page.
+    mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) { descendIntoChildren(of: tutorialTableOfContents) }
     /// Visits an image node.
     mutating func visitImageMedia(_ imageMedia: ImageMedia) { descendIntoChildren(of: imageMedia) }
     /// Visits a video node.

--- a/Sources/SwiftDocC/Semantics/Walker/Walkers/SemanticTreeDumper.swift
+++ b/Sources/SwiftDocC/Semantics/Walker/Walkers/SemanticTreeDumper.swift
@@ -148,7 +148,7 @@ struct SemanticTreeDumper: SemanticWalker {
         dump(markupContainer, customDescription: description)
     }
         
-    mutating func visitTechnology(_ technology: Technology) {
+    mutating func visitTechnology(_ technology: TutorialTableOfContents) {
         dump(technology, customDescription: "name: '\(technology.name)'")
     }
     

--- a/Sources/SwiftDocC/Semantics/Walker/Walkers/SemanticTreeDumper.swift
+++ b/Sources/SwiftDocC/Semantics/Walker/Walkers/SemanticTreeDumper.swift
@@ -147,9 +147,14 @@ struct SemanticTreeDumper: SemanticWalker {
         }
         dump(markupContainer, customDescription: description)
     }
-        
+
+    @available(*, deprecated) // This is a deprecated protocol requirement
     mutating func visitTechnology(_ technology: TutorialTableOfContents) {
-        dump(technology, customDescription: "name: '\(technology.name)'")
+        visitTutorialTableOfContents(technology)
+    }
+
+    mutating func visitTutorialTableOfContents(_ tutorialTableOfContents: TutorialTableOfContents) -> () {
+        dump(tutorialTableOfContents, customDescription: "name: '\(tutorialTableOfContents.name)'")
     }
     
     mutating func visitContentAndMedia(_ contentAndMedia: ContentAndMedia) -> () {

--- a/Sources/SwiftDocC/Semantics/Walker/Walkers/SemanticTreeDumper.swift
+++ b/Sources/SwiftDocC/Semantics/Walker/Walkers/SemanticTreeDumper.swift
@@ -148,7 +148,7 @@ struct SemanticTreeDumper: SemanticWalker {
         dump(markupContainer, customDescription: description)
     }
 
-    @available(*, deprecated) // This is a deprecated protocol requirement
+    @available(*, deprecated) // This is a deprecated protocol requirement. Remove after 6.2 is released
     mutating func visitTechnology(_ technology: TutorialTableOfContents) {
         visitTutorialTableOfContents(technology)
     }

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Directives.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/Directives.md
@@ -29,9 +29,9 @@ For example ``ContentAndMedia`` requires at least one `Image` or `Video` directi
 - ``DirectiveConvertible``
 - ``TechnologyBound``
 
-### Technology Directives
+### Tutorial Table of Contents Directives
 
-- ``Technology``
+- ``TutorialTableOfContents``
 - ``Volume``
 - ``Chapter``
 - ``TutorialReference``

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
@@ -13,7 +13,7 @@ import Markdown
 extension BlockDirective {
     /// Names of directives expected to represent special types of Markdown documents.
     static let topLevelDirectiveNames: [String] = [
-        Technology.directiveName,
+        TutorialTableOfContents.directiveName,
         Tutorial.directiveName,
         TutorialArticle.directiveName,
     ]
@@ -55,7 +55,7 @@ extension BlockDirective {
         Steps.directiveName,
         SupportedLanguage.directiveName,
         TabNavigator.directiveName,
-        Technology.directiveName,
+        TutorialTableOfContents.directiveName,
         TechnologyRoot.directiveName,
         TechnologyRoot.directiveName,
         Tile.directiveName,

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -397,7 +397,7 @@ public struct ConvertAction: Action, RecreatingContext {
         // Warn the user if the catalog is a tutorial but does not contains a table of contents
         // and provide template content to fix this problem.
         if (
-            context.rootTechnologies.isEmpty &&
+            context.tutorialTableOfContentsReferences.isEmpty &&
             hasTutorial
         ) {
             let tableOfContentsFilename = CatalogTemplateKind.tutorialTopLevelFilename

--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -244,7 +244,7 @@ extension DocumentationContext {
         }
     }
     
-    /// Finds the module and technology pages in the context and returns their paths.
+    /// Finds the module and tutorial table-of-contents pages in the context and returns their paths.
     func previewPaths() throws -> [String] {
         let urlGenerator = PresentationURLGenerator(context: self, baseURL: URL(string: "/")!)
         

--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -250,7 +250,7 @@ extension DocumentationContext {
         
         let rootModules = try renderRootModules
         
-        return (rootModules + rootTechnologies).map { page in
+        return (rootModules + tutorialTableOfContentsReferences).map { page in
             urlGenerator.presentationURLForReference(page).absoluteString
         }
     }

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -6313,10 +6313,7 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A tutorial to complete in order to gain knowledge of a ``Technology``."
-          },
-          {
-            "text" : ""
+            "text" : "A tutorial to complete in order to gain knowledge of a technology."
           },
           {
             "text" : "- Parameters:"

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -91,7 +91,7 @@ let supportedDirectives: [Directive] = [
 
     .init(
         name: "Tutorials",
-        implementationName: "Technology",
+        implementationName: "TutorialTableOfContents",
         introducedVersion: "5.5",
         isLeaf: false
     ),

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4230,7 +4230,7 @@ let expected = """
             let expected = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
 
             // Resolve from various locations in the bundle
-            for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialsRootReference] {
+            for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialTableOfContentsContainer] {
                 switch context.resolve(unresolved, in: parent) {
                     case .success(let reference):
                         if reference.path != expected.path {
@@ -4272,7 +4272,7 @@ let expected = """
             
 
             // Resolve from various locations in the bundle
-            for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialsRootReference, symbolReference] {
+            for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialTableOfContentsContainer, symbolReference] {
                 switch context.resolve(unresolved, in: parent) {
                     case .success(let reference):
                         if reference.path != expected.path {

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -106,7 +106,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         externalResolver.bundleIdentifier = "com.test.external"
         externalResolver.expectedReferencePath = "/path/to/external/api"
         externalResolver.resolvedEntityTitle = "Name of API"
-        externalResolver.resolvedEntityKind = .technology
+        externalResolver.resolvedEntityKind = .tutorialTableOfContents
         
         // Set the language of the externally resolved entity to 'data'.
         externalResolver.resolvedEntityLanguage = .data

--- a/Tests/SwiftDocCTests/Infrastructure/TopicGraphTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TopicGraphTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,7 +17,7 @@ class TopicGraphTests: XCTestCase {
         static func testNodeWithTitle(_ title: String) -> TopicGraph.Node {
             let urlSafeTitle = title.replacingOccurrences(of: " ", with: "_")
             let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(urlSafeTitle)", sourceLanguage: .swift)
-            return TopicGraph.Node(reference: reference, kind: .technology, source: .file(url: URL(fileURLWithPath: "/path/to/\(urlSafeTitle)")), title: title)
+            return TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(urlSafeTitle)")), title: title)
         }
         
         /// Return a graph with one node A

--- a/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
@@ -17,7 +17,7 @@ class RenderHierarchyTranslatorTests: XCTestCase {
         let technologyReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift)
         
         var translator = RenderHierarchyTranslator(context: context, bundle: bundle)
-        let renderHierarchy = translator.visitTechnologyNode(technologyReference)?.hierarchy
+        let renderHierarchy = translator.visitTutorialTableOfContentsNode(technologyReference)?.hierarchy
 
         // Verify that the hierarchy translator has collected all topic references from the hierarchy
         XCTAssertEqual(translator.collectedTopicReferences.sorted(by: { $0.absoluteString <= $1.absoluteString }).map{ $0.absoluteString }, [

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -572,13 +572,13 @@ class SemaToRenderNodeTests: XCTestCase {
     private func assertCompileOverviewWithNoVolumes(bundle: DocumentationBundle, context: DocumentationContext, expectedProblemsCount: Int = 0) throws {
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
-        guard let technologyDirective = node.markup as? BlockDirective else {
+        guard let tutorialTableOfContentsDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
             return
         }
         
         var problems = [Problem]()
-        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -588,7 +588,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
-        let renderNode = translator.visit(technology) as! RenderNode
+        let renderNode = translator.visit(tutorialTableOfContents) as! RenderNode
         
         XCTAssertEqual(renderNode.variants?.flatMap(\.traits), [.interfaceLanguage("swift")])
         
@@ -809,13 +809,13 @@ class SemaToRenderNodeTests: XCTestCase {
     
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
-        guard let technologyDirective = node.markup as? BlockDirective else {
-            XCTFail("Unexpected document structure, tutorial not found as first child.")
+        guard let tutorialTableOfContentsDirective = node.markup as? BlockDirective else {
+            XCTFail("Unexpected document structure, tutorial table-of-contents not found as first child.")
             return
         }
         
         var problems = [Problem]()
-        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -824,7 +824,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
-        let renderNode = translator.visit(technology) as! RenderNode
+        let renderNode = translator.visit(tutorialTableOfContents) as! RenderNode
 
         XCTAssertEqual(renderNode.sections.count, 4, "Unexpected section count")
         
@@ -2442,13 +2442,13 @@ Document
         
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
-        guard let technologyDirective = node.markup as? BlockDirective else {
-            XCTFail("Unexpected document structure, technology not found as first child.")
+        guard let tutorialTableOfContentsDirective = node.markup as? BlockDirective else {
+            XCTFail("Unexpected document structure, tutorial table-of-contents not found as first child.")
             return
         }
         
         var problems = [Problem]()
-        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -2458,7 +2458,7 @@ Document
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         // Verify we don't crash.
-        _ = translator.visit(technology)
+        _ = translator.visit(tutorialTableOfContents)
         
         do {
             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
@@ -3185,12 +3185,12 @@ Document
             return
         }
         var problems = [Problem]()
-        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create technology from markup: \(problems)")
             return
         }
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
-        let renderNode = try XCTUnwrap(translator.visit(technology) as? RenderNode)
+        let renderNode = try XCTUnwrap(translator.visit(tutorialTableOfContents) as? RenderNode)
         XCTAssertEqual(renderNode.references.count, 5)
         XCTAssertNotNil(renderNode.references["doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial"] as? TopicRenderReference)
         XCTAssertNotNil(renderNode.references["doc://org.swift.docc.example/tutorials/TestOverview"] as? TopicRenderReference)

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -578,7 +578,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let technology = Technology(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -815,7 +815,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let technology = Technology(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -2283,7 +2283,7 @@ Document
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
-        let symbol = node.semantic as! Technology
+        let symbol = node.semantic as! TutorialTableOfContents
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         let renderNode = translator.visit(symbol) as! RenderNode
@@ -2448,7 +2448,7 @@ Document
         }
         
         var problems = [Problem]()
-        guard let technology = Technology(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -3185,7 +3185,7 @@ Document
             return
         }
         var problems = [Problem]()
-        guard let technology = Technology(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let technology = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
             XCTFail("Couldn't create technology from markup: \(problems)")
             return
         }

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -70,7 +70,7 @@ class RenderMetadataTests: XCTestCase {
     }
 
     func testAllPagesHaveTitleMetadata() throws {
-        var typesOfPages = [Tutorial.self, Technology.self, Article.self, TutorialArticle.self, Symbol.self]
+        var typesOfPages = [Tutorial.self, TutorialTableOfContents.self, Article.self, TutorialArticle.self, Symbol.self]
         
         for bundleName in ["TestBundle"] {
             let (bundle, context) = try testBundleAndContext(named: bundleName)

--- a/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
@@ -109,8 +109,8 @@ class RedirectedTests: XCTestCase {
         let directive = document.child(at: 0)! as! BlockDirective
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         var problems = [Problem]()
-        let technology = TutorialTableOfContents(from: directive, source: nil, for: bundle, in: context, problems: &problems)
-        XCTAssertNotNil(technology, "A Technology value can be created with a Redirected child.")
+        let tutorialTableOfContents = TutorialTableOfContents(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        XCTAssertNotNil(tutorialTableOfContents, "A tutorial table-of-contents value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
         var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)

--- a/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
@@ -109,7 +109,7 @@ class RedirectedTests: XCTestCase {
         let directive = document.child(at: 0)! as! BlockDirective
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         var problems = [Problem]()
-        let technology = Technology(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let technology = TutorialTableOfContents(from: directive, source: nil, for: bundle, in: context, problems: &problems)
         XCTAssertNotNil(technology, "A Technology value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         

--- a/Tests/SwiftDocCTests/Semantics/TechnologyTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TechnologyTests.swift
@@ -21,7 +21,7 @@ class TechnologyTests: XCTestCase {
         let directive = document.child(at: 0)! as! BlockDirective
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         var problems = [Problem]()
-        let technology = Technology(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let technology = TutorialTableOfContents(from: directive, source: nil, for: bundle, in: context, problems: &problems)
         XCTAssertNil(technology)
         XCTAssertEqual(
             problems.map { $0.diagnostic.identifier },

--- a/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -396,7 +396,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
     func testAnalyzeNode() throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
-        let node = TopicGraph.Node(reference: reference, kind: .technology, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
+        let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
         context.topicGraph.addNode(node)
@@ -415,7 +415,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
     func testAnalyzeExternalNode() throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
-        let node = TopicGraph.Node(reference: reference, kind: .technology, source: .external, title: title)
+        let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .external, title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
         context.topicGraph.addNode(node)
@@ -435,7 +435,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
         let url = URL(fileURLWithPath: "/path/to/\(title)")
         let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
-        let node = TopicGraph.Node(reference: reference, kind: .technology, source: .range(range, url: url) , title: title)
+        let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .range(range, url: url) , title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
         context.topicGraph.addNode(node)
@@ -463,7 +463,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
 
         let tutorialArticleNode = node(withTitle: "tutorial-article", ofKind: .tutorialArticle)
 
-        let validParents: Set<DocumentationNode.Kind> = [.chapter, .technology, .volume]
+        let validParents: Set<DocumentationNode.Kind> = [.chapter, .tutorialTableOfContents, .volume]
         let otherKinds: Set<DocumentationNode.Kind> = Set(DocumentationNode.Kind.allKnownValues).subtracting(validParents)
 
         for kind in validParents {

--- a/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
@@ -450,7 +450,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
         XCTAssertNil(problem.diagnostic.source)
     }
 
-    /// Verify that a `TutorialArticle` only recognizes chapter, volume, or technology nodes as valid parents.
+    /// Verify that a `TutorialArticle` only recognizes chapter, volume, or tutorial table-of-contents nodes as valid parents.
     func testAnalyzeForValidParent() throws {
         func node(withTitle title: String, ofKind kind: DocumentationNode.Kind) -> TopicGraph.Node {
             let url = URL(fileURLWithPath: "/path/to/\(title)")

--- a/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -371,7 +371,7 @@ Tutorial @1:1-150:2 projectFiles: nil
     func testAnalyzeNode() throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
-        let node = TopicGraph.Node(reference: reference, kind: .technology, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
+        let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
         context.topicGraph.addNode(node)
@@ -390,7 +390,7 @@ Tutorial @1:1-150:2 projectFiles: nil
     func testAnalyzeExternalNode() throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
-        let node = TopicGraph.Node(reference: reference, kind: .technology, source: .external, title: title)
+        let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .external, title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
         context.topicGraph.addNode(node)
@@ -410,7 +410,7 @@ Tutorial @1:1-150:2 projectFiles: nil
         let url = URL(fileURLWithPath: "/path/to/\(title)")
         let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
-        let node = TopicGraph.Node(reference: reference, kind: .technology, source: .range(range, url: url) , title: title)
+        let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .range(range, url: url) , title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
         context.topicGraph.addNode(node)
@@ -438,7 +438,7 @@ Tutorial @1:1-150:2 projectFiles: nil
 
         let tutorialNode = node(withTitle: "tutorial-article", ofKind: .tutorial)
 
-        let validParents: Set<DocumentationNode.Kind> = [.chapter, .technology, .volume]
+        let validParents: Set<DocumentationNode.Kind> = [.chapter, .tutorialTableOfContents, .volume]
         let otherKinds: Set<DocumentationNode.Kind> = Set(DocumentationNode.Kind.allKnownValues).subtracting(validParents)
 
         for kind in validParents {

--- a/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
@@ -425,7 +425,7 @@ Tutorial @1:1-150:2 projectFiles: nil
         XCTAssertNil(problem.diagnostic.source)
     }
 
-    /// Verify that a `Tutorial` only recognizes chapter, volume, or technology nodes as valid parents.
+    /// Verify that a `Tutorial` only recognizes chapter, volume, or tutorial table-of-contents nodes as valid parents.
     func testAnalyzeForValidParent() throws {
         func node(withTitle title: String, ofKind kind: DocumentationNode.Kind) -> TopicGraph.Node {
             let url = URL(fileURLWithPath: "/path/to/\(title)")

--- a/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
@@ -106,7 +106,7 @@ class VolumeTests: XCTestCase {
                 path: "/tutorials/TestOverview",
                 sourceLanguage: .swift))
 
-        let tutorial = try XCTUnwrap(node.semantic as? Technology)
+        let tutorial = try XCTUnwrap(node.semantic as? TutorialTableOfContents)
 
         let volume = tutorial.volumes.first
         XCTAssertNotNil(volume)

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1412,7 +1412,7 @@ class ConvertActionTests: XCTestCase {
             case "/tutorials/TechnologyX":
                 return [
                     LinkDestinationSummary(
-                        kind: .technology,
+                        kind: .tutorialTableOfContents,
                         relativePresentationURL: URL(string: "/tutorials/technologyx")!,
                         referenceURL: reference.url,
                         title: "Technology X",


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This renames `Technology` to `TutorialTableOfContents` so that the symbol names in the code matches the user-facing terminology. This makes it slightly easier to understand what type of pages this code is related to.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
