### PR TITLE
Define commands as asynchronous and use Task for preview cancellation 

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticEngine.swift
@@ -29,7 +29,9 @@ public final class DiagnosticEngine {
     /// diagnostics with a severity up to and including `.information` will be printed.
     public var filterLevel: DiagnosticSeverity {
         didSet {
-            self.filter = { $0.diagnostic.severity.rawValue <= self.filterLevel.rawValue }
+            self.filter = { [filterLevel] in
+                $0.diagnostic.severity.rawValue <= filterLevel.rawValue
+            }
         }
     }
     

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1331,6 +1331,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     }
 
     private func shouldContinueRegistration() throws {
+        try Task.checkCancellation()
         guard isRegistrationEnabled.sync({ $0 }) else {
             throw ContextError.registrationDisabled
         }
@@ -1773,6 +1774,7 @@ public class DocumentationContext: DocumentationContextDataProviderDelegate {
     ///
     /// When given `false` the context will try to cancel as quick as possible
     /// any ongoing bundle registrations.
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
     public func setRegistrationEnabled(_ value: Bool) {
         isRegistrationEnabled.sync({ $0 = value })
     }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -50,6 +50,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
     private var dataProvider: DocumentationWorkspaceDataProvider
     
     /// An optional closure that sets up a context before the conversion begins.
+    @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
     public var setupContext: ((inout DocumentationContext) -> Void)?
     
     /// Conversion batches should be big enough to keep all cores busy but small enough not to keep
@@ -189,9 +190,6 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         if let dataProvider = self.currentDataProvider {
             try workspace.unregisterProvider(dataProvider)
         }
-        
-        // Do additional context setup.
-        setupContext?(&context)
 
         /*
            Asynchronously cancel registration if necessary.

--- a/Sources/SwiftDocCUtilities/Action/Action.swift
+++ b/Sources/SwiftDocCUtilities/Action/Action.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,18 +13,16 @@ import SwiftDocC
 
 /// An independent unit of work in the command-line workflow.
 ///
-/// An `Action` represents a discrete documentation task; it takes options and inputs, 
-/// performs its work, reports any problems it encounters, and outputs it generates.
-public protocol Action {
+/// An action represents a discrete documentation task; it takes options and inputs, performs its work, reports any problems it encounters, and outputs it generates.
+package protocol AsyncAction {
     /// Performs the action and returns an ``ActionResult``.
-    mutating func perform(logHandle: LogHandle) throws -> ActionResult
+    mutating func perform(logHandle: inout LogHandle) async throws -> ActionResult
 }
 
-/// An action for which you can optionally customize the documentation context.
-public protocol RecreatingContext: Action {
-    /// A closure that an action calls with the action's context for built documentation,
-    /// before the action performs work.
-    ///
-    /// Use this closure to set the action's context to a certain state before the action runs.
-    var setupContext: ((inout DocumentationContext) -> Void)? { get set }
+package extension AsyncAction {
+    mutating func perform(logHandle: LogHandle) async throws -> ActionResult {
+        var logHandle = logHandle
+        return try await perform(logHandle: &logHandle)
+    }
 }
+

--- a/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
@@ -11,7 +11,7 @@
 import Foundation
 import SwiftDocC
 
-extension Action {
+extension AsyncAction {
     
     /// Creates a new unique directory, with an optional template, inside of specified container.
     /// - Parameters:

--- a/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
@@ -12,24 +12,24 @@ import Foundation
 import SwiftDocC
 
 /// An action that creates documentation coverage info for a documentation bundle.
-public struct CoverageAction: Action {
-    internal init(
+public struct CoverageAction: AsyncAction {
+    init(
         documentationCoverageOptions: DocumentationCoverageOptions,
         workingDirectory: URL,
-        fileManager: FileManagerProtocol) {
+        fileManager: FileManagerProtocol
+    ) {
         self.documentationCoverageOptions = documentationCoverageOptions
         self.workingDirectory = workingDirectory
         self.fileManager = fileManager
     }
 
     public let documentationCoverageOptions: DocumentationCoverageOptions
-    internal let workingDirectory: URL
+    let workingDirectory: URL
     private let fileManager: FileManagerProtocol
 
-    public mutating func perform(logHandle: LogHandle) throws -> ActionResult {
+    public mutating func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         switch documentationCoverageOptions.level {
         case .brief, .detailed:
-            var logHandle = logHandle
             print("   --- Experimental coverage output enabled. ---", to: &logHandle)
 
             let summaryString = try CoverageDataEntry.generateSummary(

--- a/Sources/SwiftDocCUtilities/Action/Actions/EmitGeneratedCurationAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/EmitGeneratedCurationAction.swift
@@ -12,7 +12,7 @@ import Foundation
 import SwiftDocC
 
 /// An action that emits documentation extension files that reflect the auto-generated curation.
-struct EmitGeneratedCurationAction: Action {
+struct EmitGeneratedCurationAction: AsyncAction {
     let catalogURL: URL?
     let additionalSymbolGraphDirectory: URL?
     let outputURL: URL
@@ -41,7 +41,7 @@ struct EmitGeneratedCurationAction: Action {
         self.fileManager = fileManager
     }
     
-    mutating func perform(logHandle: LogHandle) throws -> ActionResult {
+    mutating func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         let workspace = DocumentationWorkspace()
         let context = try DocumentationContext(dataProvider: workspace)
 

--- a/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
@@ -12,7 +12,7 @@ import Foundation
 import SwiftDocC
 
 /// An action that creates an index of a documentation bundle.
-public struct IndexAction: Action {
+public struct IndexAction: AsyncAction {
     let rootURL: URL
     let outputURL: URL
     let bundleIdentifier: String
@@ -22,8 +22,7 @@ public struct IndexAction: Action {
     private var dataProvider: LocalFileSystemDataProvider!
 
     /// Initializes the action with the given validated options, creates or uses the given action workspace & context.
-    public init(documentationBundleURL: URL, outputURL: URL, bundleIdentifier: String, diagnosticEngine: DiagnosticEngine = .init()) throws
-    {
+    public init(documentationBundleURL: URL, outputURL: URL, bundleIdentifier: String, diagnosticEngine: DiagnosticEngine = .init()) throws {
         // Initialize the action context.
         self.rootURL = documentationBundleURL
         self.outputURL = outputURL
@@ -35,7 +34,7 @@ public struct IndexAction: Action {
     
     /// Converts each eligible file from the source documentation bundle,
     /// saves the results in the given output alongside the template files.
-    mutating public func perform(logHandle: LogHandle) throws -> ActionResult {
+    mutating public func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         let problems = try buildIndex()
         diagnosticEngine.emit(problems)
         

--- a/Sources/SwiftDocCUtilities/Action/Actions/Init/InitAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Init/InitAction.swift
@@ -12,8 +12,8 @@ import Foundation
 import SwiftDocC
 
 /// An action that generates a documentation catalog from a template seed.
-public struct InitAction: Action {
-    
+public struct InitAction: AsyncAction {
+
     enum Error: DescribedError {
         case catalogAlreadyExists
         var errorDescription: String {
@@ -72,8 +72,7 @@ public struct InitAction: Action {
     /// Generates a documentation catalog from a catalog template.
     ///
     /// - Parameter logHandle: The file handle that the convert and preview actions will print debug messages to.
-    public mutating func perform(logHandle: SwiftDocC.LogHandle) throws -> ActionResult {
-        
+    public mutating func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         let diagnosticEngine: DiagnosticEngine = DiagnosticEngine(treatWarningsAsErrors: false)
         diagnosticEngine.filterLevel = .warning
         diagnosticEngine.add(DiagnosticConsoleWriter(formattingOptions: []))

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
@@ -13,7 +13,7 @@ import SwiftDocC
 import Markdown
 
 /// An action that merges a list of documentation archives into a combined archive.
-struct MergeAction: Action {
+struct MergeAction: AsyncAction {
     var archives: [URL]
     var landingPageInfo: LandingPageInfo
     var outputURL: URL
@@ -33,7 +33,7 @@ struct MergeAction: Action {
         }
     }
     
-    mutating func perform(logHandle: LogHandle) throws -> ActionResult {
+    mutating func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         guard let firstArchive = archives.first else {
             // A validation warning should have already been raised in `Docc/Merge/InputAndOutputOptions/validate()`.
             return ActionResult(didEncounterError: true, outputs: [])

--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -33,7 +33,7 @@ fileprivate func trapSignals() {
 }
 
 /// An action that monitors a documentation bundle for changes and runs a live web-preview.
-public final class PreviewAction: Action, RecreatingContext {
+public final class PreviewAction: AsyncAction {
     /// A test configuration allowing running multiple previews for concurrent testing.
     static var allowConcurrentPreviews = false
 
@@ -46,8 +46,7 @@ public final class PreviewAction: Action, RecreatingContext {
     let port: Int
     
     var convertAction: ConvertAction
-    
-    public var setupContext: ((inout DocumentationContext) -> Void)?
+
     private var previewPaths: [String] = []
     
     // Use for testing to override binding to a system port
@@ -96,7 +95,7 @@ public final class PreviewAction: Action, RecreatingContext {
     /// > Important: On macOS, the bundle will be converted each time the source is modified.
     ///
     /// - Parameter logHandle: The file handle that the convert and preview actions will print debug messages to.
-    public func perform(logHandle: LogHandle) throws -> ActionResult {
+    public func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         self.logHandle = logHandle
 
         if let rootURL = convertAction.rootURL {
@@ -110,7 +109,7 @@ public final class PreviewAction: Action, RecreatingContext {
             print("Template: \(htmlTemplateDirectory.path)", to: &self.logHandle)
         }
         
-        let previewResult = try preview()
+        let previewResult = try await preview()
         return ActionResult(didEncounterError: previewResult.didEncounterError, outputs: [convertAction.targetDirectory])
     }
 
@@ -120,9 +119,9 @@ public final class PreviewAction: Action, RecreatingContext {
         servers.removeValue(forKey: serverIdentifier)
     }
     
-    func preview() throws -> ActionResult {
+    func preview() async throws -> ActionResult {
         // Convert the documentation source for previewing.
-        let result = try convert()
+        let result = try await convert()
         guard !result.didEncounterError else {
             return result
         }
@@ -163,14 +162,13 @@ public final class PreviewAction: Action, RecreatingContext {
         return previewResult
     }
     
-    func convert() throws -> ActionResult {
+    func convert() async throws -> ActionResult {
         // `cancel()` will throw `cancelPending` if there is already queued conversion.
         try convertAction.cancel()
         
         convertAction = try createConvertAction()
-        convertAction.setupContext = setupContext
 
-        let result = try convertAction.perform(logHandle: logHandle)
+        let result = try await convertAction.perform(logHandle: &logHandle)
         previewPaths = try convertAction.context.previewPaths()
         return result
     }
@@ -198,6 +196,9 @@ extension PreviewAction {
         guard let rootURL = convertAction.rootURL else {
             return
         }
+
+        var convertTask: Task<Void, any Error>?
+
         monitor = try DirectoryMonitor(root: rootURL) { _, folderURL in
             defer {
                 // Reload the directory contents and start to monitor for changes.
@@ -209,23 +210,26 @@ extension PreviewAction {
                     print(error.localizedDescription, to: &self.logHandle)
                 }
             }
-            
-            do {
-                print("Source bundle was modified, converting... ", terminator: "", to: &self.logHandle)
-                let result = try self.convert()
-                if result.didEncounterError {
-                    throw ErrorsEncountered()
+
+            print("Source bundle was modified, converting... ", terminator: "", to: &self.logHandle)
+            convertTask?.cancel()
+            convertTask = Task {
+                do {
+                    let result = try await self.convert()
+                    if result.didEncounterError {
+                        throw ErrorsEncountered()
+                    }
+                    print("Done.", to: &self.logHandle)
+                } catch ConvertAction.Error.cancelPending {
+                    // `monitor.restart()` is already queueing a new convert action which will start when the previous one completes.
+                    // We can safely ignore the current action and just log to the console.
+                    print("\nConversion already in progress...", to: &self.logHandle)
+                } catch DocumentationContext.ContextError.registrationDisabled {
+                    // The context cancelled loading the bundles and threw to yield execution early.
+                    print("\nConversion cancelled...", to: &self.logHandle)
+                } catch {
+                    print("\n\(error.localizedDescription)\nCompilation failed", to: &self.logHandle)
                 }
-                print("Done.", to: &self.logHandle)
-            } catch ConvertAction.Error.cancelPending {
-                // `monitor.restart()` is already queueing a new convert action which will start when the previous one completes.
-                // We can safely ignore the current action and just log to the console.
-                print("\nConversion already in progress...", to: &self.logHandle)
-            } catch DocumentationContext.ContextError.registrationDisabled {
-                // The context cancelled loading the bundles and threw to yield execution early.
-                print("\nConversion cancelled...", to: &self.logHandle)
-            } catch {
-                print("\n\(error.localizedDescription)\nCompilation failed", to: &self.logHandle)
             }
         }
         try monitor.start()

--- a/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
@@ -12,8 +12,7 @@ import Foundation
 import SwiftDocC
 
 /// An action that emits a static hostable website from a DocC Archive.
-struct TransformForStaticHostingAction: Action {
-    
+struct TransformForStaticHostingAction: AsyncAction {
     let rootURL: URL
     let outputURL: URL
     let hostingBasePath: String?
@@ -30,8 +29,8 @@ struct TransformForStaticHostingAction: Action {
          hostingBasePath: String?,
          htmlTemplateDirectory: URL,
          fileManager: FileManagerProtocol = FileManager.default,
-         diagnosticEngine: DiagnosticEngine = .init()) throws
-    {
+         diagnosticEngine: DiagnosticEngine = .init()
+    ) throws {
         // Initialize the action context.
         self.rootURL = documentationBundleURL
         self.outputURL = outputURL ?? documentationBundleURL
@@ -45,19 +44,16 @@ struct TransformForStaticHostingAction: Action {
     
     /// Converts each eligible file from the source archive and
     /// saves the results in the given output folder.
-    mutating func perform(logHandle: LogHandle) throws -> ActionResult {
+    mutating func perform(logHandle: inout LogHandle) async throws -> ActionResult {
         try emit()
         return ActionResult(didEncounterError: false, outputs: [outputURL])
     }
     
     mutating private func emit() throws {
-        
-
         // If the emit is to create the static hostable content outside of the source archive
         // then the output folder needs to be set up and the archive data copied
         // to the new folder.
         if outputIsExternal {
-            
             try setupOutputDirectory(outputURL: outputURL)
 
             // Copy the appropriate folders from the archive.
@@ -104,7 +100,6 @@ struct TransformForStaticHostingAction: Action {
     
     /// Create output directory or empty its contents if it already exists.
     private func setupOutputDirectory(outputURL: URL) throws {
-        
         var isDirectory: ObjCBool = false
         if fileManager.fileExists(atPath: outputURL.path, isDirectory: &isDirectory), isDirectory.boolValue {
             let contents = try fileManager.contentsOfDirectory(at: outputURL, includingPropertiesForKeys: [], options: [.skipsHiddenFiles])

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
@@ -11,15 +11,16 @@
 import SwiftDocC
 import Foundation
 
-extension Action {
+extension AsyncAction {
     /// Performs the action and checks for any problems in the result.
-    /// 
+    ///
     /// - Parameter logHandle: The log handle to write encountered warnings and errors to.
     ///
     /// - Throws: `ErrorsEncountered` if any errors are produced while performing the action.
-    public mutating func performAndHandleResult(logHandle: LogHandle = .standardOutput) throws {
+    public mutating func performAndHandleResult(logHandle: LogHandle = .standardOutput) async throws {
+        var logHandle = logHandle
         // Perform the Action and collect the result
-        let result = try perform(logHandle: logHandle)
+        let result = try await perform(logHandle: &logHandle)
 
         // Throw if any errors were encountered. Errors will have already been
         // reported to the user by the diagnostic engine.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -14,7 +14,7 @@ import Foundation
 
 extension Docc {
     /// Converts documentation markup, assets, and symbol information into a documentation archive.
-    public struct Convert: ParsableCommand {
+    public struct Convert: AsyncParsableCommand {
         public init() {}
 
         /// The name of the directory docc will write its build artifacts to.
@@ -625,8 +625,6 @@ extension Docc {
             set { featureFlags.emitLMDBIndex = newValue }
             
         }
-        
-        // MARK: - ParsableCommand conformance
 
         public mutating func validate() throws {
             if transformForStaticHosting {
@@ -675,12 +673,9 @@ extension Docc {
             }
         }
 
-        public mutating func run() throws {
-            // Initialize a `ConvertAction` from the current options in the `Convert` command.
+        public func run() async throws {
             var convertAction = try ConvertAction(fromConvertCommand: self)
-
-            // Perform the conversion and print any warnings or errors found
-            try convertAction.performAndHandleResult()
+            try await convertAction.performAndHandleResult()
         }
         
         // MARK: Warnings

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import ArgumentParser
 
 extension Docc.ProcessCatalog {
     /// Emits documentation extension files that reflect the auto-generated curation.
-    struct EmitGeneratedCuration: ParsableCommand {
+    struct EmitGeneratedCuration: AsyncParsableCommand {
         
         static var configuration = CommandConfiguration(
             commandName: "emit-generated-curation",
@@ -155,12 +155,10 @@ extension Docc.ProcessCatalog {
             get { generationOptions.startingPointSymbolLink }
             set { generationOptions.startingPointSymbolLink = newValue }
         }
-
-        // MARK: - Execution
         
-        mutating func run() throws {
+        func run() async throws {
             var action = try EmitGeneratedCurationAction(fromCommand: self)
-            try action.performAndHandleResult()
+            try await action.performAndHandleResult()
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,16 +13,11 @@ import Foundation
 
 extension Docc {
     /// Indexes a documentation bundle.
-    public struct Index: ParsableCommand {
-
+    public struct Index: AsyncParsableCommand {
         public init() {}
-
-        // MARK: - Configuration
 
         public static var configuration = CommandConfiguration(
             abstract: "Create an index for the documentation from compiled data.")
-
-        // MARK: - Command Line Options & Arguments
 
         /// The user-provided path to a `.doccarchive` documentation archive.
         @OptionGroup()
@@ -36,27 +31,20 @@ extension Docc {
         @Flag(help: "Print out the index information while the process runs.")
         public var verbose = false
 
-        // MARK: - Computed Properties
-
         /// The path to the directory that all build output should be placed in.
         public var outputURL: URL {
             documentationBundle.urlOrFallback.appendingPathComponent("index", isDirectory: true)
         }
 
-        // MARK: - Execution
-
-        public mutating func run() throws {
-            // Initialize an `IndexAction` from the current options in the `Index` command.
+        public func run() async throws {
             var indexAction = try IndexAction(fromIndexCommand: self)
-
-            // Perform the index and print any warnings or errors found
-            try indexAction.performAndHandleResult()
+            try await indexAction.performAndHandleResult()
         }
     }
     
     // This command wraps the Index command so that we can still support it as a top-level command without listing it in the help
     // text (but still list the Index command as a subcommand of the ProcessArchive command).
-    struct _Index: ParsableCommand {
+    struct _Index: AsyncParsableCommand {
         init() {}
 
         static var configuration = CommandConfiguration(
@@ -68,8 +56,8 @@ extension Docc {
         @OptionGroup
         var command: Index
 
-        public mutating func run() throws {
-            try command.run()
+        public func run() async throws {
+            try await command.run()
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Init.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Init.swift
@@ -13,33 +13,20 @@ import Foundation
 import SwiftDocC
 
 extension Docc {
-    public struct Init: ParsableCommand {
-        
-        public init() {
-        }
-        
-        // MARK: - Configuration
+    public struct Init: AsyncParsableCommand {
+        public init() {}
         
         public static var configuration: CommandConfiguration = CommandConfiguration(
-            abstract: "Generate a documentation catalog from the selected template.",
-            shouldDisplay: true
+            abstract: "Generate a documentation catalog from the selected template."
         )
-        
-        // MARK: - Command Line Options & Arguments
         
         /// The options used for configuring the init action.
         @OptionGroup
         public var initOptions: InitOptions
         
-        // MARK: - Execution
-        
-        public mutating func run() throws {
-            
-            // Initialize a `InitAction` from the current options in the `Init` command.
+        public func run() async throws {
             var initAction = try InitAction(fromInitOptions: initOptions)
-            
-            // Perform the action and print any warnings or errors found.
-            try initAction.performAndHandleResult()
+            try await initAction.performAndHandleResult()
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -14,7 +14,7 @@ import Foundation
 
 extension Docc {
     /// Merge a list of documentation archives into a combined archive.
-    public struct Merge: ParsableCommand {
+    public struct Merge: AsyncParsableCommand {
         public init() {}
         
         public static var configuration = CommandConfiguration(
@@ -167,7 +167,7 @@ extension Docc {
             synthesizedLandingPageOptions.topicStyle
         }
         
-        public mutating func run() throws {
+        public func run() async throws {
             // Initialize a `ConvertAction` from the current options in the `Convert` command.
             var convertAction = MergeAction(
                 archives: archives,
@@ -177,7 +177,7 @@ extension Docc {
             )
             
             // Perform the conversion and print any warnings or errors found
-            try convertAction.performAndHandleResult()
+            try await convertAction.performAndHandleResult()
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,11 +14,8 @@ import Foundation
 
 extension Docc {
     /// Runs the ``Convert`` command and then sets up a web server that can be used to preview that documentation content.
-    public struct Preview: ParsableCommand {
-
+    public struct Preview: AsyncParsableCommand {
         public init() {}
-
-        // MARK: - Configuration
 
         public static var configuration = CommandConfiguration(
             abstract: "Convert documentation inputs and preview the documentation output.",
@@ -31,14 +28,10 @@ extension Docc {
             The 'preview' command extends the 'convert' command by running a preview server and monitoring the documentation input for modifications to rebuild the documentation.
             """
         )
-
-        // MARK: - Command Line Options & Arguments
         
         /// The options used for configuring the preview server.
         @OptionGroup(title: "Preview options")
         public var previewOptions: PreviewOptions
-
-        // MARK: - Property Validation
         
         public mutating func validate() throws {
             // The default template wasn't validated by the Convert command.
@@ -50,14 +43,9 @@ extension Docc {
             }
         }
 
-        // MARK: - Execution
-
-        public mutating func run() throws {
-            // Initialize a `PreviewAction` from the current options in the `Preview` command.
+        public func run() async throws {
             var previewAction = try PreviewAction(fromPreviewOptions: previewOptions)
-
-            // Perform the preview and print any warnings or errors found
-            try previewAction.performAndHandleResult()
+            try await previewAction.performAndHandleResult()
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/ProcessArchive.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/ProcessArchive.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import Foundation
 
 extension Docc {
     /// Processes an action on an archive
-    struct ProcessArchive: ParsableCommand {
+    struct ProcessArchive: AsyncParsableCommand {
 
         static var configuration = CommandConfiguration(
             commandName: "process-archive",

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/ProcessCatalog.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/ProcessCatalog.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import Foundation
 
 extension Docc {
     /// Processes an action on a catalog
-    struct ProcessCatalog: ParsableCommand {
+    struct ProcessCatalog: AsyncParsableCommand {
 
         static var configuration = CommandConfiguration(
             commandName: "process-catalog",

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/TransformForStaticHosting.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/TransformForStaticHosting.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import ArgumentParser
 
 extension Docc.ProcessArchive {
     /// Emits a statically hostable website from a DocC Archive.
-    struct TransformForStaticHosting: ParsableCommand {
+    struct TransformForStaticHosting: AsyncParsableCommand {
         
         static var configuration = CommandConfiguration(
             commandName: "transform-for-static-hosting",
@@ -47,7 +47,6 @@ extension Docc.ProcessArchive {
         var templateOption: TemplateOption
 
         mutating func validate() throws {
-
             if let templateURL = templateOption.templateURL {
                 let indexTemplate = templateURL.appendingPathComponent(HTMLTemplate.templateFileName.rawValue)
                 if !FileManager.default.fileExists(atPath: indexTemplate.path) {
@@ -62,15 +61,10 @@ extension Docc.ProcessArchive {
                 )
             }
         }
-
-        // MARK: - Execution
         
-        mutating func run() throws {
-            // Initialize an `TransformForStaticHostingAction` from the current options in the `TransformForStaticHostingAction` command.
+        func run() async throws {
             var action = try TransformForStaticHostingAction(fromCommand: self)
-            
-            // Perform the emit and print any warnings or errors found
-            try action.performAndHandleResult()
+            try await action.performAndHandleResult()
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/Docc.swift
+++ b/Sources/SwiftDocCUtilities/Docc.swift
@@ -10,8 +10,8 @@
 
 import ArgumentParser
 
-private var subcommands: [ParsableCommand.Type] {
-    var subcommands: [ParsableCommand.Type] = [
+private var subcommands: [AsyncParsableCommand.Type] {
+    var subcommands: [AsyncParsableCommand.Type] = [
         Docc.Convert.self,
         Docc.ProcessArchive.self,
         Docc.ProcessCatalog.self,
@@ -34,7 +34,7 @@ private var usage: String {
 }
 
 /// The default, command-line interface you use to compile and preview documentation.
-public struct Docc: ParsableCommand {
+public struct Docc: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         abstract: "Documentation Compiler: compile, analyze, and preview documentation.",
         usage: usage,

--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
@@ -126,10 +126,10 @@ final class PreviewServer {
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
 
             // Configure the channel handler - it handles plain HTTP requests
-            .childChannelInitializer { channel in
+            .childChannelInitializer { [contentURL] channel in
                 // HTTP pipeline
                 return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-                    channel.pipeline.addHandler(PreviewHTTPHandler(rootURL: self.contentURL))
+                    channel.pipeline.addHandler(PreviewHTTPHandler(rootURL: contentURL))
                 }
             }
             

--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
@@ -184,5 +184,11 @@ final class PreviewServer {
         try threadPool.syncShutdownGracefully()
         print("Stopped preview server at \(bindTo)", to: &logHandle)
     }
+    
+    deinit {
+        if channel?.isWritable == true {
+            try? stop()
+        }
+    }
 }
 #endif

--- a/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities.md
+++ b/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities.md
@@ -11,7 +11,7 @@ Use SwiftDocCUtilities to build a custom, command-line interface and extend it w
 ```swift
 import ArgumentParser
 
-public struct MyDocumentationTool: ParsableCommand {
+public struct MyDocumentationTool: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         abstract: "My custom documentation tool",
         subcommands: [ConvertAction.self, ExampleAction.self]

--- a/Sources/docc/main.swift
+++ b/Sources/docc/main.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,9 @@
 #if os(macOS) || os(Linux) || os(Android) || os(Windows)
 import SwiftDocCUtilities
 
-Docc.main()
+await Task {
+    await Docc.main()
+}.value
 #else
 fatalError("Command line interface supported only on macOS, Linux and Windows platforms.")
 #endif

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionStaticHostableTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionStaticHostableTests.swift
@@ -16,7 +16,7 @@ import SwiftDocCTestUtilities
 
 class ConvertActionStaticHostableTests: StaticHostingBaseTests {
     /// Creates a DocC archive and then archives it with options  to produce static content which is then validated.
-    func testConvertActionStaticHostableTestOutput() throws {
+    func testConvertActionStaticHostableTestOutput() async throws {
         
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         let targetURL = try createTemporaryDirectory()
@@ -44,7 +44,7 @@ class ConvertActionStaticHostableTests: StaticHostingBaseTests {
             transformForStaticHosting: true,
             hostingBasePath: basePath
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         // Test the content of the output folder.
         var expectedContent = ["data", "documentation", "tutorials", "downloads", "images", "metadata.json" ,"videos", "index.html", "index"]

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -36,7 +36,7 @@ class ConvertActionTests: XCTestCase {
         forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         .appendingPathComponent("project.zip")
     
-    func testCopyingImageAssets() throws {
+    func testCopyingImageAssets() async throws {
         XCTAssert(FileManager.default.fileExists(atPath: imageFile.path))
         let testImageName = "TestImage.png"
         
@@ -61,8 +61,8 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
         
+        let result = try await action.perform(logHandle: .none)
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
             Folder(name: "images", content: [
@@ -81,7 +81,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(copiedImageOutput, [testImageName])
     }
     
-    func testCopyingVideoAssets() throws {
+    func testCopyingVideoAssets() async throws {
         let videoFile = Bundle.module.url(
             forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
                 .appendingPathComponent("introvideo.mp4")
@@ -110,7 +110,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -131,7 +131,7 @@ class ConvertActionTests: XCTestCase {
     }
     
     // Ensures we don't regress on copying download assets to the build folder (72599615)
-    func testCopyingDownloadAssets() throws {
+    func testCopyingDownloadAssets() async throws {
         let downloadFile = Bundle.module.url(
             forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
                 .appendingPathComponent("project.zip")
@@ -171,7 +171,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -186,7 +186,7 @@ class ConvertActionTests: XCTestCase {
     
     // Ensures we always create the required asset folders even if no assets are explicitly
     // provided
-    func testCreationOfAssetFolders() throws {
+    func testCreationOfAssetFolders() async throws {
         // Empty documentation bundle
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
@@ -207,7 +207,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -218,7 +218,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: testDataProvider)
     }
     
-    func testConvertsWithoutErrorsWhenBundleIsNotAtRoot() throws {
+    func testConvertsWithoutErrorsWhenBundleIsNotAtRoot() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
         ])
@@ -240,11 +240,11 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         XCTAssertEqual(result.problems.count, 0)
     }
     
-    func testConvertWithoutBundle() throws {
+    func testConvertWithoutBundle() async throws {
         let myKitSymbolGraph = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json")
         
@@ -278,7 +278,7 @@ class ConvertActionTests: XCTestCase {
             )
         )
         
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         XCTAssertEqual(result.problems.count, 0)
         XCTAssertEqual(result.outputs, [outputLocation.absoluteURL])
         
@@ -380,7 +380,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertThrowsError(try action.moveOutput(from: source.absoluteURL, to: targetURL))
     }
 
-    func testConvertDoesNotLowercasesResourceFileNames() throws {
+    func testConvertDoesNotLowercasesResourceFileNames() async throws {
         // Documentation bundle that contains an image
         let bundle = Folder(name: "unit-test.docc", content: [
             CopyOfFile(original: imageFile, newName: "TEST.png"),
@@ -403,7 +403,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -423,7 +423,7 @@ class ConvertActionTests: XCTestCase {
     
     // Ensures that render JSON produced by the convert action
     // does not include file location information for symbols.
-    func testConvertDoesNotIncludeFilePathsInRenderNodes() throws {
+    func testConvertDoesNotIncludeFilePathsInRenderNodes() async throws {
         // Documentation bundle that contains a symbol graph.
         // The symbol graph contains symbols that include location information.
         let bundle = Folder(name: "unit-test.docc", content: [
@@ -446,8 +446,8 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
         
+        let result = try await action.perform(logHandle: .none)
         // Construct the URLs for the produced render json:
         
         let documentationDataDirectoryURL = result.outputs[0]
@@ -493,7 +493,7 @@ class ConvertActionTests: XCTestCase {
     }
     
     // Ensures that render JSON produced by the convert action does not include symbol access level information.
-    func testConvertDoesNotIncludeSymbolAccessLevelsInRenderNodes() throws {
+    func testConvertDoesNotIncludeSymbolAccessLevelsInRenderNodes() async throws {
         // Documentation bundle that contains a symbol graph.
         // The symbol graph contains symbols that include access level information.
         let bundle = Folder(name: "unit-test.docc", content: [
@@ -516,7 +516,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         // Construct the URLs for the produced render json:
         
@@ -561,7 +561,7 @@ class ConvertActionTests: XCTestCase {
         }
     }
 
-    func testOutputFolderContainsDiagnosticJSONWhenThereAreWarnings() throws {
+    func testOutputFolderContainsDiagnosticJSONWhenThereAreWarnings() async throws {
         // Documentation bundle that contains an image
         let bundle = Folder(name: "unit-test.docc", content: [
             CopyOfFile(original: imageFile, newName: "referenced-tutorials-image.png"),
@@ -604,7 +604,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -630,7 +630,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: testDataProvider)
     }
     
-    func testOutputFolderContainsDiagnosticJSONWhenThereAreErrorsAndNoTemplate() throws {
+    func testOutputFolderContainsDiagnosticJSONWhenThereAreErrorsAndNoTemplate() async throws {
         // Documentation bundle that contains an image
         let bundle = Folder(name: "unit-test.docc", content: [
             TextFile(name: "TechnologyX.tutorial", utf8Content: """
@@ -664,7 +664,7 @@ class ConvertActionTests: XCTestCase {
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "hint") // report all errors during the test
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -698,7 +698,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: testDataProvider)
     }
     
-    func testWarningForUncuratedTutorial() throws {
+    func testWarningForUncuratedTutorial() async throws {
         // Documentation bundle that contains an image
         let bundle = Folder(name: "unit-test.docc", content: [
             TextFile(name: "TechnologyX.tutorial", utf8Content: """
@@ -745,7 +745,7 @@ class ConvertActionTests: XCTestCase {
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "hint") // report all errors during the test
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         // Verify that the following files and folder exist at the output location
         let expectedOutput = Folder(name: ".docc-build", content: [
@@ -771,7 +771,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: testDataProvider)
     }
     
-    func testOutputFolderIsNotRemovedWhenThereAreErrors() throws {
+    func testOutputFolderIsNotRemovedWhenThereAreErrors() async throws {
         let tutorialsFile = TextFile(name: "TechnologyX.tutorial", utf8Content: """
             @Tutorials(name: "Technology Z") {
                @Intro(title: "Technology Z") {
@@ -824,7 +824,7 @@ class ConvertActionTests: XCTestCase {
                 dataProvider: testDataProvider,
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             
             XCTAssertFalse(
                 result.didEncounterError,
@@ -843,7 +843,7 @@ class ConvertActionTests: XCTestCase {
 
     /// Verifies that digest is correctly emitted for API documentation topics
     /// like module pages, symbols, and articles.
-    func testMetadataIsWrittenToOutputFolderAPIDocumentation() throws {
+    func testMetadataIsWrittenToOutputFolderAPIDocumentation() async throws {
         // Example documentation bundle that contains an image
         let bundle = Folder(name: "unit-test.docc", content: [
             // An asset
@@ -926,7 +926,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         // Because the page order isn't deterministic, we create the indexing records and linkable entities in the same order as the pages.
         let indexingRecords: [IndexingRecord] = action.context.knownPages.compactMap { reference in
@@ -1102,7 +1102,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(resultAssets.images.map({ $0.identifier.identifier }).sorted(), images.map({ $0.identifier.identifier }).sorted())
     }
 
-    func testLinkableEntitiesMetadataIncludesOverloads() throws {
+    func testLinkableEntitiesMetadataIncludesOverloads() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let bundle = try Folder.createFromDisk(
@@ -1134,7 +1134,7 @@ class ConvertActionTests: XCTestCase {
             dataProvider: testDataProvider,
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory())
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         guard let resultLikableEntities: [LinkDestinationSummary] = contentsOfJSONFile(url: result.outputs[0].appendingPathComponent("linkable-entities.json")) else {
             XCTFail("Can't find linkable-entities.json in output")
@@ -1160,7 +1160,7 @@ class ConvertActionTests: XCTestCase {
         ])
     }
 
-    func testDownloadMetadataIsWrittenToOutputFolder() throws {
+    func testDownloadMetadataIsWrittenToOutputFolder() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             CopyOfFile(original: projectZipFile),
             CopyOfFile(original: imageFile, newName: "referenced-tutorials-image.png"),
@@ -1256,7 +1256,7 @@ class ConvertActionTests: XCTestCase {
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         func contentsOfJSONFile<Result: Decodable>(url: URL) -> Result? {
             guard let data = testDataProvider.contents(atPath: url.path) else {
@@ -1280,7 +1280,7 @@ class ConvertActionTests: XCTestCase {
         }))
     }
 
-    func testMetadataIsWrittenToOutputFolder() throws {
+    func testMetadataIsWrittenToOutputFolder() async throws {
         // Example documentation bundle that contains an image
         let bundle = Folder(name: "unit-test.docc", content: [
             CopyOfFile(original: imageFile, newName: "referenced-article-image.png"),
@@ -1347,7 +1347,7 @@ class ConvertActionTests: XCTestCase {
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         // Because the page order isn't deterministic, we create the indexing records and linkable entities in the same order as the pages.
         let indexingRecords: [IndexingRecord] = action.context.knownPages.compactMap { reference in
@@ -1485,8 +1485,8 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(resultAssets.images.map({ $0.identifier.identifier }).sorted(), images.map({ $0.identifier.identifier }).sorted())
     }
     
-    func testMetadataIsOnlyWrittenToOutputFolderWhenEmitDigestFlagIsSet() throws {
         
+    func testMetadataIsOnlyWrittenToOutputFolderWhenEmitDigestFlagIsSet() async throws {
         // An empty documentation bundle
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
@@ -1510,7 +1510,7 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
             )
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             
             XCTAssertTrue(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("assets.json").path))
             XCTAssertTrue(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("diagnostics.json").path))
@@ -1536,7 +1536,7 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
             )
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             
             XCTAssertFalse(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("assets.json").path))
             XCTAssertFalse(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("diagnostics.json").path))
@@ -1569,7 +1569,7 @@ class ConvertActionTests: XCTestCase {
         }
     }
 
-    func testMetadataIsOnlyWrittenToOutputFolderWhenDocumentationCoverage() throws {
+    func testMetadataIsOnlyWrittenToOutputFolderWhenDocumentationCoverage() async throws {
 
         // An empty documentation bundle, except for a single symbol graph file
         // containing 8 symbols.
@@ -1601,12 +1601,12 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 documentationCoverageOptions: .noCoverage)
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
 
             XCTAssertFalse(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("documentation-coverage.json").path))
 
             // Rerun the convert and test no coverage info structs were consumed
-            let _ = try action.converter.convert(outputConsumer: TestDocumentationCoverageConsumer(coverageConsumeHandler: coverageInfoHandler))
+            _ = try action.converter.convert(outputConsumer: TestDocumentationCoverageConsumer(coverageConsumeHandler: coverageInfoHandler))
             XCTAssertEqual(coverageInfoCount, 0)
         }
 
@@ -1628,13 +1628,13 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 documentationCoverageOptions: DocumentationCoverageOptions(level: .brief))
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
 
             XCTAssertTrue(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("documentation-coverage.json").path))
 
             // Rerun the convert and test one coverage info structs was consumed for each symbol page (8)
             coverageInfoCount = 0
-            let _ = try action.converter.convert(outputConsumer: TestDocumentationCoverageConsumer(coverageConsumeHandler: coverageInfoHandler))
+            _ = try action.converter.convert(outputConsumer: TestDocumentationCoverageConsumer(coverageConsumeHandler: coverageInfoHandler))
             XCTAssertEqual(coverageInfoCount, 8)
         }
 
@@ -1656,13 +1656,13 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 documentationCoverageOptions: DocumentationCoverageOptions(level: .detailed))
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
 
             XCTAssertTrue(testDataProvider.fileExists(atPath: result.outputs[0].appendingPathComponent("documentation-coverage.json").path))
 
             // Rerun the convert and test one coverage info structs was consumed for each symbol page (8)
             coverageInfoCount = 0
-            let _ = try action.converter.convert(outputConsumer: TestDocumentationCoverageConsumer(coverageConsumeHandler: coverageInfoHandler))
+            _ = try action.converter.convert(outputConsumer: TestDocumentationCoverageConsumer(coverageConsumeHandler: coverageInfoHandler))
             XCTAssertEqual(coverageInfoCount, 8)
         }
     }
@@ -1769,7 +1769,7 @@ class ConvertActionTests: XCTestCase {
         ])
     }
     
-    func testResolvedTopicReferencesAreCachedByDefaultWhenConverting() throws {
+    func testResolvedTopicReferencesAreCachedByDefaultWhenConverting() async throws {
         let bundle = Folder(
             name: "unit-test.docc",
             content: [
@@ -1795,13 +1795,13 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
         
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: #function), 13)
     }
 
-    func testIgnoresAnalyzerHintsByDefault() throws {
-        func runCompiler(analyze: Bool) throws -> [Problem] {
+    func testIgnoresAnalyzerHintsByDefault() async throws {
+        func runCompiler(analyze: Bool) async throws -> [Problem] {
             // This bundle has both non-analyze and analyze style warnings.
             let testBundleURL = Bundle.module.url(
                 forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
@@ -1824,13 +1824,13 @@ class ConvertActionTests: XCTestCase {
                 fileManager: testDataProvider,
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: engine)
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             XCTAssertFalse(result.didEncounterError)
             return engine.problems
         }
 
-        let analyzeDiagnostics = try runCompiler(analyze: true)
-        let noAnalyzeDiagnostics = try runCompiler(analyze: false)
+        let analyzeDiagnostics = try await runCompiler(analyze: true)
+        let noAnalyzeDiagnostics = try await runCompiler(analyze: false)
         
         XCTAssertTrue(analyzeDiagnostics.contains { $0.diagnostic.severity == .information })
         XCTAssertFalse(noAnalyzeDiagnostics.contains { $0.diagnostic.severity == .information })
@@ -1846,7 +1846,7 @@ class ConvertActionTests: XCTestCase {
     
     /// Verify that the conversion of the same input given high concurrency and no concurrency,
     /// and also with and without generating digest produces the same results
-    func testConvertTestBundleWithHighConcurrency() throws {
+    func testConvertTestBundleWithHighConcurrency() async throws {
         let testBundleURL = Bundle.module.url(
             forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         let bundle = try Folder.createFromDisk(url: testBundleURL)
@@ -1861,7 +1861,7 @@ class ConvertActionTests: XCTestCase {
             }
         }
         
-        func convertTestBundle(batchSize: Int, emitDigest: Bool, targetURL: URL, testDataProvider: DocumentationWorkspaceDataProvider & FileManagerProtocol) throws -> ActionResult {
+        func convertTestBundle(batchSize: Int, emitDigest: Bool, targetURL: URL, testDataProvider: DocumentationWorkspaceDataProvider & FileManagerProtocol) async throws -> ActionResult {
             // Run the create ConvertAction
             
             var configuration = DocumentationContext.Configuration()
@@ -1887,7 +1887,7 @@ class ConvertActionTests: XCTestCase {
             
             action.converter.batchNodeCount = batchSize
             
-            return try action.perform(logHandle: .none)
+            return try await action.perform(logHandle: .none)
         }
 
         for withDigest in [false, true] {
@@ -1895,11 +1895,11 @@ class ConvertActionTests: XCTestCase {
 
             // Set a batch size to a high number to have no concurrency
             let serialOutputURL = URL(string: "/serialOutput")!
-            let serialResult = try convertTestBundle(batchSize: 10_000, emitDigest: withDigest, targetURL: serialOutputURL, testDataProvider: testDataProvider)
+            let serialResult = try await convertTestBundle(batchSize: 10_000, emitDigest: withDigest, targetURL: serialOutputURL, testDataProvider: testDataProvider)
 
             // Set a batch size to 1 to have maximum concurrency (this is bad for performance maximizes our chances of encountering an issue).
             let parallelOutputURL = URL(string: "/parallelOutput")!
-            let parallelResult = try convertTestBundle(batchSize: 1, emitDigest: withDigest, targetURL: parallelOutputURL, testDataProvider: testDataProvider)
+            let parallelResult = try await convertTestBundle(batchSize: 1, emitDigest: withDigest, targetURL: parallelOutputURL, testDataProvider: testDataProvider)
             
             // Compare the results
             XCTAssertEqual(
@@ -1928,7 +1928,7 @@ class ConvertActionTests: XCTestCase {
         }
     }
     
-    func testConvertActionProducesDeterministicOutput() throws {
+    func testConvertActionProducesDeterministicOutput() async throws {
         // Pretty printing the output JSON also enables sorting keys during encoding
         // which is required for testing if the conversion output is deterministic.
         let priorPrettyPrintValue = shouldPrettyPrintOutputJSON
@@ -1950,7 +1950,7 @@ class ConvertActionTests: XCTestCase {
         )
         let bundle = try Folder.createFromDisk(url: testBundleURL)
         
-        func performConvertAction(outputURL: URL, testFileSystem: TestFileSystem) throws {
+        func performConvertAction(outputURL: URL, testFileSystem: TestFileSystem) async throws {
             var action = try ConvertAction(
                 documentationBundleURL: bundle.absoluteURL,
                 outOfProcessResolver: nil,
@@ -1965,7 +1965,7 @@ class ConvertActionTests: XCTestCase {
             )
             action.diagnosticEngine.consumers.sync { $0.removeAll() } 
             
-            _ = try action.perform(logHandle: .none)
+            _ = try await action.perform(logHandle: .none)
         }
         
         // We'll perform 3 sets of conversions to confirm the output is deterministic
@@ -1977,11 +1977,11 @@ class ConvertActionTests: XCTestCase {
             // Convert the same bundle three times and place the output in
             // separate directories.
             
-            try performConvertAction(
+            try await performConvertAction(
                 outputURL: URL(fileURLWithPath: "/1", isDirectory: true),
                 testFileSystem: testFileSystem
             )
-            try performConvertAction(
+            try await performConvertAction(
                 outputURL: URL(fileURLWithPath: "/2", isDirectory: true),
                 testFileSystem: testFileSystem
             )
@@ -2018,7 +2018,7 @@ class ConvertActionTests: XCTestCase {
         }
     }
     
-    func testConvertActionNavigatorIndexGeneration() throws {
+    func testConvertActionNavigatorIndexGeneration() async throws {
         // The navigator index needs to test with the real file manager
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         
@@ -2039,7 +2039,7 @@ class ConvertActionTests: XCTestCase {
             buildIndex: true,
             temporaryDirectory: createTemporaryDirectory() // Create an index
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         let indexURL = targetURL.appendingPathComponent("index")
         
@@ -2056,7 +2056,7 @@ class ConvertActionTests: XCTestCase {
             outputURL: indexURL,
             bundleIdentifier: indexFromConvertAction.bundleIdentifier
         )
-        _ = try indexAction.perform(logHandle: .none)
+        _ = try await indexAction.perform(logHandle: .none)
         
         let indexFromIndexAction = try NavigatorIndex.readNavigatorIndex(url: indexURL)
         XCTAssertEqual(indexFromIndexAction.count, 37)
@@ -2067,7 +2067,7 @@ class ConvertActionTests: XCTestCase {
         )
     }
     
-    func testObjectiveCNavigatorIndexGeneration() throws {
+    func testObjectiveCNavigatorIndexGeneration() async throws {
         let bundle = Folder(name: "unit-test-objc.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: objectiveCSymbolGraphFile),
@@ -2099,7 +2099,7 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: createTemporaryDirectory()
         )
         
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         let index = try NavigatorIndex.readNavigatorIndex(url: targetDirectory.appendingPathComponent("index"))
         func assertAllChildrenAreObjectiveC(_ node: NavigatorTree.Node) {
@@ -2126,7 +2126,7 @@ class ConvertActionTests: XCTestCase {
         assertAllChildrenAreObjectiveC(firstChild)
     }
     
-    func testMixedLanguageNavigatorIndexGeneration() throws {
+    func testMixedLanguageNavigatorIndexGeneration() async throws {
         // The navigator index needs to test with the real File Manager
         let temporaryTestOutputDirectory = try createTemporaryDirectory()
         
@@ -2151,7 +2151,7 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: createTemporaryDirectory()
         )
         
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         let index = try NavigatorIndex.readNavigatorIndex(
             url: temporaryTestOutputDirectory.appendingPathComponent("index")
@@ -2270,7 +2270,7 @@ class ConvertActionTests: XCTestCase {
         )
     }
     
-    func testDiagnosticLevel() throws {
+    func testDiagnosticLevel() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2301,13 +2301,13 @@ class ConvertActionTests: XCTestCase {
             diagnosticLevel: "error",
             diagnosticEngine: engine
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         XCTAssertEqual(engine.problems.count, 0, "\(ConvertAction.self) didn't filter out diagnostics at-or-above the 'error' level.")
         XCTAssertFalse(result.didEncounterError, "The issues with this test bundle are not severe enough to fail the build.")
     }
 
-    func testDiagnosticLevelIgnoredWhenAnalyzeIsPresent() throws {
+    func testDiagnosticLevelIgnoredWhenAnalyzeIsPresent() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2338,7 +2338,7 @@ class ConvertActionTests: XCTestCase {
             diagnosticLevel: "error",
             diagnosticEngine: engine
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         XCTAssertEqual(engine.problems.count, 1, "\(ConvertAction.self) shouldn't filter out diagnostics when the '--analyze' flag is passed")
         XCTAssertEqual(engine.problems.map { $0.diagnostic.identifier }, ["org.swift.docc.Article.Title.NotFound"])
@@ -2346,7 +2346,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssert(engine.problems.contains(where: { $0.diagnostic.severity == .warning }))
     }
 
-    func testDoesNotIncludeDiagnosticsInThrownError() throws {
+    func testDoesNotIncludeDiagnosticsInThrownError() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2375,10 +2375,10 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
             diagnosticLevel: "error"
         )
-        XCTAssertNoThrow(try action.performAndHandleResult(logHandle: .none))
+        try await action.performAndHandleResult(logHandle: .none)
     }
     
-    func testWritesDiagnosticFileWhenThrowingError() throws {
+    func testWritesDiagnosticFileWhenThrowingError() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2414,7 +2414,7 @@ class ConvertActionTests: XCTestCase {
         
         // TODO: Support TestFileSystem in DiagnosticFileWriter
         XCTAssertFalse(FileManager.default.fileExists(atPath: diagnosticFile.path), "Diagnostic file doesn't exist before")
-        XCTAssertNoThrow(try action.performAndHandleResult(logHandle: .none))
+        try await action.performAndHandleResult(logHandle: .none)
         XCTAssertTrue(FileManager.default.fileExists(atPath: diagnosticFile.path), "Diagnostic file exist after")
     }
 
@@ -2461,7 +2461,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(action.context.configuration.externalMetadata.inheritDocs, false)
     }
     
-    func testEmitsDigest() throws {
+    func testEmitsDigest() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2486,7 +2486,7 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
         
-        XCTAssertNoThrow(try action.performAndHandleResult(logHandle: .none))
+        try await action.performAndHandleResult(logHandle: .none)
         XCTAssert(testDataProvider.fileExists(atPath: digestFileURL.path))
         
         let data = try testDataProvider.contentsOfURL(digestFileURL)
@@ -2494,7 +2494,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(diagnostics.count, 0)
     }
     
-    func testRenderIndexJSONGeneration() throws {
+    func testRenderIndexJSONGeneration() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2519,19 +2519,19 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: createTemporaryDirectory()
         )
         
-        try action.performAndHandleResult(logHandle: .none)
         
+        try await action.performAndHandleResult(logHandle: .none)
         let indexDirectory = targetDirectory.appendingPathComponent("index", isDirectory: true)
         let renderIndexJSON = indexDirectory.appendingPathComponent("index.json", isDirectory: false)
         
-        try action.performAndHandleResult(logHandle: .none)
+        try await action.performAndHandleResult(logHandle: .none)
         XCTAssertTrue(FileManager.default.directoryExists(atPath: indexDirectory.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: renderIndexJSON.path))
         try XCTAssertEqual(FileManager.default.contentsOfDirectory(at: indexDirectory, includingPropertiesForKeys: nil).count, 1)
     }
     
     /// Verifies that a metadata.json file is created in the output folder with additional metadata.
-    func testCreatesBuildMetadataFileForBundleWithInfoPlistValues() throws {
+    func testCreatesBuildMetadataFileForBundleWithInfoPlistValues() async throws {
         let bundle = Folder(
             name: "unit-test.docc",
             content: [InfoPlist(displayName: "TestBundle", identifier: "com.test.example")]
@@ -2553,7 +2553,7 @@ class ConvertActionTests: XCTestCase {
             fileManager: testDataProvider,
             temporaryDirectory: testDataProvider.uniqueTemporaryDirectory()
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         
         let expectedOutput = Folder(name: ".docc-build", content: [
             JSONFile(
@@ -2567,7 +2567,7 @@ class ConvertActionTests: XCTestCase {
     
     // Tests that the default behavior of `docc convert` on the command-line does not throw an error
     // when processing a DocC catalog that does not actually produce documentation. (r91790147)
-    func testConvertDocCCatalogThatProducesNoDocumentationDoesNotThrowError() throws {
+    func testConvertDocCCatalogThatProducesNoDocumentationDoesNotThrowError() async throws {
         let emptyCatalog = Folder(
             name: "unit-test.docc",
             content: [InfoPlist(displayName: "TestBundle", identifier: "com.test.example")]
@@ -2591,7 +2591,7 @@ class ConvertActionTests: XCTestCase {
         )
         
         var action = try ConvertAction(fromConvertCommand: convertCommand)
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
     }
     
     func emitEmptySymbolGraph(moduleName: String, destination: URL) throws {
@@ -2627,7 +2627,7 @@ class ConvertActionTests: XCTestCase {
 
     // Tests that when `docc convert` is given input that produces multiple pages at the same path
     // on disk it does not throw an error when attempting to transform it for static hosting. (94311195)
-    func testConvertDocCCatalogThatProducesMultipleDocumentationPagesAtTheSamePathDoesNotThrowError() throws {
+    func testConvertDocCCatalogThatProducesMultipleDocumentationPagesAtTheSamePathDoesNotThrowError() async throws {
         let temporaryDirectory = try createTemporaryDirectory()
         
         let catalogURL = try Folder(
@@ -2660,9 +2660,9 @@ class ConvertActionTests: XCTestCase {
             transformForStaticHosting: true
         )
         
-        XCTAssertNoThrow(try action.performAndHandleResult(logHandle: .none))
+        try await action.performAndHandleResult(logHandle: .none)
     }
-    func testConvertWithCustomTemplates() throws {
+    func testConvertWithCustomTemplates() async throws {
         let info = InfoPlist(displayName: "TestConvertWithCustomTemplates", identifier: "com.test.example")
         let index = TextFile(name: "index.html", utf8Content: """
         <!DOCTYPE html>
@@ -2713,7 +2713,7 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: createTemporaryDirectory(),
             experimentalEnableCustomTemplates: true
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         // The custom template contents should be wrapped in <template> tags and
         // prepended to the <body>
@@ -2731,7 +2731,7 @@ class ConvertActionTests: XCTestCase {
     }
 
     // Tests that custom templates are injected into the extra index.html files generated for static hosting.
-    func testConvertWithCustomTemplatesForStaticHosting() throws {
+    func testConvertWithCustomTemplatesForStaticHosting() async throws {
         let info = InfoPlist(displayName: "TestConvertWithCustomTemplatesForStaticHosting", identifier: "com.test.example")
         let index = TextFile(name: "index.html", utf8Content: """
         <!DOCTYPE html>
@@ -2795,7 +2795,7 @@ class ConvertActionTests: XCTestCase {
             experimentalEnableCustomTemplates: true,
             transformForStaticHosting: true
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         // The custom template contents should be wrapped in <template> tags and
         // prepended to the <body>
@@ -2815,7 +2815,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: FileManager.default)
     }
 
-    func testConvertWithThemeSettings() throws {
+    func testConvertWithThemeSettings() async throws {
         let info = InfoPlist(displayName: "TestConvertWithThemeSettings", identifier: "com.test.example")
         let index = TextFile(name: "index.html", utf8Content: """
         <!DOCTYPE html>
@@ -2864,7 +2864,7 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: createTemporaryDirectory(),
             experimentalEnableCustomTemplates: true
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
 
         let expectedOutput = Folder(name: ".docc-build", content: [
             index,
@@ -2873,7 +2873,7 @@ class ConvertActionTests: XCTestCase {
         expectedOutput.assertExist(at: result.outputs[0], fileManager: FileManager.default)
     }
     
-    func testTreatWarningsAsErrors() throws {
+    func testTreatWarningsAsErrors() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             CopyOfFile(original: symbolGraphFile, newName: "MyKit.symbols.json"),
@@ -2905,7 +2905,7 @@ class ConvertActionTests: XCTestCase {
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: engine
             )
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             XCTAssertEqual(engine.problems.count, 1)
             XCTAssertTrue(engine.problems.contains(where: { $0.diagnostic.severity == .warning }))
             XCTAssertFalse(result.didEncounterError)
@@ -2927,7 +2927,7 @@ class ConvertActionTests: XCTestCase {
                 temporaryDirectory: testDataProvider.uniqueTemporaryDirectory(),
                 diagnosticEngine: engine
             )
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             XCTAssertEqual(engine.problems.count, 1)
             XCTAssertTrue(result.didEncounterError)
         }
@@ -2947,13 +2947,13 @@ class ConvertActionTests: XCTestCase {
                 diagnosticEngine: nil,
                 treatWarningsAsErrors: true
             )
-            let result = try action.perform(logHandle: .none)
+            let result = try await action.perform(logHandle: .none)
             XCTAssertTrue(result.didEncounterError)
         }
 
     }
 
-    func testConvertWithoutBundleDerivesDisplayNameAndIdentifierFromSingleModuleSymbolGraph() throws {
+    func testConvertWithoutBundleDerivesDisplayNameAndIdentifierFromSingleModuleSymbolGraph() async throws {
         let myKitSymbolGraph = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json")
         
@@ -2982,7 +2982,7 @@ class ConvertActionTests: XCTestCase {
         )
         
         XCTAssert(action.context.registeredBundles.isEmpty)
-        XCTAssertNoThrow(try action.perform(logHandle: .none))
+        _ = try await action.perform(logHandle: .none)
 
         XCTAssertEqual(action.context.registeredBundles.count, 1)
         let bundle = try XCTUnwrap(action.context.registeredBundles.first, "Should have registered the generated test bundle.")
@@ -2990,7 +2990,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(bundle.identifier, "MyKit")
     }
     
-    func testConvertWithoutBundleErrorsForMultipleModulesSymbolGraph() throws {
+    func testConvertWithoutBundleErrorsForMultipleModulesSymbolGraph() async throws {
         let testBundle = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         let myKitSymbolGraph = testBundle
             .appendingPathComponent("mykit-iOS.symbols.json")
@@ -3032,8 +3032,10 @@ class ConvertActionTests: XCTestCase {
             )
         )
         
-        let logStorage = LogHandle.LogStorage()
-        XCTAssertThrowsError(try action.perform(logHandle: .memory(logStorage))) { error in
+        do {
+            _ = try await action.perform(logHandle: .none)
+            XCTFail("The action didn't raise an error")
+        } catch {
             XCTAssertEqual(error.localizedDescription, """
             The information provided as command line arguments is not enough to generate a documentation bundle:
             
@@ -3044,7 +3046,7 @@ class ConvertActionTests: XCTestCase {
         }
     }
     
-    func testConvertWithBundleDerivesDisplayNameFromBundle() throws {
+    func testConvertWithBundleDerivesDisplayNameFromBundle() async throws {
         let emptyDoccCatalog = try createTemporaryDirectory(named: "Something.docc")
         let outputLocation = try createTemporaryDirectory(named: "output")
 
@@ -3066,7 +3068,7 @@ class ConvertActionTests: XCTestCase {
             )
         )
         XCTAssert(action.context.registeredBundles.isEmpty)
-        XCTAssertNoThrow(try action.perform(logHandle: .none))
+        _ = try await action.perform(logHandle: .none)
 
         XCTAssertEqual(action.context.registeredBundles.count, 1)
         let bundle = try XCTUnwrap(action.context.registeredBundles.first, "Should have registered the generated test bundle.")
@@ -3084,8 +3086,8 @@ class ConvertActionTests: XCTestCase {
     }
     
     // Tests that when converting a catalog with no technology root a warning is raised (r93371988)
-    func testConvertWithNoTechnologyRoot() throws {
-        func problemsFromConverting(_ catalogContent: [File]) throws -> [Problem] {
+    func testConvertWithNoTechnologyRoot() async throws {
+        func problemsFromConverting(_ catalogContent: [File]) async throws -> [Problem] {
             let catalog = Folder(name: "unit-test.docc", content: catalogContent)
             let testDataProvider = try TestFileSystem(folders: [catalog, Folder.emptyHTMLTemplateDirectory])
             let engine = DiagnosticEngine()
@@ -3102,11 +3104,11 @@ class ConvertActionTests: XCTestCase {
                 temporaryDirectory: URL(fileURLWithPath: "/tmp"),
                 diagnosticEngine: engine
             )
-            _ = try action.perform(logHandle: .none)
+            _ = try await action.perform(logHandle: .none)
             return engine.problems
         }
         
-        let onlyTutorialArticleProblems = try problemsFromConverting([
+        let onlyTutorialArticleProblems = try await problemsFromConverting([
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             TextFile(name: "Article.tutorial", utf8Content: """
                 @Article(time: 20) {
@@ -3121,7 +3123,7 @@ class ConvertActionTests: XCTestCase {
             $0.diagnostic.identifier == "org.swift.docc.MissingTableOfContents"
         }))
         
-        let tutorialTableOfContentProblem = try problemsFromConverting([
+        let tutorialTableOfContentProblem = try await problemsFromConverting([
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             TextFile(name: "table-of-contents.tutorial", utf8Content: """
                 """
@@ -3139,7 +3141,7 @@ class ConvertActionTests: XCTestCase {
             $0.diagnostic.identifier == "org.swift.docc.MissingTableOfContents"
         }))
         
-        let incompleteTutorialFile = try problemsFromConverting([
+        let incompleteTutorialFile = try await problemsFromConverting([
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             TextFile(name: "article.tutorial", utf8Content: """
                 @Chapter(name: "SlothCreator Essentials") {
@@ -3160,7 +3162,7 @@ class ConvertActionTests: XCTestCase {
         }))
     }
     
-    func testWrittenDiagnosticsAfterConvert() throws {
+    func testWrittenDiagnosticsAfterConvert() async throws {
         let bundle = Folder(name: "unit-test.docc", content: [
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             TextFile(name: "Documentation.md", utf8Content: """
@@ -3195,7 +3197,7 @@ class ConvertActionTests: XCTestCase {
             diagnosticEngine: engine
         )
         
-        let _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         XCTAssertEqual(engine.problems.count, 1)
         
         XCTAssert(FileManager.default.fileExists(atPath: diagnosticFile.path))
@@ -3211,7 +3213,7 @@ class ConvertActionTests: XCTestCase {
         XCTAssertEqual(logLines.filter { $0.hasPrefix("warning: No symbol matched 'ModuleThatDoesNotExist'. Can't resolve 'ModuleThatDoesNotExist'.") }.count, 1)
     }
     
-    func testEncodedImagePaths() throws {
+    func testEncodedImagePaths() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             TextFile(name: "Something.md", utf8Content: """
             # Something
@@ -3244,7 +3246,7 @@ class ConvertActionTests: XCTestCase {
             temporaryDirectory: fileSystem.uniqueTemporaryDirectory()
         )
         
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         XCTAssertEqual(result.outputs, [targetURL])
         
         XCTAssertEqual(fileSystem.dump(subHierarchyFrom: targetURL.path), """

--- a/Tests/SwiftDocCUtilitiesTests/EmitGeneratedCurationsActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/EmitGeneratedCurationsActionTests.swift
@@ -15,7 +15,7 @@ import SwiftDocCTestUtilities
 
 class EmitGeneratedCurationsActionTests: XCTestCase {
     
-    func testWritesDocumentationExtensionFilesToOutputDir() throws {
+    func testWritesDocumentationExtensionFilesToOutputDir() async throws {
         // This can't be in the test file system because `LocalFileSystemDataProvider` doesn't support `FileManagerProtocol`.
         let bundleURL = try XCTUnwrap(Bundle.module.url(forResource: "MixedLanguageFramework", withExtension: "docc", subdirectory: "Test Bundles"))
         
@@ -26,7 +26,7 @@ class EmitGeneratedCurationsActionTests: XCTestCase {
             expectedFilesList: [String],
             file: StaticString = #file,
             line: UInt = #line
-        ) throws {
+        ) async throws {
             let fs = try TestFileSystem(folders: [
                 Folder(name: "output", content: initialContent)
             ])
@@ -40,17 +40,17 @@ class EmitGeneratedCurationsActionTests: XCTestCase {
                 startingPointSymbolLink: startingPointSymbolLink,
                 fileManager: fs
             )
-            _ = try action.perform(logHandle: .none)
             
+            _ = try await action.perform(logHandle: .none)
             XCTAssertEqual(try fs.recursiveContentsOfDirectory(atPath: "/output").sorted(), expectedFilesList, file: file, line: line)
         }
         
-        try assertOutput(initialContent: [], depthLimit: 0, startingPointSymbolLink: nil, expectedFilesList: [
+        try await assertOutput(initialContent: [], depthLimit: 0, startingPointSymbolLink: nil, expectedFilesList: [
             "Output.doccarchive",
             "Output.doccarchive/MixedLanguageFramework.md",
         ])
         
-        try assertOutput(initialContent: [], depthLimit: nil, startingPointSymbolLink: nil, expectedFilesList: [
+        try await assertOutput(initialContent: [], depthLimit: nil, startingPointSymbolLink: nil, expectedFilesList: [
             "Output.doccarchive",
             "Output.doccarchive/MixedLanguageFramework",
             "Output.doccarchive/MixedLanguageFramework.md",
@@ -59,7 +59,7 @@ class EmitGeneratedCurationsActionTests: XCTestCase {
             "Output.doccarchive/MixedLanguageFramework/SwiftOnlyStruct.md",
         ])
         
-        try assertOutput(initialContent: [], depthLimit: nil, startingPointSymbolLink: "Foo-struct", expectedFilesList: [
+        try await assertOutput(initialContent: [], depthLimit: nil, startingPointSymbolLink: "Foo-struct", expectedFilesList: [
             "Output.doccarchive",
             "Output.doccarchive/MixedLanguageFramework",
             "Output.doccarchive/MixedLanguageFramework/Foo-swift.struct.md",

--- a/Tests/SwiftDocCUtilitiesTests/IndexActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/IndexActionTests.swift
@@ -17,7 +17,7 @@ import SwiftDocCTestUtilities
 
 class IndexActionTests: XCTestCase {
     #if !os(iOS)
-    func testIndexActionOutputIsDeterministic() throws {
+    func testIndexActionOutputIsDeterministic() async throws {
         // Convert a test bundle as input for the IndexAction
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
         
@@ -37,7 +37,7 @@ class IndexActionTests: XCTestCase {
             currentPlatforms: nil,
             temporaryDirectory: createTemporaryDirectory()
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         let bundleIdentifier = "org.swift.docc.example"
         
@@ -56,7 +56,7 @@ class IndexActionTests: XCTestCase {
                 bundleIdentifier: bundleIdentifier,
                 diagnosticEngine: engine
             )
-            _ = try indexAction.perform(logHandle: .none)
+            _ = try await indexAction.perform(logHandle: .none)
             
             let index = try NavigatorIndex.readNavigatorIndex(url: indexURL)
             
@@ -69,7 +69,7 @@ class IndexActionTests: XCTestCase {
     }
     #endif
     
-    func testIndexActionOutputContainsInterfaceLanguageContent() throws {
+    func testIndexActionOutputContainsInterfaceLanguageContent() async throws {
         // Convert a test bundle as input for the IndexAction
         let bundleURL = Bundle.module.url(
             forResource: "SingleArticleTestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
@@ -87,7 +87,7 @@ class IndexActionTests: XCTestCase {
             currentPlatforms: nil,
             temporaryDirectory: createTemporaryDirectory()
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         let bundleIdentifier = "org.swift.docc.example"
         let indexURL = targetURL.appendingPathComponent("index")
         let engine = DiagnosticEngine(filterLevel: .warning)
@@ -97,7 +97,7 @@ class IndexActionTests: XCTestCase {
             bundleIdentifier: bundleIdentifier,
             diagnosticEngine: engine
         )
-        let indexPerform = try indexAction.perform(logHandle: .none)
+        let indexPerform = try await indexAction.perform(logHandle: .none)
         let index = try NavigatorIndex.readNavigatorIndex(url: indexPerform.outputs[0])
         XCTAssertEqual(index.availabilityIndex.interfaceLanguages.count, 1)
     }

--- a/Tests/SwiftDocCUtilitiesTests/Init/InitActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Init/InitActionTests.swift
@@ -16,7 +16,7 @@ import SwiftDocCTestUtilities
 final class InitActionTests: XCTestCase {
     private let documentationTitle = "MyTestDocumentation"
     
-    func testInitActionCreatesArticleOnlyCatalog() throws {
+    func testInitActionCreatesArticleOnlyCatalog() async throws {
         let outputLocation = Folder(name: "output", content: [])
         let fileManager = try TestFileSystem(folders: [outputLocation])
         var action = try InitAction(
@@ -25,7 +25,7 @@ final class InitActionTests: XCTestCase {
             catalogTemplate: .articleOnly,
             fileManager: fileManager
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         // Test the content of the output folder is the expected one.
         let outputCatalogContent = try fileManager.contentsOfDirectory(atPath: result.outputs.first!.path).sorted()
         XCTAssertEqual(outputCatalogContent, [
@@ -34,7 +34,7 @@ final class InitActionTests: XCTestCase {
         ].sorted())
     }
     
-    func testInitActionCreatesTutorialCatalog() throws {
+    func testInitActionCreatesTutorialCatalog() async throws {
         let outputLocation = Folder(name: "output", content: [])
         let fileManager = try TestFileSystem(folders: [outputLocation])
         var action = try InitAction(
@@ -45,7 +45,7 @@ final class InitActionTests: XCTestCase {
             catalogTemplate: .tutorial,
             fileManager: fileManager
         )
-        let result = try action.perform(logHandle: .none)
+        let result = try await action.perform(logHandle: .none)
         // Test the content of the output folder is the expected one.
         let outputCatalogContent = try fileManager.recursiveContentsOfDirectory(atPath: result.outputs.first!.path).sorted()
         XCTAssertEqual(outputCatalogContent, [
@@ -57,7 +57,7 @@ final class InitActionTests: XCTestCase {
         ].sorted())
     }
     
-    func testArticleOnlyCatalogContent() throws {
+    func testArticleOnlyCatalogContent() async throws {
         let outputLocation = Folder(name: "output", content: [])
         let fileManager = try TestFileSystem(folders: [outputLocation])
         var action = try InitAction(
@@ -66,7 +66,7 @@ final class InitActionTests: XCTestCase {
             catalogTemplate: .articleOnly,
             fileManager: fileManager
         )
-        let _ = try action.perform(logHandle: .none)
+        let _ = try await action.perform(logHandle: .none)
         // Test the content of the articleOnly root template is the expected one.
         let rootFile = try XCTUnwrap(fileManager.contents(atPath: "/output/\(documentationTitle).docc/\(documentationTitle).md"))
         XCTAssertEqual(String(data: rootFile, encoding: .utf8), """
@@ -86,7 +86,7 @@ final class InitActionTests: XCTestCase {
         """)
     }
     
-    func testTutorialCatalogContent() throws {
+    func testTutorialCatalogContent() async throws {
         let outputLocation = Folder(name: "output", content: [])
         let fileManager = try TestFileSystem(folders: [outputLocation])
         var action = try InitAction(
@@ -95,7 +95,7 @@ final class InitActionTests: XCTestCase {
             catalogTemplate: .tutorial,
             fileManager: fileManager
         )
-        let _ = try action.perform(logHandle: .none)
+        let _ = try await action.perform(logHandle: .none)
         // Test the content of the articleOnly root template is the expected one.
         let tableOfContentFile = try XCTUnwrap(fileManager.contents(atPath: "/output/\(documentationTitle).docc/table-of-contents.tutorial"))
         let page01File = try XCTUnwrap(fileManager.contents(atPath: "/output/\(documentationTitle).docc/Chapter01/page-01.tutorial"))

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -23,7 +23,7 @@ class MergeActionTests: XCTestCase {
         )
     )
     
-    func testCopiesArchivesIntoOutputLocation() throws {
+    func testCopiesArchivesIntoOutputLocation() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -73,7 +73,7 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        _ = try action.perform(logHandle: .memory(logStorage))
+        _ = try await action.perform(logHandle: .memory(logStorage))
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
         
         // The combined archive as the data and assets from the input archives but only one set of archive template files
@@ -175,7 +175,7 @@ class MergeActionTests: XCTestCase {
         ])
     }
     
-    func testCreatesDataDirectoryWhenMergingSingleEmptyArchive() throws {
+    func testCreatesDataDirectoryWhenMergingSingleEmptyArchive() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -201,7 +201,7 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        _ = try action.perform(logHandle: .memory(logStorage))
+        _ = try await action.perform(logHandle: .memory(logStorage))
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
         
         
@@ -250,7 +250,7 @@ class MergeActionTests: XCTestCase {
         """)
     }
     
-    func testCanMergeReferenceOnlyArchiveWithTutorialOnlyArchive() throws {
+    func testCanMergeReferenceOnlyArchiveWithTutorialOnlyArchive() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -292,7 +292,7 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        _ = try action.perform(logHandle: .memory(logStorage))
+        _ = try await action.perform(logHandle: .memory(logStorage))
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
         
         // The combined archive as the data, documentation, tutorials, and assets from the both input archives.
@@ -369,7 +369,7 @@ class MergeActionTests: XCTestCase {
         ])
     }
     
-    func testCanMergeReferenceOnlyArchiveWithTutorialOnlyArchiveWithoutStaticHosting() throws {
+    func testCanMergeReferenceOnlyArchiveWithTutorialOnlyArchiveWithoutStaticHosting() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -413,7 +413,7 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        _ = try action.perform(logHandle: .memory(logStorage))
+        _ = try await action.perform(logHandle: .memory(logStorage))
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
         
         // The combined archive doesn't have "documentation" or "tutorial" directories because the inputs didn't support static hosting.
@@ -476,7 +476,7 @@ class MergeActionTests: XCTestCase {
         ])
     }
     
-    func testSupportsArchivesWithoutStaticHosting() throws {
+    func testSupportsArchivesWithoutStaticHosting() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -528,7 +528,7 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        _ = try action.perform(logHandle: .memory(logStorage))
+        _ = try await action.perform(logHandle: .memory(logStorage))
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
         
         // The combined archive doesn't have "documentation" or "tutorial" directories because the inputs didn't support static hosting.
@@ -604,7 +604,7 @@ class MergeActionTests: XCTestCase {
         ])
     }
     
-    func testReferenceOnlyArchivesDoNotSynthesizeTutorialsTopicSection() throws {
+    func testReferenceOnlyArchivesDoNotSynthesizeTutorialsTopicSection() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -642,7 +642,7 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        _ = try action.perform(logHandle: .memory(logStorage))
+        _ = try await action.perform(logHandle: .memory(logStorage))
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
         
         let synthesizedRootNode = try fileSystem.renderNode(atPath: "/Output.doccarchive/data/documentation.json")
@@ -660,7 +660,7 @@ class MergeActionTests: XCTestCase {
         ])
     }
     
-    func testErrorWhenArchivesContainOverlappingData() throws {
+    func testErrorWhenArchivesContainOverlappingData() async throws {
         let fileSystem = try TestFileSystem(
             folders: [
                 Folder(name: "Output.doccarchive", content: []),
@@ -724,7 +724,10 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        XCTAssertThrowsError(try action.perform(logHandle: LogHandle.memory(logStorage))) { error in
+        do {
+            _ = try await action.perform(logHandle: LogHandle.memory(logStorage))
+            XCTFail("The action didn't raise an error")
+        } catch {
             XCTAssertEqual(error.localizedDescription, """
             Input archives contain overlapping data
 
@@ -738,7 +741,7 @@ class MergeActionTests: XCTestCase {
         XCTAssertEqual(fileSystem.dump(subHierarchyFrom: "/Output.doccarchive"), "Output.doccarchive/", "Nothing was written to the output directory")
     }
     
-    func testErrorWhenOutputDirectoryIsNotEmpty() throws {
+    func testErrorWhenOutputDirectoryIsNotEmpty() async throws {
         let fileSystem = try TestFileSystem(folders: [
             Self.makeArchive(name: "Output", documentationPages: [
                 "Something",
@@ -762,7 +765,10 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        XCTAssertThrowsError(try action.perform(logHandle: LogHandle.memory(logStorage))) { error in
+        do {
+            _ = try await action.perform(logHandle: LogHandle.memory(logStorage))
+            XCTFail("The action didn't raise an error")
+        } catch {
             XCTAssertEqual(error.localizedDescription, """
             Output directory is not empty. It contains:
              - css/
@@ -776,7 +782,7 @@ class MergeActionTests: XCTestCase {
         XCTAssertEqual(logStorage.text, "", "The action didn't log anything")
     }
     
-    func testErrorWhenSomeArchivesDoNotSupportStaticHosting() throws {
+    func testErrorWhenSomeArchivesDoNotSupportStaticHosting() async throws {
         let fileSystem = try TestFileSystem(folders: [
             Self.makeArchive(
                 name: "First",
@@ -824,7 +830,10 @@ class MergeActionTests: XCTestCase {
             fileManager: fileSystem
         )
         
-        XCTAssertThrowsError(try action.perform(logHandle: LogHandle.memory(logStorage))) { error in
+        do {
+            _ = try await action.perform(logHandle: LogHandle.memory(logStorage))
+            XCTFail("The action didn't raise an error")
+        } catch {
             XCTAssertEqual(error.localizedDescription, """
             Different static hosting support in different archives.
 

--- a/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -355,7 +355,6 @@ class PreviewActionIntegrationTests: XCTestCase {
         
         let logStorage = LogHandle.LogStorage()
         
-        var logHandle = LogHandle.memory(logStorage)
         let convertActionTempDirectory = try createTemporaryDirectory()
         let createConvertAction = {
             try ConvertAction(
@@ -384,6 +383,7 @@ class PreviewActionIntegrationTests: XCTestCase {
 
             // Start the preview and keep it running for the asserts that follow inside this test.
             Task {
+                var logHandle = LogHandle.memory(logStorage)
                 _ = try await preview.perform(logHandle: &logHandle)
             }
 
@@ -416,9 +416,6 @@ class PreviewActionIntegrationTests: XCTestCase {
         // Source files.
         let (sourceURL, outputURL, templateURL) = try createPreviewSetup(source: createMinimalDocsBundle())
         
-        let logStorage = LogHandle.LogStorage()
-        var logHandle = LogHandle.memory(logStorage)
-
         var convertFuture: () -> Void = {}
         
         let convertActionTempDirectory = try createTemporaryDirectory()
@@ -453,13 +450,14 @@ class PreviewActionIntegrationTests: XCTestCase {
         
         // Start watching the source and get the initial (successful) state.
         do {
+            let logStorage = LogHandle.LogStorage()
             let logOutputExpectation = asyncLogExpectation(log: logStorage, description: "Did produce log output") { $0.contains("=======") }
             
             // Start the preview and keep it running for the asserts that follow inside this test.
 
             Task {
-                var action = preview as AsyncAction
-                let result = try await action.perform(logHandle: &logHandle)
+                var logHandle = LogHandle.memory(logStorage)
+                let result = try await preview.perform(logHandle: &logHandle)
 
                 guard !result.problems.containsErrors else {
                     throw ErrorsEncountered()

--- a/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
@@ -17,7 +17,7 @@ import SwiftDocCTestUtilities
 class StaticHostableTransformerTests: StaticHostingBaseTests {
 
     /// Creates a DocC archive and then archive then executes and TransformForStaticHostingAction on it to produce static content which is then validated.
-    func testStaticHostableTransformerOutput() throws {
+    func testStaticHostableTransformerOutput() async throws {
         
         // Convert a test bundle as input for the StaticHostableTransformer
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
@@ -42,8 +42,8 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
             currentPlatforms: nil,
             temporaryDirectory: createTemporaryDirectory()
         )
-        _ = try action.perform(logHandle: .none)
         
+        _ = try await action.perform(logHandle: .none)
         let outputURL = try createTemporaryDirectory().appendingPathComponent("output")
 
         let testTemplateURL = try createTemporaryDirectory().appendingPathComponent("testTemplate")
@@ -121,7 +121,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
         }
     }
     
-    func testStaticHostableTransformerIndexHTMLOutput() throws {
+    func testStaticHostableTransformerIndexHTMLOutput() async throws {
         // Convert a test bundle as input for the StaticHostableTransformer
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
 
@@ -141,7 +141,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
             currentPlatforms: nil,
             temporaryDirectory: createTemporaryDirectory()
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
 
         let dataURL = targetBundleURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
         let dataProvider = try LocalFileSystemDataProvider(rootURL: dataURL)

--- a/Tests/SwiftDocCUtilitiesTests/TransformForStaticHostingActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/TransformForStaticHostingActionTests.swift
@@ -17,7 +17,7 @@ import SwiftDocCTestUtilities
 class TransformForStaticHostingActionTests: StaticHostingBaseTests {
 
     /// Creates a DocC archive and then archive then executes and TransformForStaticHostingAction on it to produce static content which is then validated.
-    func testTransformForStaticHostingTestExternalOutput() throws {
+    func testTransformForStaticHostingTestExternalOutput() async throws {
         
         // Convert a test bundle as input for the TransformForStaticHostingAction
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
@@ -38,7 +38,7 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
             currentPlatforms: nil,
             temporaryDirectory: try createTemporaryDirectory()
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
         let outputURL = try createTemporaryDirectory()//.appendingPathComponent("output")
     
@@ -52,8 +52,8 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
 
         var transformAction = try TransformForStaticHostingAction(documentationBundleURL: targetBundleURL, outputURL: outputURL, hostingBasePath: basePath, htmlTemplateDirectory: testTemplateURL)
         
-        _ = try transformAction.perform(logHandle: .none)
         
+        _ = try await transformAction.perform(logHandle: .none)
         let fileManager = FileManager.default
         var isDirectory: ObjCBool = false
         
@@ -97,7 +97,7 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
     
     
     // Creates a DocC archive and then archive then executes and TransformForStaticHostingAction on it to produce static content which is then validated.
-    func testTransformForStaticHostingActionTestInPlaceOutput() throws {
+    func testTransformForStaticHostingActionTestInPlaceOutput() async throws {
         
         // Convert a test bundle as input for the TransformForStaticHostingAction
         let bundleURL = Bundle.module.url(forResource: "TestBundle", withExtension: "docc", subdirectory: "Test Bundles")!
@@ -122,9 +122,8 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
             currentPlatforms: nil,
             temporaryDirectory: try createTemporaryDirectory()
         )
-        _ = try action.perform(logHandle: .none)
+        _ = try await action.perform(logHandle: .none)
         
-      
         let basePath =  "test/folder"
         let testTemplateURL = try createTemporaryDirectory().appendingPathComponent("testTemplate")
         let templateFolder = Folder.testHTMLTemplateDirectory
@@ -135,7 +134,7 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
 
         var transformAction = try TransformForStaticHostingAction(documentationBundleURL: targetBundleURL, outputURL: nil, hostingBasePath: basePath, htmlTemplateDirectory: testTemplateURL)
         
-        _ = try transformAction.perform(logHandle: .none)
+        _ = try await transformAction.perform(logHandle: .none)
         
         var isDirectory: ObjCBool = false
         


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This is the _third_ of many changes to redefine how documentation contexts are created.

This redefined the various commands to be asynchronous so that preview action cancellation, documentation converter cancellation, and context registration cancellation can use `Task.checkCancellation()` instead of [sharing a Boolean wrapped in a class](https://github.com/swiftlang/swift-docc/pull/1049/files#diff-97d66b3827022e24c102721c9f84a35bb2f5e081d80e8804cf5773dbeb8f0663L101-L102) and [polling for cancellation on a timer](https://github.com/swiftlang/swift-docc/pull/1049/files#diff-97d66b3827022e24c102721c9f84a35bb2f5e081d80e8804cf5773dbeb8f0663L210-L223).

This change also supports cancelling context registration during initialization, which enables us to move away from deferred context registration in a follow up PR.

## Dependencies

This builds on top of https://github.com/swiftlang/swift-docc/pull/1052

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
