### PR TITLE
Always set role even if automatic role headings are disabled

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -729,11 +729,10 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         node.topicSectionsStyle = topicsSectionStyle(for: documentationNode)
         
+        let role = DocumentationContentRenderer.roleForArticle(article, nodeKind: documentationNode.kind)
+        node.metadata.role = role.rawValue
+
         if shouldCreateAutomaticRoleHeading(for: documentationNode) {
-            
-            let role = DocumentationContentRenderer.roleForArticle(article, nodeKind: documentationNode.kind)
-            node.metadata.role = role.rawValue
-            
             switch role {
             case .article:
                 // If there are no links to other nodes from the article,


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://128609308.

## Summary

Fixes a bug where disabling automatic role headings with directive `@AutomaticTitleHeading` would also result in the node's role being lost.

We always want to set the node's role as part of the node's metadata, regardless of any title settings. Some unit tests were added to ensure that the interaction between `AutomaticTitleHeading`, `.metadata.roleHeading` and `.metadata.role` is all working as expected.

### Bug

For any API Collection render node, its metadata will look like:
```json
    "metadata": {
        "title": "API Collection",
        "role": "collectionGroup",
        "modules": [
            {
                "name": "AutomaticTitleHeading"
            }
        ],
        "roleHeading": "API Collection"
    },
```

The role heading is used for rendering, and can be disabled via directive `@AutomaticTitleHeading`. In `main`, disabling the role heading also unintentionally removes the role:
```json
     "metadata": {
        "title": "API Collection",
        "modules": [
            {
                "name": "AutomaticTitleHeading"
            }
        ]
    },
```

The desired behaviour is:
```json
    "metadata": {
        "title": "API Collection",
        "modules": [
            {
                "name": "AutomaticTitleHeading"
            }
        ],
        "role": "collectionGroup"
    },
```

### Additional notes

We still want the role heading to be set if it has been overridden with `@TitleHeading`, regardless of the value of `@AutomaticTitleHeading`. Only automatic title headings should be disabled, not manually curated ones.
The same applies for `@PageKind`, which manually overrides the role and role heading.

## Dependencies

N/A.

## Testing

[AutomaticTitleHeading.docc.zip](https://github.com/user-attachments/files/17310437/AutomaticTitleHeading.docc.zip)

Steps:
1. Preview or convert the DocC bundle attached above.
2. Verify that the rendered JSON for `APICollection.md` contains `role` within its metadata, but **not** a role heading:
```json
    "metadata": {
        "title": "API Collection",
        "modules": [
            {
                "name": "AutomaticTitleHeading"
            }
        ],
        "role": "collectionGroup"
    },
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- N/A ~~[ ] Updated documentation if necessary~~
