### PR TITLE
Resolve a few recently introduced warnings

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -144,7 +144,7 @@ public class DocumentationContext {
         case .legacy(let legacyDataProvider):
             return try legacyDataProvider.contentsOfURL(url, in: bundle)
         case .new(let dataProvider):
-            assert(self.bundle?.identifier == bundle.identifier, "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'.")
+            assert(self.bundle?.id == bundle.id, "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'.")
             return try dataProvider.contents(of: url)
         }
     }
@@ -392,7 +392,7 @@ public class DocumentationContext {
         case .legacy(let legacyDataProvider):
             return legacyDataProvider.bundles[identifier]
         case .new:
-            assert(bundle?.identifier == identifier, "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'.")
+            assert(bundle?.id.rawValue == identifier, "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'.")
             return bundle?.id.rawValue == identifier ? bundle : nil
         }
     }

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/String+Path.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/String+Path.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,13 +18,13 @@ extension StringProtocol {
     }
     
     /// A copy of the string appended with a slash ("/") if the string doesn't already end with a trailing slash.
-    var appendingTrailingSlash: String {
+    package var appendingTrailingSlash: String {
         guard !hasSuffix("/") else { return String(self) }
         return self.appending("/")
     }
     
     /// A copy of the string without a leading slash ("/") or the original string if it doesn't start with a leading slash.
-    var removingLeadingSlash: String {
+    package var removingLeadingSlash: String {
         guard hasPrefix("/") else { return String(self) }
         return String(dropFirst())
     }

--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 import XCTest
-@testable import SwiftDocC
+import SwiftDocC
 
 /// A Data provider and file manager that accepts pre-built documentation bundles with files on the local filesystem.
 ///
@@ -321,7 +321,7 @@ package class TestFileSystem: FileManagerProtocol {
         case invalidPath(String)
         var errorDescription: String {
             switch self { 
-                case .invalidPath(let path): return "Invalid path \(path.singleQuoted)"
+                case .invalidPath(let path): return "Invalid path '\(path)'"
             }
         }
     }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -67,7 +67,6 @@ extension MergeAction {
         renderNode.metadata.title = name
         renderNode.metadata.roleHeading = roleHeading
         renderNode.metadata.role = "collection"
-        renderNode.hierarchy = nil
         renderNode.sections = []
         
         if rootRenderReferences.containsBothKinds {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This resolves a few recently introduced warnings.

It also removes the need for `@testable import` in the testing utilities target.

## Dependencies

None

## Testing

Nothing in particular. This isn't used-facing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
