### PR TITLE
Limit the number of items in automatic See Also sections

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -167,7 +167,8 @@ public struct AutomaticCuration {
         }
         
         func filterReferences(_ references: [ResolvedTopicReference]) -> [ResolvedTopicReference] {
-            references
+            Array(
+                references
                 // Don't include the current node.
                 .filter { $0 != node.reference }
             
@@ -177,6 +178,9 @@ public struct AutomaticCuration {
                         variantsTraits.contains(where: { $0.interfaceLanguage == language.id})
                     })
                 }
+                // Don't create too long See Also sections
+                .prefix(15)
+            )
         }
         
         // Look up the render context first

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -12,6 +12,11 @@ import Foundation
 import Markdown
 import SymbolKit
 
+
+private let automaticSeeAlsoLimit: Int = {
+    ProcessInfo.processInfo.environment["DOCC_AUTOMATIC_SEE_ALSO_LIMIT"].flatMap { Int($0) } ?? 15
+}()
+
 /// A set of functions that add automatic symbol curation to a topic graph.
 public struct AutomaticCuration {
     /// A value type to store an automatically curated task group and its sorting index.
@@ -179,7 +184,7 @@ public struct AutomaticCuration {
                     })
                 }
                 // Don't create too long See Also sections
-                .prefix(15)
+                .prefix(automaticSeeAlsoLimit)
             )
         }
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://134376209

## Summary

This limits the number of items in automatic See Also sections to 15 (chosen somewhat arbitrarily).

The reason for this limit is that the usefulness of a See Also section quickly diminishes as the number of items in it grows. Somewhere beyond 10-20 items, the reader is unlikely to find additional value in even more links. This is an indication that the "topic" is a bit too broad and would benefit from being broken down into smaller sub topics, perhaps on an API collection page.

## Dependencies

None

## Testing

- Organize 20 symbols into a topic section on any page
- Navigate to one of those pages
  - At the bottom, in the See Also section, only the first 15 links will be displayed.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ We don't have any existing documentation about See Also sections. <rdar://126551956> tracks adding it.
