### PR TITLE
Don't suggest replacing part of the symbol name in ambiguous link diagnostics

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -92,8 +92,12 @@ extension PathHierarchy.Error {
             foundDisambiguation: Substring,
             solutions: [Solution]
         ) {
-            let pathPrefix = partialResultPrefix + nextPathComponent.name
-            let foundDisambiguation = nextPathComponent.full.dropFirst(nextPathComponent.name.count)
+            guard let symbolName = candidates.first?.node.name else {
+                return (partialResultPrefix, "", [])
+            }
+            let foundDisambiguation = nextPathComponent.full.dropFirst(symbolName.count)
+            let pathPrefix: Substring = partialResultPrefix + nextPathComponent.full.prefix(symbolName.count)
+            
             let replacementRange = SourceRange.makeRelativeRange(startColumn: pathPrefix.count, length: foundDisambiguation.count)
             
             let solutions: [Solution] = candidates


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://136865335

## Summary

This makes a small refinement to the ambiguous link diagnostic when the symbol name has a disambiguation-look-suffix.

Instead of suggesting to replace the disambiguation-look-suffix with each actual disambiguation, the updated diagnostic will suggest _adding_ the missing disambiguation (preserving the symbol name in the link).

## Dependencies

None

## Testing



## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
