### PR TITLE
Add directive for linking symbols as alternate representations

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -618,6 +618,19 @@ public class DocumentationContext {
                 resolver.visit(documentationNode.semantic)
             }
             
+            // Also resolve the node's alternate representations. This isn't part of the node's 'semantic' value (resolved above).
+            if let alternateRepresentations = documentationNode.metadata?.alternateRepresentations {
+                for alternateRepresentation in alternateRepresentations {
+                    let resolutionResult = resolver.resolve(
+                        alternateRepresentation.reference,
+                        in: bundle.rootReference,
+                        range: alternateRepresentation.originalMarkup.range,
+                        severity: .warning
+                    )
+                    alternateRepresentation.reference = .resolved(resolutionResult)
+                }
+            }
+
             let problems: [Problem]
             if documentationNode.semantic is Article {
                 // Diagnostics for articles have correct source ranges and don't need to be modified.

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2835,6 +2835,9 @@ public class DocumentationContext {
             }
         }
         
+        // Run analysis to determine whether manually configured alternate representations are valid.
+        analyzeAlternateRepresentations()
+        
         // Run global ``TopicGraph`` global analysis.
         analyzeTopicGraph()
     }
@@ -3197,6 +3200,87 @@ extension DocumentationContext {
             }
             return Problem(diagnostic: Diagnostic(source: source, severity: .information, range: nil, identifier: "org.swift.docc.SymbolNotCurated", summary: "You haven't curated \(node.reference.absoluteString.singleQuoted)"), possibleSolutions: [Solution(summary: "Add a link to \(node.reference.absoluteString.singleQuoted) from a Topics group of another documentation node.", replacements: [])])
         }
+        diagnosticEngine.emit(problems)
+    }
+        
+    func analyzeAlternateRepresentations() {
+        var problems = [Problem]()
+
+        func listSourceLanguages(_ sourceLanguages: Set<SourceLanguage>) -> String {
+            sourceLanguages.sorted(by: { language1, language2 in
+                // Emit Swift first, then alphabetically.
+                switch (language1, language2) {
+                case (.swift, _): return true
+                case (_, .swift): return false
+                default: return language1.id < language2.id
+                }
+            }).map(\.name).list(finalConjunction: .and)
+        }
+        func removeAlternateRepresentationSolution(_ alternateRepresentation: AlternateRepresentation) -> [Solution] {
+            [Solution(
+                summary: "Remove this alternate representation",
+                replacements: alternateRepresentation.originalMarkup.range.map { [Replacement(range: $0, replacement: "")] } ?? [])]
+        }
+
+        for reference in knownPages {
+            guard let entity = try? self.entity(with: reference), let alternateRepresentations = entity.metadata?.alternateRepresentations else { continue }
+            
+            var sourceLanguageToReference: [SourceLanguage: AlternateRepresentation] = [:]
+            for alternateRepresentation in entity.metadata?.alternateRepresentations ?? [] {
+                guard case .resolved(.success(let alternateRepresentationReference)) = alternateRepresentation.reference,
+                      let alternateRepresentationEntity = try? self.entity(with: alternateRepresentationReference) else {
+                    continue
+                }
+                
+                // Check if the documented symbol already has alternate representations from in-source annotations.
+                let duplicateSourceLanguages = alternateRepresentationEntity.availableSourceLanguages.intersection(entity.availableSourceLanguages)
+                if !duplicateSourceLanguages.isEmpty {
+                    problems.append(Problem(
+                        diagnostic: Diagnostic(
+                            source: alternateRepresentation.originalMarkup.range?.source,
+                            severity: .warning,
+                            range: alternateRepresentation.originalMarkup.range,
+                            identifier: "org.swift.docc.AlternateRepresentation.DuplicateLanguageDefinition",
+                            summary: "\(entity.name.plainText.singleQuoted) already has a representation in \(listSourceLanguages(duplicateSourceLanguages))",
+                            explanation: "Symbols can only specify custom alternate language representations for languages that the documented symbol doesn't already have a representation for."
+                        ),
+                        possibleSolutions: [Solution(summary: "Replace this alternate language representation with a symbol which isn't available in \(listSourceLanguages(entity.availableSourceLanguages))", replacements: [])]
+                    ))
+                }
+                
+                let duplicateAlternateLanguages = Set(sourceLanguageToReference.keys).intersection(alternateRepresentationEntity.availableSourceLanguages)
+                if !duplicateAlternateLanguages.isEmpty {
+                    let replacements = alternateRepresentation.originalMarkup.range.flatMap { [Replacement(range: $0, replacement: "")] } ?? []
+                    let notes: [DiagnosticNote] = duplicateAlternateLanguages.compactMap { duplicateAlternateLanguage in
+                        guard let alreadyExistingRepresentation = sourceLanguageToReference[duplicateAlternateLanguage],
+                              let range = alreadyExistingRepresentation.originalMarkup.range,
+                              let source = range.source else {
+                            return nil
+                        }
+                        
+                        return DiagnosticNote(source: source, range: range, message: "This directive already specifies an alternate \(duplicateAlternateLanguage.name) representation.")
+                    }
+                    problems.append(Problem(
+                        diagnostic: Diagnostic(
+                            source: alternateRepresentation.originalMarkup.range?.source,
+                            severity: .warning,
+                            range: alternateRepresentation.originalMarkup.range,
+                            identifier: "org.swift.docc.AlternateRepresentation.DuplicateLanguageDefinition",
+                            summary: "A custom alternate language representation for \(listSourceLanguages(duplicateAlternateLanguages)) has already been specified",
+                            explanation: "Only one custom alternate language representation can be specified per language.",
+                            notes: notes
+                        ),
+                        possibleSolutions: [Solution(summary: "Remove this alternate representation", replacements: replacements)]
+                    ))
+                }
+                
+                // Update mapping from source language to alternate declaration, for diagnostic purposes
+                for alreadySeenLanguage in alternateRepresentationEntity.availableSourceLanguages {
+                    sourceLanguageToReference[alreadySeenLanguage] = alternateRepresentation
+                }
+            }
+        }
+        
         diagnosticEngine.emit(problems)
     }
 }

