### PR TITLE
Add support for custom scripts

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -91,6 +91,10 @@ public struct DocumentationBundle {
 
     /// A custom JSON settings file used to theme renderer output.
     public let themeSettings: URL?
+    
+    /// A custom JSON settings file used to add custom scripts to the renderer output.
+    public let customScripts: URL?
+
     /// A URL prefix to be appended to the relative presentation URL.
     ///
     /// This is used when a built documentation is hosted in a known location.
@@ -107,6 +111,7 @@ public struct DocumentationBundle {
     ///   - customHeader: A custom HTML file to use as the header for rendered output.
     ///   - customFooter: A custom HTML file to use as the footer for rendered output.
     ///   - themeSettings: A custom JSON settings file used to theme renderer output.
+    ///   - customScripts: A custom JSON settings file used to add custom scripts to the renderer output.
     public init(
         info: Info,
         baseURL: URL = URL(string: "/")!,
@@ -115,7 +120,8 @@ public struct DocumentationBundle {
         miscResourceURLs: [URL],
         customHeader: URL? = nil,
         customFooter: URL? = nil,
-        themeSettings: URL? = nil
+        themeSettings: URL? = nil,
+        customScripts: URL? = nil
     ) {
         self.info = info
         self.baseURL = baseURL
@@ -125,6 +131,7 @@ public struct DocumentationBundle {
         self.customHeader = customHeader
         self.customFooter = customFooter
         self.themeSettings = themeSettings
+        self.customScripts = customScripts
         self.rootReference = ResolvedTopicReference(bundleID: info.id, path: "/", sourceLanguage: .swift)
         self.documentationRootReference = ResolvedTopicReference(bundleID: info.id, path: NodeURLGenerator.Path.documentationFolder, sourceLanguage: .swift)
         self.tutorialTableOfContentsContainer = ResolvedTopicReference(bundleID: info.id, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundleFileTypes.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundleFileTypes.swift
@@ -84,4 +84,12 @@ public enum DocumentationBundleFileTypes {
     public static func isThemeSettingsFile(_ url: URL) -> Bool {
         return url.lastPathComponent == themeSettingsFileName
     }
+    
+    private static let customScriptsFileName = "custom-scripts.json"
+    /// Checks if a file is `custom-scripts.json`.
+    /// - Parameter url: The file to check.
+    /// - Returns: Whether or not the file at `url` is `custom-scripts.json`.
+    public static func isCustomScriptsFile(_ url: URL) -> Bool {
+        return url.lastPathComponent == customScriptsFileName
+    }
 }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1584,6 +1584,7 @@ public class DocumentationContext {
     
     private static let supportedImageExtensions: Set<String> = ["png", "jpg", "jpeg", "svg", "gif"]
     private static let supportedVideoExtensions: Set<String> = ["mov", "mp4"]
+    private static let supportedScriptExtensions: Set<String> = ["js"]
 
     // TODO: Move this functionality to ``DocumentationBundleFileTypes`` (rdar://68156425).
     
@@ -1662,6 +1663,14 @@ public class DocumentationContext {
     /// - Returns: A list of all the download assets for the given bundle.
     public func registeredDownloadsAssets(for bundleID: DocumentationBundle.Identifier) -> [DataAsset] {
         registeredAssets(inContexts: [DataAsset.Context.download], forBundleID: bundleID)
+    }
+
+    /// Returns a list of all the custom scripts that registered for a given `bundleID`.
+    ///
+    /// - Parameter bundleID: The identifier of the bundle to return custom scripts for.
+    /// - Returns: A list of all the custom scripts for the given bundle.
+    public func registeredCustomScripts(for bundleID: DocumentationBundle.Identifier) -> [DataAsset] {
+        return registeredAssets(withExtensions: DocumentationContext.supportedScriptExtensions, forBundleID: bundleID)
     }
     
     typealias Articles = [DocumentationContext.SemanticResult<Article>]

--- a/Sources/SwiftDocC/Infrastructure/Input Discovery/DocumentationInputsProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Input Discovery/DocumentationInputsProvider.swift
@@ -25,6 +25,7 @@ extension DocumentationContext {
     ///  ``DocumentationBundle/symbolGraphURLs``  | ``DocumentationBundleFileTypes/isSymbolGraphFile(_:)``
     ///  ``DocumentationBundle/info``             | ``DocumentationBundleFileTypes/isInfoPlistFile(_:)``
     ///  ``DocumentationBundle/themeSettings``    | ``DocumentationBundleFileTypes/isThemeSettingsFile(_:)``
+    ///  ``DocumentationBundle/customScripts``    | ``DocumentationBundleFileTypes/isCustomScriptsFile(_:)``
     ///  ``DocumentationBundle/customHeader``     | ``DocumentationBundleFileTypes/isCustomHeader(_:)``
     ///  ``DocumentationBundle/customFooter``     | ``DocumentationBundleFileTypes/isCustomFooter(_:)``
     ///  ``DocumentationBundle/miscResourceURLs`` | Any file not already matched above.
@@ -165,7 +166,8 @@ extension DocumentationContext.InputsProvider {
             miscResourceURLs: foundContents.resources,
             customHeader:  shallowContent.first(where: FileTypes.isCustomHeader),
             customFooter:  shallowContent.first(where: FileTypes.isCustomFooter),
-            themeSettings: shallowContent.first(where: FileTypes.isThemeSettingsFile)
+            themeSettings: shallowContent.first(where: FileTypes.isThemeSettingsFile),
+            customScripts: shallowContent.first(where: FileTypes.isCustomScriptsFile)
         )
     }
 

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/CustomScripts.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/CustomScripts.spec.json
@@ -1,0 +1,98 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Custom Scripts",
+        "description": "This spec describes the permissible contents of a custom-scripts.json file in a documentation catalog, which is used to add custom scripts to a DocC-generated website.",
+        "version": "0.0.1"
+    },
+    "paths": {},
+    "components": {
+        "schemas": {
+            "Scripts": {
+                "type": "array",
+                "description": "An array of custom scripts, which is the top-level container in a custom-scripts.json file.",
+                "items": {
+                    "oneOf": [
+                        { "$ref": "#/components/schemas/ExternalScript" },
+                        { "$ref": "#/components/schemas/LocalScript" },
+                        { "$ref": "#/components/schemas/InlineScript" }
+                    ]
+                }
+            },
+            "Script": {
+                "type": "object",
+                "description": "An abstract schema representing any script, from which all three script types inherit.",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "The `type` attribute of the HTML script element."
+                    },
+                    "run": {
+                        "type": "string",
+                        "enum": ["on-load", "on-navigate", "on-load-and-navigate"],
+                        "description": "Whether the custom script should be run only on the initial page load, each time the reader navigates after the initial page load, or both."
+                    }
+                }
+            },
+            "ScriptFromFile": {
+                "description": "An abstract schema representing a script from an external or local file; that is, not an inline script.",
+                "allOf": [
+                    { "$ref": "#/components/schemas/Script" },
+                    {
+                        "properties": {
+                            "async": { "type": "boolean" },
+                            "defer": { "type": "boolean" }
+                        }
+                    }
+                ]
+            },
+            "ExternalScript": {
+                "description": "A script at an external URL.",
+                "allOf": [
+                    { "$ref": "#/components/schemas/ScriptFromFile" },
+                    {
+                        "required": ["url"],
+                        "properties": {
+                            "url": { "type": "string" },
+                            "integrity": { "type": "string" }
+                        }
+                    }
+                ]
+            },
+            "LocalScript": {
+                "description": "A script from a local file.",
+                "allOf": [
+                    { "$ref": "#/components/schemas/ScriptFromFile" },
+                    {
+                        "required": ["name"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the local script file, optionally including the '.js' extension."
+                            },
+                        }
+                    }
+                ]
+            },
+            "InlineScript": {
+                "description": "A script whose source code is in the custom-scripts.json file itself.",
+                "allOf": [
+                    { "$ref": "#/components/schemas/Script" },
+                    {
+                        "required": ["code"],
+                        "properties": {
+                            "code": {
+                                "type": "string",
+                                "description": "The source code of the inline script."
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "requestBodies": {},
+        "securitySchemes": {},
+        "links": {},
+        "callbacks": {}
+    }
+}

--- a/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/RequestHandler/FileRequestHandler.swift
@@ -107,6 +107,7 @@ struct FileRequestHandler: RequestHandlerFactory {
         TopLevelAssetFileMetadata(filePath: "/favicon.ico", mimetype: "image/x-icon"),
         TopLevelAssetFileMetadata(filePath: "/theme-settings.js", mimetype: "text/javascript"),
         TopLevelAssetFileMetadata(filePath: "/theme-settings.json", mimetype: "application/json"),
+        TopLevelAssetFileMetadata(filePath: "/custom-scripts.json", mimetype: "application/json"),
     ]
     
     /// Returns a Boolean value that indicates whether the given path is located inside an asset folder.

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleFileTypesTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleFileTypesTests.swift
@@ -13,46 +13,51 @@ import XCTest
 
 class DocumentationBundleFileTypesTests: XCTestCase {
     func testIsCustomHeader() {
-        XCTAssertTrue(DocumentationBundleFileTypes.isCustomHeader(
-            URL(fileURLWithPath: "header.html")))
-        XCTAssertTrue(DocumentationBundleFileTypes.isCustomHeader(
-            URL(fileURLWithPath: "/header.html")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isCustomHeader(
-            URL(fileURLWithPath: "header")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isCustomHeader(
-            URL(fileURLWithPath: "/header.html/foo")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isCustomHeader(
-            URL(fileURLWithPath: "footer.html")))
-        XCTAssertTrue(DocumentationBundleFileTypes.isCustomHeader(
-            URL(fileURLWithPath: "DocC.docc/header.html")))
+        assertThat(DocumentationBundleFileTypes.isCustomHeader, matchesFilesNamed: "header", withExtension: "html")
     }
 
     func testIsCustomFooter() {
-        XCTAssertTrue(DocumentationBundleFileTypes.isCustomFooter(
-            URL(fileURLWithPath: "footer.html")))
-        XCTAssertTrue(DocumentationBundleFileTypes.isCustomFooter(
-            URL(fileURLWithPath: "/footer.html")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isCustomFooter(
-            URL(fileURLWithPath: "footer")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isCustomFooter(
-            URL(fileURLWithPath: "/footer.html/foo")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isCustomFooter(
-            URL(fileURLWithPath: "header.html")))
-        XCTAssertTrue(DocumentationBundleFileTypes.isCustomFooter(
-            URL(fileURLWithPath: "DocC.docc/footer.html")))
+        assertThat(DocumentationBundleFileTypes.isCustomFooter, matchesFilesNamed: "footer", withExtension: "html")
     }
 
     func testIsThemeSettingsFile() {
-        XCTAssertTrue(DocumentationBundleFileTypes.isThemeSettingsFile(
-            URL(fileURLWithPath: "theme-settings.json")))
-        XCTAssertTrue(DocumentationBundleFileTypes.isThemeSettingsFile(
-            URL(fileURLWithPath: "/a/b/theme-settings.json")))
-
-        XCTAssertFalse(DocumentationBundleFileTypes.isThemeSettingsFile(
-            URL(fileURLWithPath: "theme-settings.txt")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isThemeSettingsFile(
-            URL(fileURLWithPath: "not-theme-settings.json")))
-        XCTAssertFalse(DocumentationBundleFileTypes.isThemeSettingsFile(
-            URL(fileURLWithPath: "/a/theme-settings.json/bar")))
+        assertThat(DocumentationBundleFileTypes.isThemeSettingsFile, matchesFilesNamed: "theme-settings", withExtension: "json")
+    }
+    
+    func testIsCustomScriptsFile() {
+        assertThat(DocumentationBundleFileTypes.isCustomScriptsFile, matchesFilesNamed: "custom-scripts", withExtension: "json")
+    }
+    
+    private func assertThat(
+        _ predicate: (URL) -> Bool,
+        matchesFilesNamed fileName: String,
+        withExtension extension: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let fileNameWithExtension = "\(fileName).\(`extension`)"
+        
+        let pathsThatShouldMatch = [
+            fileNameWithExtension,
+            "/\(fileNameWithExtension)",
+            "DocC/docc/\(fileNameWithExtension)",
+            "/a/b/\(fileNameWithExtension)"
+        ].map { URL(fileURLWithPath: $0) }
+        
+        let pathsThatShouldNotMatch = [
+            fileName,
+            "/\(fileNameWithExtension)/foo",
+            "/a/\(fileNameWithExtension)/bar",
+            "\(fileName).wrongextension",
+            "wrongname.\(`extension`)"
+        ].map { URL(fileURLWithPath: $0) }
+        
+        for url in pathsThatShouldMatch {
+            XCTAssertTrue(predicate(url), file: file, line: line)
+        }
+        
+        for url in pathsThatShouldNotMatch {
+            XCTAssertFalse(predicate(url), file: file, line: line)
+        }
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/Input Discovery/DocumentationInputsProviderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Input Discovery/DocumentationInputsProviderTests.swift
@@ -28,9 +28,10 @@ class DocumentationInputsProviderTests: XCTestCase {
                         // This top-level Info.plist will be read for bundle information
                         InfoPlist(displayName: "CustomDisplayName"),
                         
-                        // These top-level files will be treated as a custom footer and a custom theme
+                        // Top-level files with customization
                         TextFile(name: "footer.html", utf8Content: ""),
                         TextFile(name: "theme-settings.json", utf8Content: ""),
+                        TextFile(name: "custom-scripts.json", utf8Content: ""),
                         
                         // Top-level content will be found
                         TextFile(name: "CCC.md", utf8Content: ""),
@@ -95,6 +96,7 @@ class DocumentationInputsProviderTests: XCTestCase {
                 "Found.docc/Inner/Info.plist",
                 "Found.docc/Inner/header.html",
                 "Found.docc/Inner/second.png",
+                "Found.docc/custom-scripts.json",
                 "Found.docc/first.png",
                 "Found.docc/footer.html",
                 "Found.docc/theme-settings.json",
@@ -107,6 +109,7 @@ class DocumentationInputsProviderTests: XCTestCase {
             XCTAssertEqual(bundle.customFooter.map(relativePathString), "Found.docc/footer.html")
             XCTAssertEqual(bundle.customHeader.map(relativePathString), nil)
             XCTAssertEqual(bundle.themeSettings.map(relativePathString), "Found.docc/theme-settings.json")
+            XCTAssertEqual(bundle.customScripts.map(relativePathString), "Found.docc/custom-scripts.json")
         }
     }
     

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionStaticHostableTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionStaticHostableTests.swift
@@ -47,7 +47,7 @@ class ConvertActionStaticHostableTests: StaticHostingBaseTests {
         _ = try await action.perform(logHandle: .none)
         
         // Test the content of the output folder.
-        var expectedContent = ["data", "documentation", "tutorials", "downloads", "images", "metadata.json" ,"videos", "index.html", "index"]
+        var expectedContent = ["data", "documentation", "tutorials", "downloads", "images", "custom-scripts", "metadata.json", "videos", "index.html", "index"]
         expectedContent += templateFolder.content.filter { $0 is Folder }.map{ $0.name }
         
         let output = try fileManager.contentsOfDirectory(atPath: targetBundleURL.path)

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -3153,6 +3153,7 @@ class ConvertActionTests: XCTestCase {
         
         XCTAssertEqual(fileSystem.dump(subHierarchyFrom: targetURL.path), """
         Output.doccarchive/
+        ├─ custom-scripts/
         ├─ data/
         │  ╰─ documentation/
         │     ╰─ something.json

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -956,6 +956,7 @@ class MergeActionTests: XCTestCase {
             
             XCTAssertEqual(fileSystem.dump(subHierarchyFrom: outputPath.path), """
             \(name).doccarchive/
+            ├─ custom-scripts
             ├─ data/
             │  ╰─ documentation/
             │     ├─ \(name.lowercased()).json
@@ -994,6 +995,7 @@ class MergeActionTests: XCTestCase {
         
         XCTAssertEqual(fileSystem.dump(subHierarchyFrom: combinedArchiveDir.path), """
         Output.doccarchive/
+        ├─ custom-scripts/
         ├─ data/
         │  ├─ documentation.json
         │  ╰─ documentation/


### PR DESCRIPTION
## Summary
First-class support for adding custom scripts to a DocC-generated website. These may be local scripts, in which case the website will continue to work offline, or they may be external scripts at a user-specified URL. This support is in the form of a custom-scripts.json file, the scripting analog of theme-settings.json.

Full pitch: https://forums.swift.org/t/pitch-support-for-custom-scripts-in-docc/75357.

## Dependencies
[Corresponding change in swift-docc-render](https://github.com/swiftlang/swift-docc-render/pull/903).

## Testing
* Unit tests added.
* To test the feature end-to-end, you'll need to use the version of swift-docc-render with the corresponding changes. Follow the steps in the pitch for adding any custom scripts you want to your documentation website (your own scripts, or a library such as MathJax or D2). If you want a specific example to test the implementation:
  * Copy the `custom-scripts.json` and the custom `mathjax-config.js` script (shown in the pitch) to your documentation catalog.
  * Add LaTeX expressions to your in-source documentation. 
  * `docc convert` the documentation catalog with your custom scripts. Observe that the modified swift-docc copied `custom-scripts.json` and the custom scripts into the documentation archive.
  * Preview the documentation archive. Observe that the LaTeX expressions are rendered on the page.
* Live demo: see [here](https://lucca-mito.github.io/swift-science/documentation/science/normaldistribution/probabilitydensity(at:)) and [here](https://lucca-mito.github.io/swift-science/documentation/science/swift/collection/samplevariance()). The LaTeX expressions in the documentation text are dynamically rendered into equations via custom scripts.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
  - Existing documentation does not need to change. New documentation for this feature will be added after the design and implementation are finalized.