### PR TITLE
Make `NavigatorIndex.Builder` ignore language variants when requested

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -473,8 +473,8 @@ extension NavigatorIndex {
      A `Builder` is a utility class to build a navigator index.
      
      The builder generates an index for content navigation, but also maps important information to filter content based on availability, symbol type, platform and some others.
-      
-      - Note: The builder is not thread safe and therefore, calling `index(renderNode:)` requires external synchronization in case the process is performed on different threads.
+     
+     - Note: The builder is not thread safe and therefore, calling `index(renderNode:)` requires external synchronization in case the process is performed on different threads.
      */
     open class Builder {
         
@@ -613,12 +613,13 @@ extension NavigatorIndex {
         
         /// Index a single render `RenderNode`.
         /// - Parameter renderNode: The render node to be indexed.
-        public func index(renderNode: RenderNode) throws {
+        /// - Parameter ignoringLanguage: Whether language variants should be ignored when indexing this render node.
+        public func index(renderNode: RenderNode, ignoringLanguage: Bool = false) throws {
             // Always index the main render node representation
             let language = try index(renderNode, traits: nil)
             
             // Additionally, for Swift want to also index the Objective-C variant, if there is any.
-            guard language == .swift else {
+            guard !ignoringLanguage && language == .swift else {
                 return
             }
             

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -703,6 +703,14 @@ Root
     }
     
     func testNavigatorIndexGenerationVariantsPayload() throws {
+        try testNavigatorIndexGenerationVariantsPayload(ignoringLanguage: false)
+    }
+
+    func testNavigatorIndexGenerationVariantsPayloadIgnoringLanguage() throws {
+        try testNavigatorIndexGenerationVariantsPayload(ignoringLanguage: true)
+    }
+
+    private func testNavigatorIndexGenerationVariantsPayload(ignoringLanguage: Bool) throws {
         let jsonFile = Bundle.module.url(forResource: "Variant-render-node", withExtension: "json", subdirectory: "Test Resources")!
         let jsonData = try Data(contentsOf: jsonFile)
         
@@ -711,88 +719,112 @@ Root
         builder.setup()
         
         let renderNode = try XCTUnwrap(RenderJSONDecoder.makeDecoder().decode(RenderNode.self, from: jsonData))
-        try builder.index(renderNode: renderNode)
+        try builder.index(renderNode: renderNode, ignoringLanguage: ignoringLanguage)
         
         builder.finalize()
         
         let navigatorIndex = builder.navigatorIndex!
         
         assertUniqueIDs(node: navigatorIndex.navigatorTree.root)
-        assertEqualDumps(navigatorIndex.navigatorTree.root.dumpTree(), """
+        var expectedDump = """
         [Root]
+
+        """
+
+        if !ignoringLanguage {
+            expectedDump += """
         ┣╸Objective-C
         ┃ ┗╸My Article in Objective-C
         ┃   ┣╸Task Group 1
         ┃   ┣╸Task Group 2
         ┃   ┗╸Task Group 3
+
+        """
+        }
+
+        expectedDump += """
         ┗╸Swift
           ┗╸My Article
             ┣╸Task Group 1
             ┣╸Task Group 2
             ┗╸Task Group 3
-        """)
-        
-        try XCTAssertEqual(
-            RenderIndex.fromURL(targetURL.appendingPathComponent("index.json")),
-            RenderIndex.fromString(#"""
-                {
-                  "interfaceLanguages": {
-                    "occ": [
+        """
+
+        assertEqualDumps(navigatorIndex.navigatorTree.root.dumpTree(), expectedDump)
+
+        var expectedRenderIndexString = """
+        {
+            "interfaceLanguages": {
+        """
+
+        if !ignoringLanguage {
+            expectedRenderIndexString += #"""
+                "occ": [
+                  {
+                    "children": [
                       {
-                        "children": [
-                          {
-                            "title": "Task Group 1",
-                            "type": "groupMarker"
-                          },
-                          {
-                            "title": "Task Group 2",
-                            "type": "groupMarker"
-                          },
-                          {
-                            "title": "Task Group 3",
-                            "type": "groupMarker"
-                          }
-                        ],
-                        "path": "\/documentation\/mykit\/my-article",
-                        "title": "My Article in Objective-C",
-                        "type": "article"
+                        "title": "Task Group 1",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "title": "Task Group 2",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "title": "Task Group 3",
+                        "type": "groupMarker"
                       }
                     ],
-                    "swift": [
-                      {
-                        "children": [
-                          {
-                            "title": "Task Group 1",
-                            "type": "groupMarker"
-                          },
-                          {
-                            "title": "Task Group 2",
-                            "type": "groupMarker"
-                          },
-                          {
-                            "title": "Task Group 3",
-                            "type": "groupMarker"
-                          }
-                        ],
-                        "path": "\/documentation\/mykit\/my-article",
-                        "title": "My Article",
-                        "type": "article"
-                      }
-                    ]
-                  },
-                  "includedArchiveIdentifiers": [
-                    "org.swift.docc.example"
-                  ],
-                  "schemaVersion": {
-                    "major": 0,
-                    "minor": 1,
-                    "patch": 2
+                    "path": "\/documentation\/mykit\/my-article",
+                    "title": "My Article in Objective-C",
+                    "type": "article"
                   }
-                }
+                ],
                 """#
-            )
+        }
+
+        expectedRenderIndexString += #"""
+                "swift": [
+                  {
+                    "children": [
+                      {
+                        "title": "Task Group 1",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "title": "Task Group 2",
+                        "type": "groupMarker"
+                      },
+                      {
+                        "title": "Task Group 3",
+                        "type": "groupMarker"
+                      }
+                    ],
+                    "path": "\/documentation\/mykit\/my-article",
+                    "title": "My Article",
+                    "type": "article"
+                  }
+                ]
+                """#
+
+        expectedRenderIndexString += #"""
+            },
+            "includedArchiveIdentifiers": [
+                "org.swift.docc.example"
+            ],
+            "schemaVersion": {
+                "major": 0,
+                "minor": 1,
+                "patch": 2
+            }
+        }
+        """#
+
+        try XCTAssertEqual(
+            RenderIndex.fromURL(targetURL.appendingPathComponent("index.json")),
+            RenderIndex.fromString(expectedRenderIndexString)
         )
-        
+
         try FileManager.default.removeItem(at: targetURL)
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable:  rdar://138183564

## Summary

Clients might want the Navigator Index to not preemptively add an entry for nodes that have a language variant trait. For example, a client might not have a renderer cable of applying language variants, in this instance it doesn't make sense to generate a navigator hierarchy for other languages.

## Testing

Updated unit tests to validate the behavior

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