--- a/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+
+/// A directive that configures an alternate language representations of a symbol.
+///
+/// An API that can be called from more than one source language has more than one language representation.
+///
+/// Whenever possible, prefer to define alternative language representations for a symbol by using in-source annotations
+/// such as the `@objc` and `@_objcImplementation` attributes in Swift,
+/// or the `NS_SWIFT_NAME` macro in Objective C.
+///
+/// If your source language doesn’t have a mechanism for specifying alternate representations or if your intended alternate representation isn't compatible with those attributes,
+/// you can use the `@AlternateRepresentation` directive to specify another symbol that should be considered an alternate representation of the documented symbol.
+///
+/// ```md
+/// @Metadata {
+///     @AlternateRepresentation(MyApp/MyClass/property)
+/// }
+/// ```
+/// If you prefer, you can wrap the symbol link in a set of double backticks (\`\`), or use any other supported syntax for linking to symbols.
+/// For more information about linking to symbols, see <doc:linking-to-symbols-and-other-content>.
+///
+/// This provides a hint to the renderer as to the alternate language representations for the current symbol.
+/// The renderer may use this hint to provide a link to these alternate symbols.
+/// For example, Swift-DocC-Render shows a toggle between supported languages, where switching to a different language representation will redirect to the documentation for the configured alternate symbol.
+///
+/// ### Special considerations
+///
+/// Links containing a colon (`:`) must be wrapped in quotes:
+/// ```md
+/// @Metadata {
+///     @AlternateRepresentation("doc://com.example/documentation/MyClass/property")
+///     @AlternateRepresentation("MyClass/myFunc(_:_:)")
+/// }
+/// ```
+///
+/// The `@AlternateRepresentation` directive only specifies an alternate language representation in one direction.
+/// To define a two-way relationship, add an `@AlternateRepresentation` directive, linking to this symbol, to the other symbol as well.
+///
+/// You can only configure custom alternate language representations for languages that the documented symbol doesn't already have a language representation for,
+/// either from in-source annotations or from a previous `@AlternateRepresentation` directive.
+public final class AlternateRepresentation: Semantic, AutomaticDirectiveConvertible {
+    public static let introducedVersion = "6.1"
+            
+    // Directive parameter definition
+
+    /// A link to another symbol that should be considered an alternate language representation of the current symbol.
+    ///
+    /// If you prefer, you can wrap the symbol link in a set of double backticks (\`\`).
+    @DirectiveArgumentWrapped(
+        name: .unnamed,
+        parseArgument: { _, argumentValue in
+            // Allow authoring of links with leading and trailing "``"s
+            var argumentValue = argumentValue
+            if argumentValue.hasPrefix("``"), argumentValue.hasSuffix("``") {
+                argumentValue = String(argumentValue.dropFirst(2).dropLast(2))
+            }
+            guard let url = ValidatedURL(parsingAuthoredLink: argumentValue), !url.components.path.isEmpty else {
+                return nil
+            }
+            return .unresolved(UnresolvedTopicReference(topicURL: url))
+        }
+    )
+    public internal(set) var reference: TopicReference
+
+    static var keyPaths: [String : AnyKeyPath] = [
+        "reference" : \AlternateRepresentation._reference
+    ]
+
+    // Boiler-plate required by conformance to AutomaticDirectiveConvertible
+    
+    public var originalMarkup: Markdown.BlockDirective
+
+    @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible")
+    init(originalMarkup: Markdown.BlockDirective) {
+        self.originalMarkup = originalMarkup
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -19,6 +19,7 @@ import Markdown
 /// 
 /// ### Child Directives
 ///
+/// - ``AlternateRepresentation``
 /// - ``DocumentationExtension``
 /// - ``TechnologyRoot``
 /// - ``DisplayName``
@@ -77,6 +78,9 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
 
     @ChildDirective
     var redirects: [Redirect]? = nil
+    
+    @ChildDirective(requirements: .zeroOrMore)
+    var alternateRepresentations: [AlternateRepresentation]
 
     static var keyPaths: [String : AnyKeyPath] = [
         "documentationOptions"  : \Metadata._documentationOptions,
@@ -91,6 +95,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         "_pageColor"            : \Metadata.__pageColor,
         "titleHeading"          : \Metadata._titleHeading,
         "redirects"             : \Metadata._redirects,
+        "alternateRepresentations"  : \Metadata._alternateRepresentations,
     ]
     
     @available(*, deprecated, message: "Do not call directly. Required for 'AutomaticDirectiveConvertible'.")
@@ -100,7 +105,7 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
     
     func validate(source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> Bool {
         // Check that something is configured in the metadata block
-        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil && redirects == nil {
+        if documentationOptions == nil && technologyRoot == nil && displayName == nil && pageImages.isEmpty && customMetadata.isEmpty && callToAction == nil && availability.isEmpty && pageKind == nil && pageColor == nil && titleHeading == nil && redirects == nil && alternateRepresentations.isEmpty {
             let diagnostic = Diagnostic(
                 source: source,
                 severity: .information,

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/BlockDirectiveExtensions.swift
@@ -41,6 +41,7 @@ extension BlockDirective {
         Metadata.directiveName,
         Metadata.Availability.directiveName,
         Metadata.PageKind.directiveName,
+        AlternateRepresentation.directiveName,
         MultipleChoice.directiveName,
         Options.directiveName,
         PageColor.directiveName,

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -32,6 +32,245 @@
         {
           "domain" : "Swift-DocC",
           "introduced" : {
+            "major" : 6,
+            "minor" : 1,
+            "patch" : 0
+          }
+        }
+      ],
+      "declarationFragments" : [
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "@"
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "AlternateRepresentation"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "("
+        },
+        {
+          "kind" : "text",
+          "spelling" : "_ "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "reference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ": "
+        },
+        {
+          "kind" : "typeIdentifier",
+          "spelling" : "TopicReference"
+        },
+        {
+          "kind" : "text",
+          "spelling" : ")"
+        }
+      ],
+      "docComment" : {
+        "lines" : [
+          {
+            "text" : "A directive that configures an alternate language representations of a symbol."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "An API that can be called from more than one source language has more than one language representation."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Whenever possible, prefer to define alternative language representations for a symbol by using in-source annotations"
+          },
+          {
+            "text" : "such as the `@objc` and `@_objcImplementation` attributes in Swift,"
+          },
+          {
+            "text" : "or the `NS_SWIFT_NAME` macro in Objective C."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "If your source language doesn’t have a mechanism for specifying alternate representations or if your intended alternate representation isn't compatible with those attributes,"
+          },
+          {
+            "text" : "you can use the `@AlternateRepresentation` directive to specify another symbol that should be considered an alternate representation of the documented symbol."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @AlternateRepresentation(MyApp\/MyClass\/property)"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : "If you prefer, you can wrap the symbol link in a set of double backticks (\\`\\`), or use any other supported syntax for linking to symbols."
+          },
+          {
+            "text" : "For more information about linking to symbols, see <doc:linking-to-symbols-and-other-content>."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "This provides a hint to the renderer as to the alternate language representations for the current symbol."
+          },
+          {
+            "text" : "The renderer may use this hint to provide a link to these alternate symbols."
+          },
+          {
+            "text" : "For example, Swift-DocC-Render shows a toggle between supported languages, where switching to a different language representation will redirect to the documentation for the configured alternate symbol."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "### Special considerations"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "Links containing a colon (`:`) must be wrapped in quotes:"
+          },
+          {
+            "text" : "```md"
+          },
+          {
+            "text" : "@Metadata {"
+          },
+          {
+            "text" : "    @AlternateRepresentation(\"doc:\/\/com.example\/documentation\/MyClass\/property\")"
+          },
+          {
+            "text" : "    @AlternateRepresentation(\"MyClass\/myFunc(_:_:)\")"
+          },
+          {
+            "text" : "}"
+          },
+          {
+            "text" : "```"
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "The `@AlternateRepresentation` directive only specifies an alternate language representation in one direction."
+          },
+          {
+            "text" : "To define a two-way relationship, add an `@AlternateRepresentation` directive, linking to this symbol, to the other symbol as well."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "You can only configure custom alternate language representations for languages that the documented symbol doesn't already have a language representation for,"
+          },
+          {
+            "text" : "either from in-source annotations or from a previous `@AlternateRepresentation` directive."
+          },
+          {
+            "text" : "- Parameters:"
+          },
+          {
+            "text" : "  - reference: A link to another symbol that should be considered an alternate language representation of the current symbol."
+          },
+          {
+            "text" : "     **(required)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     If you prefer, you can wrap the symbol link in a set of double backticks (\\`\\`)."
+          }
+        ]
+      },
+      "identifier" : {
+        "interfaceLanguage" : "swift",
+        "precise" : "__docc_universal_symbol_reference_$AlternateRepresentation"
+      },
+      "kind" : {
+        "displayName" : "Directive",
+        "identifier" : "class"
+      },
+      "names" : {
+        "navigator" : [
+          {
+            "kind" : "attribute",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "preciseIdentifier" : "__docc_universal_symbol_reference_$AlternateRepresentation",
+            "spelling" : "AlternateRepresentation"
+          }
+        ],
+        "subHeading" : [
+          {
+            "kind" : "identifier",
+            "spelling" : "@"
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "AlternateRepresentation"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "text",
+            "spelling" : "_ "
+          },
+          {
+            "kind" : "identifier",
+            "spelling" : "reference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "spelling" : "TopicReference"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+        ],
+        "title" : "AlternateRepresentation"
+      },
+      "pathComponents" : [
+        "AlternateRepresentation"
+      ]
+    },
+    {
+      "accessLevel" : "public",
+      "availability" : [
+        {
+          "domain" : "Swift-DocC",
+          "introduced" : {
             "major" : 5,
             "minor" : 5,
             "patch" : 0
@@ -3346,6 +3585,9 @@
           },
           {
             "text" : ""
+          },
+          {
+            "text" : "- ``AlternateRepresentation``"
           },
           {
             "text" : "- ``DocumentationExtension``"

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5435,7 +5435,7 @@ let expected = """
         XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'MissingSymbol'")
     }
         
-    func testDiagnosesAlternateDeclarations() throws {
+    func testDiagnosesSymbolAlternateDeclarations() throws {
         let (_, context) = try loadBundle(catalog: Folder(
             name: "unit-test.docc",
             content: [
@@ -5505,6 +5505,67 @@ let expected = """
         XCTAssertEqual(solution.replacements.count, 1)
         XCTAssertEqual(solution.replacements.first?.replacement, "")
     }
+    
+    func testDiagnosesArticleAlternateDeclarations() throws {
+        let (_, context) = try loadBundle(catalog: Folder(
+            name: "unit-test.docc",
+            content: [
+                TextFile(name: "Symbol.md", utf8Content: """
+                # ``Symbol``
+                @Metadata {
+                    @AlternateRepresentation("doc:Article")
+                }
+                A symbol extension file specifying an alternate representation which is an article.
+                """),
+                TextFile(name: "Article.md", utf8Content: """
+                # Article
+                @Metadata {
+                    @AlternateRepresentation(``Symbol``)
+                }
+                An article specifying a custom alternate representation.
+                """),
+                JSONFile(
+                    name: "unit-test.occ.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "unit-test",
+                        symbols: [
+                            makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
+                        ]
+                    )
+                )
+            ]
+        ))
+
+        let alternateRepresentationProblems = context.problems.sorted(by: \.diagnostic.summary)
+        XCTAssertEqual(alternateRepresentationProblems.count, 2)
+        
+        // Verify a problem is reported for trying to define an alternate representation for a language the symbol already supports
+        var problem = try XCTUnwrap(alternateRepresentationProblems.first)
+        XCTAssertEqual(problem.diagnostic.severity, .warning)
+        XCTAssertEqual(problem.diagnostic.summary, "Custom alternate representations are not supported for page kind 'Article'")
+        XCTAssertEqual(problem.diagnostic.explanation, "Alternate representations are only supported for symbols.")
+        XCTAssertEqual(problem.possibleSolutions.count, 1)
+    
+        // Verify solutions provide context and suggest to remove the invalid directive
+        var solution = try XCTUnwrap(problem.possibleSolutions.first)
+        XCTAssertEqual(solution.summary, "Remove this alternate representation")
+        XCTAssertEqual(solution.replacements.count, 1)
+        XCTAssertEqual(solution.replacements.first?.replacement, "")
+
+        // Verify a problem is reported for having alternate representations with duplicate source languages
+        problem = try XCTUnwrap(alternateRepresentationProblems[1])
+        XCTAssertEqual(problem.diagnostic.severity, .warning)
+        XCTAssertEqual(problem.diagnostic.summary, "Page kind 'Article' is not allowed as a custom alternate language representation")
+        XCTAssertEqual(problem.diagnostic.explanation, "Symbols can only specify other symbols as custom language representations.")
+        XCTAssertEqual(problem.possibleSolutions.count, 1)
+                
+        // Verify solutions provide context and suggest to remove the invalid directive
+        solution = try XCTUnwrap(problem.possibleSolutions.first)
+        XCTAssertEqual(solution.summary, "Remove this alternate representation")
+        XCTAssertEqual(solution.replacements.count, 1)
+        XCTAssertEqual(solution.replacements.first?.replacement, "")
+    }
+
 }
 
 func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5433,7 +5433,78 @@ let expected = """
         let problem = try XCTUnwrap(context.problems.first)
         XCTAssertEqual(problem.diagnostic.severity, .warning)
         XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'MissingSymbol'")
-    }    
+    }
+        
+    func testDiagnosesAlternateDeclarations() throws {
+        let (_, context) = try loadBundle(catalog: Folder(
+            name: "unit-test.docc",
+            content: [
+                TextFile(name: "Symbol.md", utf8Content: """
+                # ``Symbol``
+                @Metadata {
+                    @AlternateRepresentation(``CounterpartSymbol``)
+                    @AlternateRepresentation(``OtherCounterpartSymbol``)
+                }
+                A symbol extension file defining an alternate representation which overlaps source languages with another one.
+                """),
+                TextFile(name: "SwiftSymbol.md", utf8Content: """
+                # ``SwiftSymbol``
+                @Metadata {
+                    @AlternateRepresentation(``Symbol``)
+                }
+                A symbol extension file defining an alternate representation which overlaps source languages with the current node.
+                """),
+                JSONFile(
+                    name: "unit-test.swift.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "unit-test",
+                        symbols: [
+                            makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
+                            makeSymbol(id: "other-symbol-id", kind: .class, pathComponents: ["SwiftSymbol"]),
+                        ]
+                    )
+                ),
+                JSONFile(
+                    name: "unit-test.occ.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "unit-test",
+                        symbols: [
+                            makeSymbol(id: "counterpart-symbol-id", language: .objectiveC, kind: .class, pathComponents: ["CounterpartSymbol"]),
+                            makeSymbol(id: "other-counterpart-symbol-id", language: .objectiveC, kind: .class, pathComponents: ["OtherCounterpartSymbol"]),
+                        ]
+                    )
+                ),
+            ]
+        ))
+
+        let alternateRepresentationProblems = context.problems.sorted(by: \.diagnostic.summary)
+        XCTAssertEqual(alternateRepresentationProblems.count, 2)
+        
+        // Verify a problem is reported for trying to define an alternate representation for a language the symbol already supports
+        var problem = try XCTUnwrap(alternateRepresentationProblems.first)
+        XCTAssertEqual(problem.diagnostic.severity, .warning)
+        XCTAssertEqual(problem.diagnostic.summary, "'SwiftSymbol' already has a representation in Swift")
+        XCTAssertEqual(problem.diagnostic.explanation, "Symbols can only specify custom alternate language representations for languages that the documented symbol doesn't already have a representation for.")
+        XCTAssertEqual(problem.possibleSolutions.count, 1)
+    
+        // Verify solutions provide context, but no replacements
+        var solution = try XCTUnwrap(problem.possibleSolutions.first)
+        XCTAssertEqual(solution.summary, "Replace this alternate language representation with a symbol which isn't available in Swift")
+        XCTAssertEqual(solution.replacements.count, 0)
+
+        // Verify a problem is reported for having alternate representations with duplicate source languages
+        problem = try XCTUnwrap(alternateRepresentationProblems[1])
+        XCTAssertEqual(problem.diagnostic.severity, .warning)
+        XCTAssertEqual(problem.diagnostic.summary, "A custom alternate language representation for Objective-C has already been specified")
+        XCTAssertEqual(problem.diagnostic.explanation, "Only one custom alternate language representation can be specified per language.")
+        XCTAssertEqual(problem.possibleSolutions.count, 1)
+                
+        // Verify solutions provide context and suggest to remove the duplicate directive
+        solution = try XCTUnwrap(problem.possibleSolutions.first)
+        XCTAssertEqual(solution.summary, "Remove this alternate representation")
+        XCTAssertEqual(solution.replacements.count, 1)
+        XCTAssertEqual(solution.replacements.first?.replacement, "")
+    }
 }
 
 func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1495,4 +1495,84 @@ class RenderNodeTranslatorTests: XCTestCase {
             }
         }
     }
+    
+    func testAlternateRepresentationsRenderedAsVariants() throws {
+        let (bundle, context) = try loadBundle(catalog: Folder(
+            name: "unit-test.docc",
+            content: [
+                TextFile(name: "Symbol.md", utf8Content: """
+                # ``Symbol``
+                @Metadata {
+                    @AlternateRepresentation(``CounterpartSymbol``)
+                }
+                A symbol extension file defining an alternate representation.
+                """),
+                TextFile(name: "OtherSymbol.md", utf8Content: """
+                # ``OtherSymbol``
+                @Metadata {
+                    @AlternateRepresentation(``MissingCounterpart``)
+                }
+                A symbol extension file defining an alternate representation which doesn't exist.
+                """),
+                TextFile(name: "MultipleSwiftVariantsSymbol.md", utf8Content: """
+                # ``MultipleSwiftVariantsSymbol``
+                @Metadata {
+                    @AlternateRepresentation(``Symbol``)
+                }
+                A symbol extension file defining an alternate representation which is also in Swift.
+                """),
+                JSONFile(
+                    name: "unit-test.swift.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "unit-test",
+                        symbols: [
+                            makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
+                            makeSymbol(id: "other-symbol-id", kind: .class, pathComponents: ["OtherSymbol"]),
+                            makeSymbol(id: "multiple-swift-variants-symbol-id", kind: .class, pathComponents: ["MultipleSwiftVariantsSymbol"]),
+                        ]
+                    )
+                ),
+                JSONFile(
+                    name: "unit-test.occ.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "unit-test",
+                        symbols: [
+                            makeSymbol(id: "counterpart-symbol-id", language: .objectiveC, kind: .class, pathComponents: ["CounterpartSymbol"]),
+                        ]
+                    )
+                ),
+            ]
+        ))
+
+        func renderNodeArticleFromReferencePath(
+            referencePath: String
+        ) throws -> RenderNode {
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: referencePath, sourceLanguage: .swift)
+            let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
+            return try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
+        }
+        
+        // Assert that CounterpartSymbol's source languages have been added as source languages of Symbol
+        var renderNode = try renderNodeArticleFromReferencePath(referencePath: "/documentation/unit-test/Symbol")
+        XCTAssertEqual(renderNode.variants?.count, 2)
+        XCTAssertEqual(renderNode.variants, [
+            .init(traits: [.interfaceLanguage("swift")], paths: ["/documentation/unit-test/symbol"]),
+            .init(traits: [.interfaceLanguage("occ")], paths: ["/documentation/unit-test/counterpartsymbol"])
+        ])
+        
+        // Assert that alternate representations which can't be resolved are ignored
+        renderNode = try renderNodeArticleFromReferencePath(referencePath: "/documentation/unit-test/OtherSymbol")
+        XCTAssertEqual(renderNode.variants?.count, 1)
+        XCTAssertEqual(renderNode.variants, [
+            .init(traits: [.interfaceLanguage("swift")], paths: ["/documentation/unit-test/othersymbol"]),
+        ])
+
+        // Assert that duplicate alternate representations are not added as variants
+        renderNode = try renderNodeArticleFromReferencePath(referencePath: "/documentation/unit-test/MultipleSwiftVariantsSymbol")
+        XCTAssertEqual(renderNode.variants?.count, 1)
+        XCTAssertEqual(renderNode.variants, [
+            .init(traits: [.interfaceLanguage("swift")], paths: ["/documentation/unit-test/multipleswiftvariantssymbol"]),
+        ])
+    }
 }

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveIndexTests.swift
@@ -17,6 +17,7 @@ class DirectiveIndexTests: XCTestCase {
         XCTAssertEqual(
             DirectiveIndex.shared.indexedDirectives.keys.sorted(),
             [
+                "AlternateRepresentation",
                 "Assessments",
                 "AutomaticArticleSubheading",
                 "AutomaticSeeAlso",

--- a/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DirectiveInfrastructure/DirectiveMirrorTests.swift
@@ -52,7 +52,7 @@ class DirectiveMirrorTests: XCTestCase {
         XCTAssertFalse(reflectedDirective.allowsMarkup)
         XCTAssert(reflectedDirective.arguments.isEmpty)
         
-        XCTAssertEqual(reflectedDirective.childDirectives.count, 12)
+        XCTAssertEqual(reflectedDirective.childDirectives.count, 13)
         
         XCTAssertEqual(
             reflectedDirective.childDirectives["DocumentationExtension"]?.propertyLabel,

--- a/Tests/SwiftDocCTests/Semantics/MetadataAlternateRepresentationTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAlternateRepresentationTests.swift
@@ -1,0 +1,67 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import XCTest
+import Markdown
+
+@testable import SwiftDocC
+
+class MetadataAlternateRepresentationTests: XCTestCase {
+    func testValidLocalLink() throws {
+        for link in ["``MyClass/property``", "MyClass/property"] {
+            let (problems, metadata) = try parseDirective(Metadata.self) {
+                """
+                @Metadata {
+                    @AlternateRepresentation(\(link))
+                }
+                """
+            }
+            
+            XCTAssertTrue(problems.isEmpty, "Unexpected problems: \(problems.joined(separator: "\n"))")
+            XCTAssertEqual(metadata?.alternateRepresentations.count, 1)
+            
+            let alternateRepresentation = try XCTUnwrap(metadata?.alternateRepresentations.first)
+            XCTAssertEqual(alternateRepresentation.reference.url, URL(string: "MyClass/property"))
+        }
+    }
+        
+    func testValidExternalLinkReference() throws {
+        let (problems, metadata) = try parseDirective(Metadata.self) {
+            """
+            @Metadata {
+                @AlternateRepresentation("doc://com.example/documentation/MyClass/property")
+            }
+            """
+        }
+        
+        XCTAssertTrue(problems.isEmpty, "Unexpected problems: \(problems.joined(separator: "\n"))")
+        XCTAssertEqual(metadata?.alternateRepresentations.count, 1)
+        
+        let alternateRepresentation = try XCTUnwrap(metadata?.alternateRepresentations.first)
+        XCTAssertEqual(alternateRepresentation.reference.url, URL(string: "doc://com.example/documentation/MyClass/property"))
+    }
+
+    func testInvalidTopicReference() throws {
+        let (problems, _) = try parseDirective(Metadata.self) {
+            """
+            @Metadata {
+                @AlternateRepresentation("doc://")
+            }
+            """
+        }
+        
+        XCTAssertEqual(problems.count, 2, "Unexpected number of problems: \(problems.joined(separator: "\n"))")
+        XCTAssertEqual(problems, [
+            "1: note – org.swift.docc.Metadata.NoConfiguration",
+            "2: warning – org.swift.docc.HasArgument.unlabeled.ConversionFailed"
+        ])
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://109417745

## Summary

Adds a directive which is meant to be used in markdown extension files for a specific symbol:
```swift
@Metadata {
  @AlternateRepresentation(``MyApp/MyClass/property``)
}
```
Where all variants of ``MyApp/MyClass/property`` will be added as variants of the current symbol.

Its purpose is to be able to define an alternative language representation for a symbol, where the alternative symbol is an unrelated symbol as far as the compiler is aware (i.e. they have different USRs in the symbol graph).

This makes it possible to switch between both symbols through the language switcher:
<img width="997" alt="Screenshot 2024-11-22 at 17 46 00" src="https://github.com/user-attachments/assets/53c5e1a8-db14-45bd-b59d-51939744c3cb">

Whenever possible, the alternative language representations should be defined in-source, by using in-source annotations such as the `@objc` and `@_objcImplementation` attributes in Swift, or the `NS_SWIFT_NAME` macro in Objective C.

However, if this is not possible, this is an alternative to be able to render both symbols as counterparts of each other.


### Diagnostics

Links within the directive are resolved, and emit a warning if the link cannot be resolved same as all other markup links:
```
    warning: 'MissingSymbol' doesn't exist at '/Synonyms'
     --> SynonymSample.docc/SymbolExtension2.md:4:19-4:32
    2 |
    3 | @Metadata {
    4 +     @AlternateRepresentation(``Synonyms/MissingSymbol``)
    5 | }
```

Duplication of source language availability is also detected:
- if the symbol the alternate representation is being defined for (the "original" symbol) was already available in one of the languages the counterpart symbol is available in
 - if the alternate representations have duplicate source languages in common, i.e. if counterpart1 is available in Objective-C and counterpart2 is **also** available in Objective-C.

And suggestions will be provided depending on context:
- which languages are duplicate
- all the languages the symbol is already available in will be available as part of the diagnostic explanation
- if the `@AlternateRepresentation` directive is a duplicate, a suggestion will be made to remove it, with a suitable replacement
- if the `@AlternateRepresentation` directive is a duplicate, a note pointing to the original directive will be added


 ```
warning: An alternate representation for Swift already exists
This node is already available in Swift and Objective-C.
SynonymSample.docc/SymbolExtension2.md:4:5: An alternate representation for Swift has already be
en defined by an @AlternateRepresentation directive.
 --> SynonymSample.docc/SymbolExtension2.md:5:5-5:57
3 | @Metadata {
4 |     @AlternateRepresentation(``Synonyms/Synonym-5zxmc``)
5 +     @AlternateRepresentation(``Synonyms/Synonym-5zxmc``)
  |     ╰─suggestion: Remove this alternate representation
6 | }
7 |
```

```
warning: This node already has a representation in Swift
This node is already available in Swift.
 --> SynonymSample.docc/SynonymExtension.md:5:5-5:56
3 | @Metadata {
4 |     @AlternateRepresentation(``Synonyms/Synonym-1wqxt``)
5 +     @AlternateRepresentation(``Synonyms/OtherSynonym``)
  |     ╰─suggestion: Replace the counterpart link with a node which isn't available in Swift
6 | }
7 |
```

## Dependencies

None.

## Testing

Tested by building and rendering the following archive locally, which uses the new directive: 
[SynonymSample.docc.zip](https://github.com/user-attachments/files/17874236/SynonymSample.docc.zip)

This contains two symbols which have been configured to be counterparts of each other.

You should be able to switch between both symbols using the language picker from either:
http://localhost:8080/documentation/synonyms/synonym-1wqxt?language=objc
or
http://localhost:8080/documentation/synonyms/synonym-5zxmc

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
