### PR TITLE
Improve performance of JSONPointer encoding

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/JSONPointer.swift
@@ -99,6 +99,7 @@ public struct JSONPointer: Codable, CustomStringConvertible, Equatable {
             pathComponents.reduce(0) { acc, component in
                 acc + 1 /* the "/" separator */ + component.utf8.count
             }
+            + 16 // some extra capacity since the escaped replacements grow the string beyond its original length.
         )
         
         for component in pathComponents {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This improves the performance of JSONPointer encoding which is a hot spot when building documentation for mixed Swift and Objective-C projects.

On an example mixed Swift and Objective-C project with 10k+ symbols, these changes improves the _total_ documentation convert time by almost 1%:

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main                 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'convert-total-time'        │ -0,9475 %¹      │ 14,88 sec            │ 14,739 sec           │
│ Duration for 'documentation-processing'  │ -1,533 %²       │ 6,859 sec            │ 6,754 sec            │
│ Duration for 'finalize-navigation-index' │ -1,141 %³       │ 0,293 sec            │ 0,29 sec             │
│ Peak memory footprint                    │ no change⁴,⁵    │ 743,2 MB             │ 745,9 MB             │
│ Data subdirectory size                   │ no change⁶      │ 248,6 MB             │ 248,6 MB             │
│ Index subdirectory size                  │ no change⁷      │ 5,3 MB               │ 5,3 MB               │
│ Total DocC archive size                  │ no change⁸      │ 288,5 MB             │ 288,6 MB             │
│ Topic Anchor Checksum                    │ no change       │ 081bb0f890c7fa3fba23 │ 081bb0f890c7fa3fba23 │
│ Topic Graph Checksum                     │ no change       │ 2683bd73f5612a553927 │ 2683bd73f5612a553927 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘

 1: There's a statistically significant difference between the two benchmark measurements.
    The values are different enough that the most probable explanation is that they're random samples from two different data sets.
    t-statistic : +3,226          degrees of freedom : 28       95% confidence critical value : +2,042

 2: There's a statistically significant difference between the two benchmark measurements.
    The values are different enough that the most probable explanation is that they're random samples from two different data sets.
    t-statistic : +3,576          degrees of freedom : 28       95% confidence critical value : +2,042

 3: There's a statistically significant difference between the two benchmark measurements.
    The values are different enough that the most probable explanation is that they're random samples from two different data sets.
    t-statistic : +2,606          degrees of freedom : 28       95% confidence critical value : +2,042

 4: No statistically significant difference.
    The values are similar enough that the most probable explanation is that they're random samples from the same data set.
    t-statistic : -0,707          degrees of freedom : 28       95% confidence critical value : +2,042

 5: A human should check that the measurements for this metric look like random samples around a certain value to ensure the validity of this result.


 6: No statistically significant difference.
    The values are similar enough that the most probable explanation is that they're random samples from the same data set.
    t-statistic : -1,569          degrees of freedom : 28       95% confidence critical value : +2,042

 7: No statistically significant difference.
    The values are similar enough that the most probable explanation is that they're random samples from the same data set.
    t-statistic : -0,005          degrees of freedom : 28       95% confidence critical value : +2,042

 8: No statistically significant difference.
    The values are similar enough that the most probable explanation is that they're random samples from the same data set.
    t-statistic : -1,566          degrees of freedom : 28       95% confidence critical value : +2,042
```

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
