### PR TITLE
[6.1] Cherry-pick two last-minute PRs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"
@@ -57,7 +57,7 @@
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/apple/swift-docc-plugin.git",
       "state" : {
         "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
         "version" : "1.3.0"
@@ -66,7 +66,7 @@
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/apple/swift-docc-symbolkit.git",
       "state" : {
         "branch" : "main",
         "revision" : "96bce1cfad4f4d7e265c1eb46729ebf8a7695f4b"

--- a/Package.swift
+++ b/Package.swift
@@ -132,10 +132,10 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-        .package(url: "https://github.com/apple/swift-docc-symbolkit", branch: "main"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+        .package(url: "https://github.com/apple/swift-docc-symbolkit.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.2.0"),
     ]
 } else {
     // Building in the Swift.org CI system, so rely on local versions of dependencies.

--- a/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
@@ -52,8 +52,7 @@ extension Benchmark {
                 let peakMemoryString = statusString.components(separatedBy: .newlines)
                     .first(where: { $0.hasPrefix("VmPeak") })?
                     .components(separatedBy: CharacterSet.decimalDigits.inverted)
-                    .filter({ !$0.isEmpty })
-                    .first,
+                    .first(where: { !$0.isEmpty }),
                 let peakMemory = Double(peakMemoryString) else { return nil }
 
             return Int64(peakMemory * 1024) // convert from KBytes to bytes


### PR DESCRIPTION
This PR cherry-picks two recent PRs that landed in main just after the `release/6.1` branch was created.

cc @icanzilb @Kyome22 

  - **Explanation**: Refactors some code in the benchmark runner for performance and clarity.
  - **Scope**: Small refactor; no change to behavior.
  - **Issues**: https://github.com/swiftlang/swift-docc/issues/1066
  - **Original PRs**: https://github.com/swiftlang/swift-docc/pull/1067
  - **Risk**: Very low. The changed code is minor and has equivalent semantics.
  - **Testing**: Automated and manual testing has passed.
  - **Reviewers**: @d-ronnqvist 

<!-- break up these lists -->

  - **Explanation**: Updates Package.swift to use URLs ending in `.git`, for consistency with other first-party Swift packages.
  - **Scope**: Minor update to package specification.
  - **Issues**: None
  - **Original PRs**: https://github.com/swiftlang/swift-docc/pull/1073
  - **Risk**: Very low. The change updates URLs to an equivalent URL that resolves to the same dependency.
  - **Testing**: Automated testing has passed.
  - **Reviewers**: @d-ronnqvist 