### PR TITLE
Remove a few redundant conformance implementations

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
@@ -331,11 +331,7 @@ extension Platform.Version: CustomStringConvertible, Equatable, Comparable, Coda
         return "\(majorVersion).\(minorVersion)"
     }
     
-    // MARK: - Equatable and Comparable
-    
-    public static func == (lhs: Platform.Version, rhs: Platform.Version) -> Bool {
-        return lhs.majorVersion == rhs.majorVersion && lhs.minorVersion == rhs.minorVersion && lhs.patchVersion == rhs.patchVersion
-    }
+    // MARK: Comparable
     
     public static func < (lhs: Platform.Version, rhs: Platform.Version) -> Bool {
         if lhs.majorVersion != rhs.majorVersion { return lhs.majorVersion < rhs.majorVersion }

--- a/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
@@ -340,30 +340,6 @@ extension Platform.Version: CustomStringConvertible, Equatable, Comparable, Coda
         return false // Equals, so return false.
     }
     
-    
-    // MARK: Codable
-    
-    enum CodingKeys: String, CodingKey {
-        case majorVersion
-        case minorVersion
-        case patchVersion
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        let majorVersion = try values.decode(Int.self, forKey: .majorVersion)
-        let minorVersion = try values.decode(Int.self, forKey: .minorVersion)
-        let patchVersion = try values.decode(Int.self, forKey: .patchVersion)
-        self.init(majorVersion: majorVersion, minorVersion: minorVersion, patchVersion: patchVersion)
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(majorVersion, forKey: .majorVersion)
-        try container.encode(minorVersion, forKey: .minorVersion)
-        try container.encode(patchVersion, forKey: .patchVersion)
-    }
-    
     // MARK: UInt32 version encoding
     public init(uint32: UInt32) {
         var representation = uint32

--- a/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/AvailabilityIndex+Ext.swift
@@ -344,13 +344,6 @@ extension Platform.Version: CustomStringConvertible, Equatable, Comparable, Coda
         return false // Equals, so return false.
     }
     
-    // MARK: Hashable
-    
-    public func hash(into hasher: inout Hasher) {
-      hasher.combine(majorVersion)
-      hasher.combine(minorVersion)
-      hasher.combine(patchVersion)
-    }
     
     // MARK: Codable
     

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -151,16 +151,6 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
         return data
     }
     
-    // MARK: - Equatable
-    
-    public static func == (lhs: NavigatorItem, rhs: NavigatorItem) -> Bool {
-        return lhs.pageType == rhs.pageType &&
-            lhs.languageID == rhs.languageID &&
-            lhs.title == rhs.title &&
-            lhs.platformMask == rhs.platformMask &&
-            lhs.availabilityID == rhs.availabilityID
-    }
-    
     // MARK: - Description
     
     public var description: String {

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -161,16 +161,6 @@ public final class NavigatorItem: Serializable, Codable, Equatable, CustomString
             lhs.availabilityID == rhs.availabilityID
     }
     
-    // MARK: - Hasher
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(pageType)
-        hasher.combine(languageID)
-        hasher.combine(title)
-        hasher.combine(platformMask)
-        hasher.combine(availabilityID)
-    }
-    
     // MARK: - Description
     
     public var description: String {

--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
@@ -354,9 +354,4 @@ public struct AssetReference: Hashable, Codable {
         self.assetName = assetName
         self.bundleIdentifier = bundleIdentifier
     }
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(assetName)
-        hasher.combine(bundleIdentifier)
-    }
 }

--- a/Sources/SwiftDocC/Model/Name.swift
+++ b/Sources/SwiftDocC/Model/Name.swift
@@ -22,15 +22,6 @@ extension DocumentationNode {
         /// The name of the symbol.
         case symbol(name: String)
         
-        public func hash(into hasher: inout Hasher) {
-            switch self {
-            case .conceptual(let text):
-                hasher.combine(text)
-            case .symbol(let name):
-                hasher.combine(name)
-            }
-        }
-        
         public var description: String {
             switch self {
             case .conceptual(let title):

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -91,12 +91,6 @@ public struct DownloadReference: RenderReference, URLReference, Equatable {
             try container.encode(url, forKey: .url)
         }
     }
-
-    static public func ==(lhs: DownloadReference, rhs: DownloadReference) -> Bool {
-        lhs.identifier == rhs.identifier
-        && lhs.url == rhs.url
-        && lhs.checksum == rhs.checksum
-    }
 }
 
 extension DownloadReference {

--- a/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Variant.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/VariantCollection+Variant.swift
@@ -41,8 +41,4 @@ public extension VariantCollection {
     }
 }
 
-extension VariantCollection.Variant: Equatable where Value: Equatable {
-    public static func == (lhs: VariantCollection<Value>.Variant, rhs: VariantCollection<Value>.Variant) -> Bool {
-        return lhs.traits == rhs.traits && lhs.patch == rhs.patch
-    }
-}
+extension VariantCollection.Variant: Equatable where Value: Equatable {}


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes a few redundant `Hashable`, `Equatable`, and `Codable` conformance implementations where the synthesized implementation behaves the same. 

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
