### PR TITLE
Deprecate `DocumentationBundle.Info.version`

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -63,6 +63,7 @@ public struct DocumentationBundle {
 
      It's not safe to make computations based on assumptions about the format of bundle's version. The version can be in any format.
      */
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
     public var version: String? {
         info.version
     }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -22,6 +22,7 @@ extension DocumentationBundle {
         public var identifier: String
         
         /// The version of the bundle.
+        @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
         public var version: String?
         
         /// The default language identifier for code listings in the bundle.
@@ -42,7 +43,6 @@ extension DocumentationBundle {
         enum CodingKeys: String, CodingKey, CaseIterable {
             case displayName = "CFBundleDisplayName"
             case identifier = "CFBundleIdentifier"
-            case version = "CFBundleVersion"
             case defaultCodeListingLanguage = "CDDefaultCodeListingLanguage"
             case defaultAvailability = "CDAppleDefaultAvailability"
             case defaultModuleKind = "CDDefaultModuleKind"
@@ -54,8 +54,6 @@ extension DocumentationBundle {
                     return "--fallback-display-name"
                 case .identifier:
                     return "--fallback-bundle-identifier"
-                case .version:
-                    return "--fallback-bundle-version"
                 case .defaultCodeListingLanguage:
                     return "--default-code-listing-language"
                 case .defaultModuleKind:
@@ -82,26 +80,22 @@ extension DocumentationBundle {
             }
         }
         
-        
         /// Creates a new documentation bundle information value.
         /// - Parameters:
         ///   - displayName: The display name of the bundle.
         ///   - identifier:  The unique identifier of the bundle.
-        ///   - version: The version of the bundle.
         ///   - defaultCodeListingLanguage: The default language identifier for code listings in the bundle.
         ///   - defaultAvailability: The default availability for the various modules in the bundle.
         ///   - defaultModuleKind: The default kind for the various modules in the bundle.
         public init(
             displayName: String,
             identifier: String,
-            version: String?,
             defaultCodeListingLanguage: String?,
             defaultAvailability: DefaultAvailability?,
             defaultModuleKind: String?
         ) {
             self.displayName = displayName
             self.identifier = identifier
-            self.version = version
             self.defaultCodeListingLanguage = defaultCodeListingLanguage
             self.defaultAvailability = defaultAvailability
             self.defaultModuleKind = defaultModuleKind
@@ -228,7 +222,6 @@ extension DocumentationBundle {
             // contain a display name. If they do but that value fails to decode, that error would be raised before accessing `derivedDisplayName`.
             self.displayName = try decodeOrFallbackIfPresent(String.self, with: .displayName) ?? derivedDisplayName!
             self.identifier = try decodeOrFallbackIfPresent(String.self, with: .identifier) ?? self.displayName
-            self.version = try decodeOrFallbackIfPresent(String.self, with: .version)
             
             // Finally, decode the optional keys if they're present.
             
@@ -237,11 +230,10 @@ extension DocumentationBundle {
             self.defaultAvailability = try decodeOrFallbackIfPresent(DefaultAvailability.self, with: .defaultAvailability)
             self.featureFlags = try decodeOrFallbackIfPresent(BundleFeatureFlags.self, with: .featureFlags)
         }
-        
+
         init(
             displayName: String,
             identifier: String,
-            version: String? = nil,
             defaultCodeListingLanguage: String? = nil,
             defaultModuleKind: String? = nil,
             defaultAvailability: DefaultAvailability? = nil,
@@ -249,7 +241,6 @@ extension DocumentationBundle {
         ) {
             self.displayName = displayName
             self.identifier = identifier
-            self.version = version
             self.defaultCodeListingLanguage = defaultCodeListingLanguage
             self.defaultModuleKind = defaultModuleKind
             self.defaultAvailability = defaultAvailability
@@ -267,7 +258,6 @@ extension BundleDiscoveryOptions {
     /// - Parameters:
     ///   - fallbackDisplayName: A fallback display name for the bundle.
     ///   - fallbackIdentifier: A fallback identifier for the bundle.
-    ///   - fallbackVersion: A fallback version for the bundle.
     ///   - fallbackDefaultCodeListingLanguage: A fallback default code listing language for the bundle.
     ///   - fallbackDefaultModuleKind: A fallback default module kind for the bundle.
     ///   - fallbackDefaultAvailability: A fallback default availability for the bundle.
@@ -275,7 +265,6 @@ extension BundleDiscoveryOptions {
     public init(
         fallbackDisplayName: String? = nil,
         fallbackIdentifier: String? = nil,
-        fallbackVersion: String? = nil,
         fallbackDefaultCodeListingLanguage: String? = nil,
         fallbackDefaultModuleKind: String? = nil,
         fallbackDefaultAvailability: DefaultAvailability? = nil,
@@ -294,8 +283,6 @@ extension BundleDiscoveryOptions {
                 value = fallbackDisplayName
             case .identifier:
                 value = fallbackIdentifier
-            case .version:
-                value = fallbackVersion
             case .defaultCodeListingLanguage:
                 value = fallbackDefaultCodeListingLanguage
             case .defaultAvailability:
@@ -318,6 +305,26 @@ extension BundleDiscoveryOptions {
             additionalSymbolGraphFiles: additionalSymbolGraphFiles
         )
     }
+
+    @available(*, deprecated, renamed: "init(fallbackDisplayName:fallbackIdentifier:fallbackDefaultCodeListingLanguage:fallbackDefaultModuleKind:fallbackDefaultAvailability:additionalSymbolGraphFiles:)", message: "Use 'init(fallbackDisplayName:fallbackIdentifier:fallbackDefaultCodeListingLanguage:fallbackDefaultModuleKind:fallbackDefaultAvailability:additionalSymbolGraphFiles:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(
+        fallbackDisplayName: String? = nil,
+        fallbackIdentifier: String? = nil,
+        fallbackVersion: String?,
+        fallbackDefaultCodeListingLanguage: String? = nil,
+        fallbackDefaultModuleKind: String? = nil,
+        fallbackDefaultAvailability: DefaultAvailability? = nil,
+        additionalSymbolGraphFiles: [URL] = []
+    ) {
+        self.init(
+            fallbackDisplayName: fallbackDisplayName,
+            fallbackIdentifier: fallbackIdentifier,
+            fallbackDefaultCodeListingLanguage: fallbackDefaultCodeListingLanguage,
+            fallbackDefaultModuleKind: fallbackDefaultModuleKind,
+            fallbackDefaultAvailability: fallbackDefaultAvailability,
+            additionalSymbolGraphFiles:additionalSymbolGraphFiles
+        )
+    }
 }
 
 private extension CodingUserInfoKey {
@@ -325,4 +332,24 @@ private extension CodingUserInfoKey {
     static let bundleDiscoveryOptions = CodingUserInfoKey(rawValue: "bundleDiscoveryOptions")!
     /// A user info key to store derived display name in the decoder.
     static let derivedDisplayName = CodingUserInfoKey(rawValue: "derivedDisplayName")!
+}
+
+extension DocumentationBundle.Info {
+    @available(*, deprecated, renamed: "init(displayName:identifier:defaultCodeListingLanguage:defaultAvailability:defaultModuleKind:)", message: "Use 'init(displayName:identifier:defaultCodeListingLanguage:defaultAvailability:defaultModuleKind:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(
+        displayName: String,
+        identifier: String,
+        version: String?,
+        defaultCodeListingLanguage: String?,
+        defaultAvailability: DefaultAvailability?,
+        defaultModuleKind: String?
+    ) {
+        self.init(
+            displayName: displayName,
+            identifier: identifier,
+            defaultCodeListingLanguage: defaultCodeListingLanguage,
+            defaultAvailability: defaultAvailability,
+            defaultModuleKind: defaultModuleKind
+        )
+    }
 }

--- a/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
+++ b/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
@@ -94,29 +94,25 @@ public struct InfoPlist: File, DataRepresentable {
     /// The information that the Into.plist file contains.
     public let content: Content
 
-    public init(displayName: String? = nil, identifier: String? = nil, versionString: String = "1.0") {
+    public init(displayName: String? = nil, identifier: String? = nil) {
         self.content = Content(
             displayName: displayName,
-            identifier: identifier,
-            versionString: versionString
+            identifier: identifier
         )
     }
 
     public struct Content: Codable, Equatable {
         public let displayName: String?
         public let identifier: String?
-        public let versionString: String?
 
-        fileprivate init(displayName: String?, identifier: String?, versionString: String) {
+        fileprivate init(displayName: String?, identifier: String?) {
             self.displayName = displayName
             self.identifier = identifier
-            self.versionString = versionString
         }
 
         enum CodingKeys: String, CodingKey {
             case displayName = "CFBundleDisplayName"
             case identifier = "CFBundleIdentifier"
-            case versionString = "CFBundleVersion"
         }
     }
 
@@ -127,7 +123,6 @@ public struct InfoPlist: File, DataRepresentable {
         return try encoder.encode([
             Content.CodingKeys.displayName.rawValue: content.displayName,
             Content.CodingKeys.identifier.rawValue: content.identifier,
-            Content.CodingKeys.versionString.rawValue: content.versionString,
         ])
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -49,7 +49,6 @@ extension ConvertAction {
         let bundleDiscoveryOptions = BundleDiscoveryOptions(
             fallbackDisplayName: convert.fallbackBundleDisplayName,
             fallbackIdentifier: convert.fallbackBundleIdentifier,
-            fallbackVersion: nil,
             fallbackDefaultCodeListingLanguage: convert.defaultCodeListingLanguage,
             fallbackDefaultModuleKind: convert.fallbackDefaultModuleKind,
             additionalSymbolGraphFiles: additionalSymbolGraphFiles

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -17,8 +17,7 @@ import SwiftDocCTestUtilities
 class ConvertServiceTests: XCTestCase {
     private let testBundleInfo = DocumentationBundle.Info(
         displayName: "TestBundle",
-        identifier: "identifier",
-        version: "1.0.0"
+        identifier: "identifier"
     )
     
     func testConvertSinglePage() throws {
@@ -1731,8 +1730,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
-                identifier: "com.test.bundle",
-                version: "1.0.0"
+                identifier: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
@@ -2021,8 +2019,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
-                identifier: "org.swift.example",
-                version: "1.0.0"
+                identifier: "org.swift.example"
             ),
             externalIDsToConvert: ["s:32MyKit3FooV"],
             documentPathsToConvert: [],
@@ -2131,8 +2128,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
-                identifier: "com.test.bundle",
-                version: "1.0.0"
+                identifier: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework40EnumerationWithSingleUnresolvableDocLinkO"],
             documentPathsToConvert: [],
@@ -2170,8 +2166,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
-                identifier: "com.test.bundle",
-                version: "1.0.0"
+                identifier: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework15TestEnumerationO06NesteddE0O0D6StructV06deeplyfD31FunctionWithUnresolvableDocLinkyyF"],
             documentPathsToConvert: [],
@@ -2210,8 +2205,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
-                identifier: "com.test.bundle",
-                version: "1.0.0"
+                identifier: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework43EnumerationWithSingleUnresolvableSymbolLinkO"],
             documentPathsToConvert: [],

--- a/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -68,8 +68,7 @@ class DocumentationServer_DefaultTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
-                identifier: "identifier",
-                version: "1.0.0"
+                identifier: "identifier"
             ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             symbolGraphs: [symbolGraph],

--- a/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -256,8 +256,7 @@ class BundleDiscoveryTests: XCTestCase {
         let bundleDiscoveryOptions = BundleDiscoveryOptions(
             infoPlistFallbacks: [
                 "CFBundleDisplayName": "Fallback Display Name",
-                "CFBundleIdentifier": "com.fallback.bundle.identifier",
-                "CFBundleVersion": "1.2.3",
+                "CFBundleIdentifier": "com.fallback.bundle.identifier"
             ],
             additionalSymbolGraphFiles: []
         )
@@ -269,7 +268,6 @@ class BundleDiscoveryTests: XCTestCase {
         // The bundle information was specified via the options
         XCTAssertEqual(bundle.identifier, "com.fallback.bundle.identifier")
         XCTAssertEqual(bundle.displayName, "Fallback Display Name")
-        XCTAssertEqual(bundle.version, "1.2.3")
     }
 
     func testNoCustomTemplates() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -23,7 +23,6 @@ class DocumentationBundleInfoTests: XCTestCase {
         
         XCTAssertEqual(info.displayName, "Test Bundle")
         XCTAssertEqual(info.identifier, "org.swift.docc.example")
-        XCTAssertEqual(info.version, "0.1.0")
         XCTAssertEqual(info.defaultCodeListingLanguage, "swift")
     }
 
@@ -52,8 +51,6 @@ class DocumentationBundleInfoTests: XCTestCase {
             <string>Info Plist Display Name</string>
             <key>CFBundleIdentifier</key>
             <string>com.info.Plist</string>
-            <key>CFBundleVersion</key>
-            <string>1.0.0</string>
         </dict>
         </plist>
         """
@@ -65,8 +62,6 @@ class DocumentationBundleInfoTests: XCTestCase {
         <dict>
             <key>CFBundleIdentifier</key>
             <string>com.info.Plist</string>
-            <key>CFBundleVersion</key>
-            <string>1.0.0</string>
         </dict>
         </plist>
         """
@@ -76,8 +71,7 @@ class DocumentationBundleInfoTests: XCTestCase {
         let bundleDiscoveryOptions = BundleDiscoveryOptions(
             infoPlistFallbacks: [
                 "CFBundleDisplayName": "Fallback Display Name",
-                "CFBundleIdentifier": "com.fallback.Identifier",
-                "CFBundleVersion": "2.0.0",
+                "CFBundleIdentifier": "com.fallback.Identifier"
             ]
         )
         
@@ -88,8 +82,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Info Plist Display Name",
-                identifier: "com.info.Plist",
-                version: "1.0.0"
+                identifier: "com.info.Plist"
             )
         )
         
@@ -100,8 +93,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Fallback Display Name",
-                identifier: "com.fallback.Identifier",
-                version: "2.0.0"
+                identifier: "com.fallback.Identifier"
             )
         )
         
@@ -112,8 +104,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Fallback Display Name",
-                identifier: "com.info.Plist",
-                version: "1.0.0"
+                identifier: "com.info.Plist"
             )
         )
         
@@ -137,8 +128,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Info Plist Display Name",
-                identifier: "com.info.Plist",
-                version: nil
+                identifier: "com.info.Plist"
             )
         )
     }
@@ -199,8 +189,6 @@ class DocumentationBundleInfoTests: XCTestCase {
             <string>ShapeKit</string>
             <key>CFBundleIdentifier</key>
             <string>com.shapes.ShapeKit</string>
-            <key>CFBundleVersion</key>
-            <string>0.1.0</string>
         </dict>
         </plist>
         
@@ -230,7 +218,6 @@ class DocumentationBundleInfoTests: XCTestCase {
         let bundleDiscoveryOptions = BundleDiscoveryOptions(
             fallbackDisplayName: "Display Name",
             fallbackIdentifier: "swift.org.Identifier",
-            fallbackVersion: "1.0.0",
             fallbackDefaultCodeListingLanguage: "swift",
             fallbackDefaultModuleKind: "Executable",
             fallbackDefaultAvailability: DefaultAvailability(
@@ -251,7 +238,6 @@ class DocumentationBundleInfoTests: XCTestCase {
             DocumentationBundle.Info(
                 displayName: "Display Name",
                 identifier: "swift.org.Identifier",
-                version: "1.0.0",
                 defaultCodeListingLanguage: "swift",
                 defaultModuleKind: "Executable",
                 defaultAvailability: DefaultAvailability(
@@ -272,7 +258,6 @@ class DocumentationBundleInfoTests: XCTestCase {
         let info = DocumentationBundle.Info(
             displayName: "Display Name",
             identifier: "swift.org.Identifier",
-            version: "1.0.0",
             defaultCodeListingLanguage: "swift",
             defaultModuleKind: "Executable",
             defaultAvailability: DefaultAvailability(
@@ -316,8 +301,6 @@ class DocumentationBundleInfoTests: XCTestCase {
           <string>DOCS</string>
           <key>CFBundleShortVersionString</key>
           <string>0.1.0</string>
-          <key>CFBundleVersion</key>
-          <string>0.1.0</string>
           <key>CDAppleDefaultAvailability</key>
         </dict>
         </plist>
@@ -358,8 +341,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Derived Display Name",
-                identifier: "Derived Display Name",
-                version: nil
+                identifier: "Derived Display Name"
             )
         )
     }
@@ -384,8 +366,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Derived Display Name",
-                identifier: "org.swift.docc.example",
-                version: nil
+                identifier: "org.swift.docc.example"
             )
         )
     }
@@ -409,8 +390,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Example",
-                identifier: "Example",
-                version: nil
+                identifier: "Example"
             )
         )
     }
@@ -423,8 +403,6 @@ class DocumentationBundleInfoTests: XCTestCase {
             <string>Info Plist Display Name</string>
             <key>CFBundleIdentifier</key>
             <string>com.info.Plist</string>
-            <key>CFBundleVersion</key>
-            <string>1.0.0</string>
             <key>CDExperimentalFeatureFlags</key>
             <dict>
                 <key>ExperimentalOverloadedSymbolPresentation</key>

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -148,8 +148,7 @@ class DocumentationWorkspaceTests: XCTestCase {
             return DocumentationBundle(
                 info: DocumentationBundle.Info(
                     displayName: "Test" + suffix,
-                    identifier: "com.example.test" + suffix,
-                    version: "0.1.0"
+                    identifier: "com.example.test" + suffix
                 ),
                 symbolGraphURLs: [testSymbolGraphFile],
                 markupURLs: [testMarkupFile],

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -496,8 +496,6 @@ class SymbolGraphLoaderTests: XCTestCase {
             <string>MyModule</string>
             <key>CFBundleIdentifier</key>
             <string>com.apple.MyModule</string>
-            <key>CFBundleVersion</key>
-            <string>0.1.0</string>
             <key>CDAppleDefaultAvailability</key>
             <dict>
                 <key>MyModule</key>
@@ -1664,8 +1662,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let bundle = DocumentationBundle(
             info: DocumentationBundle.Info(
                 displayName: "Test",
-                identifier: "com.example.test",
-                version: "1.2.3"
+                identifier: "com.example.test"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: symbolGraphURLs,

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -399,8 +399,6 @@ class DefaultAvailabilityTests: XCTestCase {
                 <string>MyModule</string>
                 <key>CFBundleIdentifier</key>
                 <string>com.apple.MyModule</string>
-                <key>CFBundleVersion</key>
-                <string>0.1.0</string>
                 <key>CDAppleDefaultAvailability</key>
                 <dict>
                     <key>MyModule</key>

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -43,7 +43,6 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
             info: DocumentationBundle.Info(
                 displayName: testBundleWithLanguageDefault.displayName,
                 identifier: testBundleWithLanguageDefault.identifier,
-                version: testBundleWithLanguageDefault.version,
                 defaultCodeListingLanguage: nil
             ),
             baseURL: testBundleWithLanguageDefault.baseURL,

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -144,8 +144,7 @@ private extension DocumentationContentRendererTests {
             bundle: DocumentationBundle(
                 info: DocumentationBundle.Info(
                     displayName: "Test",
-                    identifier: "org.swift.test",
-                    version: "1.2.3"
+                    identifier: "org.swift.test"
                 ),
                 baseURL: URL(string: "https://example.com/example")!,
                 symbolGraphURLs: [],

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -134,8 +134,7 @@ extension XCTestCase {
         let bundle = DocumentationBundle(
             info: DocumentationBundle.Info(
                 displayName: "Test",
-                identifier: "com.example.test",
-                version: "1.0"
+                identifier: "com.example.test"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: [],

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -260,7 +260,6 @@ class ConvertActionTests: XCTestCase {
         var infoPlistFallbacks = [String: Any]()
         infoPlistFallbacks["CFBundleDisplayName"] = "MyKit" // same as the symbol graph
         infoPlistFallbacks["CFBundleIdentifier"] = "com.example.test"
-        infoPlistFallbacks["CFBundleVersion"] = "1.2.3"
         infoPlistFallbacks["CDDefaultCodeListingLanguage"] = "swift"
         
         var action = try ConvertAction(

--- a/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
+++ b/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
@@ -70,11 +70,10 @@ extension InfoPlist: AssertableFile {
             }
             let infoPlist = try PropertyListSerialization.propertyList(from: infoPlistData, options: [], format: nil) as? [String: String]
             
-            let displayName = infoPlist?["CFBundleIdentifier"]
-            let identifier = infoPlist?["CFBundleVersion"]
-            let versionString = infoPlist?["CFBundleDevelopmentRegion"]
+            let displayName = infoPlist?["CFBundleDisplayName"]
+            let identifier = infoPlist?["CFBundleIdentifier"]
             
-            XCTAssert(displayName == content.displayName && identifier == content.identifier && versionString == content.versionString,
+            XCTAssert(displayName == content.displayName && identifier == content.identifier,
                       "File '\(name)' should contain the correct information.", file: (file), line: line)
             
         } catch {


### PR DESCRIPTION


<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This deprecates the version information on `DocumentationBundle.Info`. 

This information was never read and 6.0 was the last version that supported passing it on the command line.

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
