### PR TITLE
Remove unused code in preview server and directory monitor

### DIFF
--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewHTTPHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewHTTPHandler.swift
@@ -51,16 +51,10 @@ final class PreviewHTTPHandler: ChannelInboundHandler {
     private var keepAlive = false
     private let rootURL: URL
 
-    private var handlerFuture: EventLoopFuture<Void>?
-    private let fileIO: NonBlockingFileIO
-
     /// - Parameters:
-    ///   - fileIO: Async file I/O.
     ///   - rootURL: The root of the content directory to serve.
-    ///   - credentials: Optional user credentials to authorize incoming requests.
-    init(fileIO: NonBlockingFileIO, rootURL: URL) {
+    init(rootURL: URL) {
         self.rootURL = rootURL
-        self.fileIO = fileIO
     }
     
     /// Handles incoming data on a channel.
@@ -79,7 +73,7 @@ final class PreviewHTTPHandler: ChannelInboundHandler {
             let handler: RequestHandlerFactory
             if FileRequestHandler.isAssetPath(head.uri) {
                 // Serve a static asset file.
-                handler = FileRequestHandler(rootURL: rootURL, fileIO: fileIO)
+                handler = FileRequestHandler(rootURL: rootURL)
             } else {
                 // Serve the fallback index file.
                 handler = DefaultRequestHandler(rootURL: rootURL)

--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewServer.swift
@@ -118,7 +118,6 @@ final class PreviewServer {
     ///   to its destination but before it has started serving content.
     func start(onReady: (() -> Void)? = nil) throws {
         // Create a server bootstrap
-        let fileIO = NonBlockingFileIO(threadPool: threadPool)
         bootstrap = ServerBootstrap(group: group)
             // Learn more about the `listen` command pending clients backlog from its reference;
             // do that by typing `man 2 listen` on your command line.
@@ -130,7 +129,7 @@ final class PreviewServer {
             .childChannelInitializer { channel in
                 // HTTP pipeline
                 return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-                    channel.pipeline.addHandler(PreviewHTTPHandler(fileIO: fileIO, rootURL: self.contentURL))
+                    channel.pipeline.addHandler(PreviewHTTPHandler(rootURL: self.contentURL))
                 }
             }
             

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
@@ -12,7 +12,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import SwiftDocC
 
 fileprivate extension String {
     var fileExtension: String {
@@ -54,7 +53,6 @@ struct RangeHeader {
 /// A response handler that serves asset files.
 struct FileRequestHandler: RequestHandlerFactory {
     let rootURL: URL
-    let fileIO: NonBlockingFileIO
 
     /// Metadata that pairs file paths with content mime types.
     struct AssetFileMetadata {

--- a/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
+++ b/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
@@ -59,8 +59,6 @@ class DirectoryMonitor {
     
     /// An observed directory structure including the file handler and dispatch source.
     private struct WatchedDirectory {
-        let url: URL
-        let fileDescriptor: Int32
         let sources: [DispatchSourceFileSystemObject]
     }
     
@@ -204,9 +202,9 @@ class DirectoryMonitor {
     /// Provided a URL and a monitor queue, returns a `WatchedDirectory` with event handling hooked up.
     private func watchedDirectory(at url: URL, files: [URL], on queue: DispatchQueue) throws -> WatchedDirectory {
         let watched = try watch(url: url, for: .all, on: queue)
-        return try WatchedDirectory(url: url, 
-            fileDescriptor: watched.descriptor, 
-            sources: [watched.source] + files.map { try watch(url: $0, for: .write, on: queue).source } )
+        return try WatchedDirectory(
+            sources: [watched.source] + files.map { try watch(url: $0, for: .write, on: queue).source }
+        )
     }
     
     /// Start monitoring the root directory and its contents.

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
@@ -19,8 +19,6 @@ import NIO
 import NIOHTTP1
 
 class PreviewHTTPHandlerTests: XCTestCase {
-    let fileIO = NonBlockingFileIO(threadPool: NIOThreadPool(numberOfThreads: 2))
-
     /// Tests the three different responses we offer: static file, default, and error.
     func testPreviewHandler() throws {
         let tempFolderURL = try createTempFolder(content: [
@@ -31,7 +29,7 @@ class PreviewHTTPHandlerTests: XCTestCase {
         ])
 
         let channel = EmbeddedChannel()
-        let channelHandler = PreviewHTTPHandler(fileIO: fileIO, rootURL: tempFolderURL)
+        let channelHandler = PreviewHTTPHandler(rootURL: tempFolderURL)
 
         let response = Response()
         

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -23,7 +23,7 @@ class FileRequestHandlerTests: XCTestCase {
 
     private func verifyAsset(root: URL, path: String, body: String, type: String, file: StaticString = #file, line: UInt = #line) throws {
         let request = makeRequestHead(uri: path)
-        let factory = FileRequestHandler(rootURL: root, fileIO: fileIO)
+        let factory = FileRequestHandler(rootURL: root)
         let response = try responseWithPipeline(request: request, handler: factory)
         
         XCTAssertEqual(response.head?.status, .ok, file: (file), line: line)
@@ -97,7 +97,7 @@ class FileRequestHandlerTests: XCTestCase {
         let tempFolderURL = try createTempFolder(content: [])
 
         let request = makeRequestHead(uri: "/css/b00011100.css")
-        let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
+        let factory = FileRequestHandler(rootURL: tempFolderURL)
         let response = try responseWithPipeline(request: request, handler: factory)
         
         XCTAssertEqual(response.requestError?.status, .notFound)
@@ -111,7 +111,7 @@ class FileRequestHandlerTests: XCTestCase {
         ])
 
         let request = makeRequestHead(uri: "/videos/video.mov", headers: [("Range", "bytes=0-1")])
-        let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
+        let factory = FileRequestHandler(rootURL: tempFolderURL)
         let response = try responseWithPipeline(request: request, handler: factory)
         
         XCTAssertEqual(response.body, "He")
@@ -130,7 +130,7 @@ class FileRequestHandlerTests: XCTestCase {
         ])
 
         let request = makeRequestHead(uri: "/videos/../video.mov", headers: [("Range", "bytes=0-1")])
-        let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
+        let factory = FileRequestHandler(rootURL: tempFolderURL)
         let response = try responseWithPipeline(request: request, handler: factory)
         
         XCTAssertNil(response.body, "He")
@@ -145,7 +145,7 @@ class FileRequestHandlerTests: XCTestCase {
         ])
 
         let request = makeRequestHead(uri: "https://invalid host.com", headers: [("Range", "bytes=0-1")])
-        let factory = FileRequestHandler(rootURL: tempFolderURL, fileIO: fileIO)
+        let factory = FileRequestHandler(rootURL: tempFolderURL)
         let response = try responseWithPipeline(request: request, handler: factory)
         
         XCTAssertNil(response.body, "He")


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This removes some unused properties and an unused function in the preview server and some unused properties in the directory monitor.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
