### PR TITLE
Remove repeated `TechnologyRoot.directiveName` in known directives list

### DIFF
--- a/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
@@ -57,7 +57,6 @@ extension BlockDirective {
         TabNavigator.directiveName,
         Technology.directiveName,
         TechnologyRoot.directiveName,
-        TechnologyRoot.directiveName,
         Tile.directiveName,
         TitleHeading.directiveName,
         TopicsVisualStyle.directiveName,


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes a repeated `TechnologyRoot.directiveName` line in list of known directives.
## Dependencies

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
