### PR TITLE
Add a precondition for declaring a node as beta.

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -211,7 +211,7 @@ public class DocumentationContentRenderer {
         guard let symbol = node.semantic as? Symbol,
               let currentPlatforms = documentationContext.configuration.externalMetadata.currentPlatforms,
               !currentPlatforms.isEmpty,
-              let symbolAvailability = symbol.availability?.availability
+              let symbolAvailability = symbol.availability?.availability,
               !symbolAvailability.isEmpty // A symbol without availability items can't be in beta.
         else { return false }
 

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -212,12 +212,8 @@ public class DocumentationContentRenderer {
               let currentPlatforms = documentationContext.configuration.externalMetadata.currentPlatforms,
               !currentPlatforms.isEmpty,
               let symbolAvailability = symbol.availability?.availability
+              !symbolAvailability.isEmpty // A symbol without availability items can't be in beta.
         else { return false }
-        
-        // If the symbol does not have any availability item it can't be `beta`.
-        guard !symbolAvailability.isEmpty else {
-            return false
-        }
 
         // Verify that if current platforms are in beta, they match the introduced version of the symbol
         for availability in symbolAvailability {

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -211,11 +211,16 @@ public class DocumentationContentRenderer {
         guard let symbol = node.semantic as? Symbol,
               let currentPlatforms = documentationContext.configuration.externalMetadata.currentPlatforms,
               !currentPlatforms.isEmpty,
-              let symbolAvailability = symbol.availability
+              let symbolAvailability = symbol.availability?.availability
         else { return false }
+        
+        // If the symbol does not have any availability item it can't be `beta`.
+        guard !symbolAvailability.isEmpty else {
+            return false
+        }
 
         // Verify that if current platforms are in beta, they match the introduced version of the symbol
-        for availability in symbolAvailability.availability {
+        for availability in symbolAvailability {
             // If not available on this platform, skip to next platform.
             guard !availability.isUnconditionallyUnavailable, let introduced = availability.introducedVersion else {
                 continue

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1922,6 +1922,22 @@ Document
             XCTAssertEqual(renderNode.metadata.platforms?.first?.isBeta, false)
         }
         
+        // Symbol with an empty set of availbility items.
+        
+        do {
+            
+            let (bundle, context, _) = try makeTestBundle(currentPlatforms: [
+                "Custom Name": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
+            ])
+            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+            (node.semantic as? Symbol)?.availability = SymbolGraph.Symbol.Availability(availability: [])
+            let documentationContentRendered = DocumentationContentRenderer(documentationContext: context, bundle: bundle)
+            let isBeta = documentationContentRendered.isBeta(node)
+            // Verify that the symbol is not beta since it does not contains availability info.
+            XCTAssertFalse(isBeta)
+        }
+        
         // Different platform is beta
         do {
             let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1926,10 +1926,9 @@ Document
         
         do {
             
-            let (bundle, context, _) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
                 "Custom Name": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
             ])
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             (node.semantic as? Symbol)?.availability = SymbolGraph.Symbol.Availability(availability: [])
             let documentationContentRendered = DocumentationContentRenderer(documentationContext: context, bundle: bundle)


### PR DESCRIPTION

<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable:  rdar://137762221
 
## Summary

A node can only be declared as beta if it contains at least one availability item that includes all the defined characteristics. This code introduces a precondition requiring the node to have at least one availability item to be considered as potentially in beta.

Before this change, a node would be considered as beta when its availability set was empty.

## Dependencies

N/A

## Testing

Review unit tests.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
