### PR TITLE
Add back `--fallback-bundle-version` argument for backwards compatibility 

### DIFF
--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -340,6 +340,13 @@ extension Docc {
                 """)
             )
             var fallbackDefaultModuleKind: String?
+
+            @Option(
+                name: [.customLong("fallback-bundle-version"), .customLong("bundle-version")],
+                help: .hidden
+            )
+            @available(*, deprecated, message: "The bundle version isn't used for anything.")
+            var _unusedVersionForBackwardsCompatibility: String?
             
             func validate() throws {
                 for deprecatedOptionName in ["display-name", "bundle-identifier", "bundle-version"] {

--- a/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -580,4 +580,15 @@ class ConvertSubcommandTests: XCTestCase {
         let disabledFlagConvert = try Docc.Convert.parse(["--disable-parameters-and-returns-validation"])
         XCTAssertEqual(disabledFlagConvert.enableParametersAndReturnsValidation, false)
     }
+
+    // This test calls ``ConvertOptions.infoPlistFallbacks._unusedVersionForBackwardsCompatibility`` which is deprecated.
+    // Deprecating the test silences the deprecation warning when running the tests. It doesn't skip the test.
+    @available(*, deprecated)
+    func testVersionFlag() throws {
+        let noFlagConvert = try Docc.Convert.parse([])
+        XCTAssertEqual(noFlagConvert.infoPlistFallbacks._unusedVersionForBackwardsCompatibility, nil)
+
+        let enabledFlagConvert = try Docc.Convert.parse(["--fallback-bundle-version", "1.2.3"])
+        XCTAssertEqual(enabledFlagConvert.infoPlistFallbacks._unusedVersionForBackwardsCompatibility, "1.2.3")
+    }
 }


### PR DESCRIPTION

Bug/issue #, if applicable: rdar://136837581

## Summary

This adds back the `--fallback-bundle-version` argument as a silently ignored option for backwards compatibility with tools that still pass it.

## Dependencies

None

## Testing

- Run `docc convert --help`
  - The `--fallback-bundle-version` shouldn't be listed.
  
- Run `docc convert path/to/SomeCatalog.docc --fallback-bundle-version 1.2.3`
  - The flag should be supported 


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
