### PR TITLE
Deprecate `FileSystemProvider` and `RenderNodeProvider`

### DIFF
--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex+Ext.swift
@@ -10,56 +10,11 @@
 
 import Foundation
 
-/// A class that provides render nodes by traversing the file system.
-package class FileManagerRenderNodeProvider: RenderNodeProvider {
-    /// The iterator of files to provide render nodes for.
-    private var iterator: any IteratorProtocol<URL>
-    
-    package init(fileManager: FileManagerProtocol, startingPoint: URL) {
-        iterator = fileManager.recursiveFiles(startingPoint: startingPoint).makeIterator()
-    }
-    
-    /// Returns a render node that can be processed by an index creator, for example.
-    package func getRenderNode() -> RenderNode? {
-        guard let nextFile = iterator.next() else {
-            return nil // Traversed the entire directory structure
-        }
-        guard nextFile.pathExtension.lowercased() == "json" else {
-            return getRenderNode() // Iterate again to find the next matching file
-        }
-        
-        do {
-            let data = try Data(contentsOf: nextFile)
-            return try RenderNode.decode(fromJSON: data)
-        } catch {
-            problems.append(
-                Problem(diagnostic: Diagnostic(
-                    source: nextFile,
-                    severity: .warning,
-                    range: nil,
-                    identifier: "org.swift.docc.RenderNodeDecodingError",
-                    summary: "Encountered an unexpected error decoding render node for indexing file found while indexing content: \(error.localizedDescription)"
-                ))
-            )
-            // Iterate again to find the next matching file
-            return getRenderNode()
-        }
-    }
-    
-    private var problems = [Problem]()
-    
-    /// Returns the list problems that the provider encountered during the process.
-    /// - Note: These problems represent unexpected errors and aren't user-actionable.
-    package func getProblems() -> [Problem] {
-        problems
-    }
-}
-
 /**
  This class provides a simple way to transform a `FileSystemProvider` into a `RenderNodeProvider` to feed an index builder.
  The data from the disk is fetched and processed in an efficient way to build a navigator index.
  */
-@available(*, deprecated, message: "Use 'FileManagerRenderNodeProvider' instead. This deprecated API will be removed after 6.2 is released.")
+@available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released.")
 public class FileSystemRenderNodeProvider: RenderNodeProvider {
     
     /// The internal `FileSystemProvider` reference.

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -12,6 +12,7 @@ import Foundation
 import Crypto
 
 /// A protocol to provide data to be indexed.
+@available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released.")
 public protocol RenderNodeProvider {
     /// Get an instance of `RenderNode` to be processed by the index.
     /// - Note: Returning `nil` will end the indexing process.
@@ -20,8 +21,6 @@ public protocol RenderNodeProvider {
     /// Returns an array of `Problem` indicating which problems the `Provider` encountered.
     func getProblems() -> [Problem]
 }
-
-
 
 /**
  A `NavigatorIndex` contains all the necessary information to display the data inside a navigator.
@@ -479,7 +478,11 @@ extension NavigatorIndex {
     open class Builder {
         
         /// The data provider.
+        @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
         public let renderNodeProvider: RenderNodeProvider?
+        
+        /// The documentation archive to build an index from.
+        public let archiveURL: URL?
         
         /// The output URL.
         public let outputURL: URL
@@ -554,7 +557,6 @@ extension NavigatorIndex {
         /// Indicates if the page title should be used instead of the navigator title.
         private let usePageTitle: Bool
         
-        
         /// Maps the icon render references in the navigator items created by this builder
         /// to their image references.
         ///
@@ -562,18 +564,31 @@ extension NavigatorIndex {
         /// for any custom icons used in this navigator index.
         var iconReferences = [String : ImageReference]()
         
-        
         /// Create a new a builder with the given data provider and output URL.
         /// - Parameters:
-        ///    - renderNodeProvider: The `RenderNode` provider to use.
+        ///    - archiveURL: The location of the documentation archive that the builder builds an navigator index for.
         ///    - outputURL: The location where the builder will write the the built navigator index.
         ///    - bundleIdentifier: The bundle identifier of the documentation that the builder builds a navigator index for.
         ///    - sortRootChildrenByName: Configure the builder to sort root's children by name.
         ///    - groupByLanguage: Configure the builder to group the entries by language.
         ///    - writePathsOnDisk: Configure the builder to write each navigator item's path components to the location.
         ///    - usePageTitle: Configure the builder to use the "page title" instead of the "navigator title" as the title for each entry.
+        public init(archiveURL: URL? = nil, outputURL: URL, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
+            self.archiveURL = archiveURL
+            self.renderNodeProvider = nil
+            self.outputURL = outputURL
+            self.bundleIdentifier = bundleIdentifier
+            self.sortRootChildrenByName = sortRootChildrenByName
+            self.groupByLanguage = groupByLanguage
+            self.writePathsOnDisk = writePathsOnDisk
+            self.usePageTitle = usePageTitle
+        }
+        
+        @available(*, deprecated, renamed: "init(archiveURL:outputURL:bundleIdentifier:sortRootChildrenByName:groupByLanguage:writePathsOnDisk:usePageTitle:)", message: "Use 'init(archiveURL:outputURL:bundleIdentifier:sortRootChildrenByName:groupByLanguage:writePathsOnDisk:usePageTitle:)' instead. This deprecated API will be removed after 6.2 is released")
+        @_disfavoredOverload
         public init(renderNodeProvider: RenderNodeProvider? = nil, outputURL: URL, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
             self.renderNodeProvider = renderNodeProvider
+            self.archiveURL = nil
             self.outputURL = outputURL
             self.bundleIdentifier = bundleIdentifier
             self.sortRootChildrenByName = sortRootChildrenByName
@@ -1245,13 +1260,43 @@ extension NavigatorIndex {
             problems.append(problem)
         }
         
-        /**
-         Build the index using the passed instance of `RenderNodeProvider` if available.
-         - Returns: A list containing all the problems encountered during indexing.
-         - Note: If a provider is not available, this method would generate a fatal error.
-         */
+        
+        /// Build the index using the render nodes files in the provided documentation archive.
+        /// - Returns: A list containing all the errors encountered during indexing.
+        /// - Precondition: Either ``archiveURL`` or ``renderNodeProvider`` is set.
         public func build() -> [Problem] {
-            precondition(renderNodeProvider != nil, "Calling build without a renderNodeProvider set is not permitted.")
+            if let archiveURL {
+                return _build(archiveURL: archiveURL)
+            } else {
+                return (self as _DeprecatedRenderNodeProviderAccess)._legacyBuild()
+            }
+        }
+        
+        // After 6.2 is released, move this into `build()`.
+        private func _build(archiveURL: URL) -> [Problem] {
+            setup()
+            
+            let dataDirectory = archiveURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName, isDirectory: true)
+            for file in FileManager.default.recursiveFiles(startingPoint: dataDirectory) where file.pathExtension.lowercased() == "json" {
+                do {
+                    let data = try Data(contentsOf: file)
+                    let renderNode = try RenderNode.decode(fromJSON: data)
+                    try index(renderNode: renderNode)
+                } catch {
+                    problems.append(error.problem(source: file,
+                                                  severity: .warning,
+                                                  summaryPrefix: "RenderNode indexing process failed"))
+                }
+            }
+            
+            finalize()
+            
+            return problems
+        }
+        
+        @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
+        fileprivate func _legacyBuild() -> [Problem] {
+            precondition(renderNodeProvider != nil, "Calling `build()` without an `archiveURL` or `renderNodeProvider` set is not permitted.")
             
             setup()
             
@@ -1274,7 +1319,6 @@ extension NavigatorIndex {
             return availabilityIDs[Int(availabilityID)]
         }
     }
-    
 }
 
 fileprivate extension Error {
@@ -1343,3 +1387,9 @@ enum PathHasher: String {
         }
     }
 }
+
+private protocol _DeprecatedRenderNodeProviderAccess {
+    // This private function accesses the deprecated RenderNodeProvider
+    func _legacyBuild() -> [Problem]
+}
+extension NavigatorIndex.Builder: _DeprecatedRenderNodeProviderAccess {}

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FileSystemProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FileSystemProvider.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,12 +11,14 @@
 import Foundation
 
 /// A type that vends a tree of virtual filesystem objects.
+@available(*, deprecated, message: "Use 'FileManagerProtocol.recursiveFiles(startingPoint:)' instead. This deprecated API will be removed after 6.2 is released.")
 public protocol FileSystemProvider {
     /// The organization of the files that this provider provides.
     var fileSystem: FSNode { get }
 }
 
 /// An element in a virtual filesystem.
+@available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released.")
 public enum FSNode {
     /// A file in a filesystem.
     case file(File)

--- a/Sources/SwiftDocC/Infrastructure/Workspace/LocalFileSystemDataProvider+BundleDiscovery.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/LocalFileSystemDataProvider+BundleDiscovery.swift
@@ -142,6 +142,7 @@ extension LocalFileSystemDataProvider: DocumentationWorkspaceDataProvider {
     }
 }
 
+@available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released.")
 fileprivate extension [FSNode] {
     /// Returns the first file that matches a given predicate.
     /// - Parameter predicate: A closure that takes a file as its argument and returns a Boolean value indicating whether the file should be returned from this function.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/LocalFileSystemDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/LocalFileSystemDataProvider.swift
@@ -11,6 +11,7 @@
 import Foundation
 
 /// A type that provides documentation bundles that it discovers by traversing the local file system.
+@available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released.")
 public struct LocalFileSystemDataProvider: FileSystemProvider {
     public var identifier: String = UUID().uuidString
     

--- a/Sources/SwiftDocC/Utility/FileManagerProtocol+FilesSequence.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol+FilesSequence.swift
@@ -1,0 +1,66 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension FileManagerProtocol {
+    /// Returns a sequence of all the files in the directory structure from the starting point.
+    package func recursiveFiles(startingPoint: URL) -> some Sequence<URL> {
+        IteratorSequence(FilesIterator(fileManager: self, startingPoint: startingPoint))
+    }
+}
+
+/// An iterator that traverses the directory structure and returns the files in breadth-first order.
+private struct FilesIterator<FileManager: FileManagerProtocol>: IteratorProtocol {
+    /// The file manager that the iterator uses to traverse the directory structure.
+    var fileManager: FileManager
+    
+    private var foundFiles: [URL]
+    private var foundDirectories: [URL]
+    
+    init(fileManager: FileManager, startingPoint: URL) {
+        self.fileManager = fileManager
+        
+        // Check if the starting point is a file or a directory.
+        if fileManager.directoryExists(atPath: startingPoint.path) {
+            foundFiles       = []
+            foundDirectories = [startingPoint]
+        } else {
+            foundFiles       = [startingPoint]
+            foundDirectories = []
+        }
+    }
+    
+    mutating func next() -> URL? {
+        // If the iterator has already found some files, return those first
+        if !foundFiles.isEmpty {
+            return foundFiles.removeFirst()
+        }
+        
+        // Otherwise, check the next found directory and add its contents
+        guard !foundDirectories.isEmpty else {
+            // Traversed the entire directory structure
+            return nil
+        }
+        
+        let directory = foundDirectories.removeFirst()
+        guard let (newFiles, newDirectories) = try? fileManager.contentsOfDirectory(at: directory, options: .skipsHiddenFiles) else {
+            // The iterator protocol doesn't have a mechanism for raising errors. If an error occurs we
+            return nil
+        }
+        
+        foundFiles.append(contentsOf: newFiles)
+        foundDirectories.append(contentsOf: newDirectories)
+        
+        // Iterate again after adding new found files and directories.
+        // This enables the iterator do recurse multiple layers of directories until it finds a file.
+        return next()
+    }
+}

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/Indexer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/Indexer.swift
@@ -36,7 +36,7 @@ extension ConvertAction {
         init(outputURL: URL, bundleID: DocumentationBundle.Identifier) throws {
             let indexURL = outputURL.appendingPathComponent("index", isDirectory: true)
             indexBuilder = Synchronized<NavigatorIndex.Builder>(
-                NavigatorIndex.Builder(renderNodeProvider: nil,
+                NavigatorIndex.Builder(
                     outputURL: indexURL,
                     bundleIdentifier: bundleID.rawValue,
                     sortRootChildrenByName: true,

--- a/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
@@ -40,8 +40,8 @@ public struct IndexAction: AsyncAction {
     }
     
     private func buildIndex() throws -> [Problem] {
-        let dataProvider = try LocalFileSystemDataProvider(rootURL: rootURL)
-        let indexBuilder = NavigatorIndex.Builder(renderNodeProvider: FileSystemRenderNodeProvider(fileSystemProvider: dataProvider),
+        let renderNodeProvider = FileManagerRenderNodeProvider(fileManager: FileManager.default, startingPoint: rootURL)
+        let indexBuilder = NavigatorIndex.Builder(renderNodeProvider: renderNodeProvider,
                                                   outputURL: outputURL,
                                                   bundleIdentifier: bundleIdentifier,
                                                   sortRootChildrenByName: true,

--- a/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
@@ -40,8 +40,7 @@ public struct IndexAction: AsyncAction {
     }
     
     private func buildIndex() throws -> [Problem] {
-        let renderNodeProvider = FileManagerRenderNodeProvider(fileManager: FileManager.default, startingPoint: rootURL)
-        let indexBuilder = NavigatorIndex.Builder(renderNodeProvider: renderNodeProvider,
+        let indexBuilder = NavigatorIndex.Builder(archiveURL: rootURL,
                                                   outputURL: outputURL,
                                                   bundleIdentifier: bundleIdentifier,
                                                   sortRootChildrenByName: true,

--- a/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
@@ -13,21 +13,21 @@ import SwiftDocC
 
 /// An action that creates an index of a documentation bundle.
 public struct IndexAction: AsyncAction {
-    let rootURL: URL
+    let archiveURL: URL
     let outputURL: URL
     let bundleIdentifier: String
 
     var diagnosticEngine: DiagnosticEngine
 
     /// Initializes the action with the given validated options, creates or uses the given action workspace & context.
-    public init(documentationBundleURL: URL, outputURL: URL, bundleIdentifier: String, diagnosticEngine: DiagnosticEngine = .init()) throws {
+    public init(archiveURL: URL, outputURL: URL, bundleIdentifier: String, diagnosticEngine: DiagnosticEngine = .init()) {
         // Initialize the action context.
-        self.rootURL = documentationBundleURL
+        self.archiveURL = archiveURL
         self.outputURL = outputURL
         self.bundleIdentifier = bundleIdentifier
 
         self.diagnosticEngine = diagnosticEngine
-        self.diagnosticEngine.add(DiagnosticConsoleWriter(formattingOptions: [], baseURL: documentationBundleURL))
+        self.diagnosticEngine.add(DiagnosticConsoleWriter(formattingOptions: [], baseURL: archiveURL))
     }
     
     /// Converts each eligible file from the source documentation bundle,
@@ -40,7 +40,7 @@ public struct IndexAction: AsyncAction {
     }
     
     private func buildIndex() throws -> [Problem] {
-        let indexBuilder = NavigatorIndex.Builder(archiveURL: rootURL,
+        let indexBuilder = NavigatorIndex.Builder(archiveURL: archiveURL,
                                                   outputURL: outputURL,
                                                   bundleIdentifier: bundleIdentifier,
                                                   sortRootChildrenByName: true,

--- a/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
@@ -92,8 +92,7 @@ struct TransformForStaticHostingAction: AsyncAction {
         )
 
         // Create a StaticHostableTransformer targeted at the archive data folder
-        let dataProvider = try LocalFileSystemDataProvider(rootURL: rootURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName))
-        let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
+        let transformer = StaticHostableTransformer(dataDirectory: rootURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName), fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
         try transformer.transform()
         
     }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/IndexAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/IndexAction+CommandInitialization.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,10 @@ import Foundation
 
 extension IndexAction {
     /// Initializes ``IndexAction`` from the options in the ``Index`` command.
-    init(fromIndexCommand index: Docc.Index) throws {
+    init(fromIndexCommand index: Docc.Index) {
         // Initialize the `IndexAction` from the options provided by the `Index` command
-        try self.init(
-            documentationBundleURL: index.documentationBundle.urlOrFallback,
+        self.init(
+            archiveURL: index.documentationArchive.urlOrFallback,
             outputURL: index.outputURL,
             bundleIdentifier: index.bundleIdentifier)
     }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
@@ -21,7 +21,7 @@ extension Docc {
 
         /// The user-provided path to a `.doccarchive` documentation archive.
         @OptionGroup()
-        public var documentationBundle: DocCArchiveOption
+        public var documentationArchive: DocCArchiveOption
 
         /// The user-provided bundle name to use for the produced index.
         @Option(help: "The bundle name for the index.")
@@ -33,11 +33,11 @@ extension Docc {
 
         /// The path to the directory that all build output should be placed in.
         public var outputURL: URL {
-            documentationBundle.urlOrFallback.appendingPathComponent("index", isDirectory: true)
+            documentationArchive.urlOrFallback.appendingPathComponent("index", isDirectory: true)
         }
 
         public func run() async throws {
-            var indexAction = try IndexAction(fromIndexCommand: self)
+            var indexAction = IndexAction(fromIndexCommand: self)
             try await indexAction.performAndHandleResult()
         }
     }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -2257,7 +2257,7 @@ class ConvertActionTests: XCTestCase {
         let targetDirectory = URL(fileURLWithPath: testDataProvider.currentDirectoryPath)
             .appendingPathComponent("target", isDirectory: true)
 
-        var action = try ConvertAction(
+        let action = try ConvertAction(
             documentationBundleURL: bundle.absoluteURL,
             outOfProcessResolver: nil,
             analyze: true,
@@ -2291,7 +2291,7 @@ class ConvertActionTests: XCTestCase {
         // TODO: Support TestFileSystem in DiagnosticFileWriter
         let diagnosticFile = try createTemporaryDirectory().appendingPathComponent("test-diagnostics.json")
         
-        var action = try ConvertAction(
+        let action = try ConvertAction(
             documentationBundleURL: bundle.absoluteURL,
             outOfProcessResolver: nil,
             analyze: true,
@@ -2363,7 +2363,7 @@ class ConvertActionTests: XCTestCase {
         let digestFileURL = targetDirectory
             .appendingPathComponent("diagnostics.json")
         
-        var action = try ConvertAction(
+        let action = try ConvertAction(
             documentationBundleURL: bundle.absoluteURL,
             outOfProcessResolver: nil,
             analyze: false,
@@ -2394,7 +2394,7 @@ class ConvertActionTests: XCTestCase {
         
         let targetDirectory = temporaryDirectory.appendingPathComponent("target", isDirectory: true)
         
-        var action = try ConvertAction(
+        let action = try ConvertAction(
             documentationBundleURL: catalogURL,
             outOfProcessResolver: nil,
             analyze: false,
@@ -2530,7 +2530,7 @@ class ConvertActionTests: XCTestCase {
         
         let targetDirectory = temporaryDirectory.appendingPathComponent("target.doccarchive", isDirectory: true)
         
-        var action = try ConvertAction(
+        let action = try ConvertAction(
             documentationBundleURL: catalogURL,
             outOfProcessResolver: nil,
             analyze: false,

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1946,8 +1946,8 @@ class ConvertActionTests: XCTestCase {
         
         // Run just the index command over the built documentation
         
-        let indexAction = try IndexAction(
-            documentationBundleURL: targetURL,
+        let indexAction = IndexAction(
+            archiveURL: targetURL,
             outputURL: indexURL,
             bundleIdentifier: indexFromConvertAction.bundleIdentifier
         )

--- a/Tests/SwiftDocCUtilitiesTests/IndexActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/IndexActionTests.swift
@@ -50,8 +50,8 @@ class IndexActionTests: XCTestCase {
             
             let engine = DiagnosticEngine(filterLevel: .warning)
             
-            let indexAction = try IndexAction(
-                documentationBundleURL: targetBundleURL,
+            let indexAction = IndexAction(
+                archiveURL: targetBundleURL,
                 outputURL: indexURL,
                 bundleIdentifier: bundleIdentifier,
                 diagnosticEngine: engine
@@ -61,6 +61,7 @@ class IndexActionTests: XCTestCase {
             let index = try NavigatorIndex.readNavigatorIndex(url: indexURL)
             
             resultIndexDumps.insert(index.navigatorTree.root.dumpTree())
+            XCTAssert(engine.problems.isEmpty, "Unexpected problems:\n\(engine.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
             XCTAssertTrue(engine.problems.isEmpty, "Indexing bundle at \(targetURL) resulted in unexpected issues")
         }
         
@@ -91,8 +92,8 @@ class IndexActionTests: XCTestCase {
         let bundleIdentifier = "org.swift.docc.example"
         let indexURL = targetURL.appendingPathComponent("index")
         let engine = DiagnosticEngine(filterLevel: .warning)
-        let indexAction = try IndexAction(
-            documentationBundleURL: targetBundleURL,
+        let indexAction = IndexAction(
+            archiveURL: targetBundleURL,
             outputURL: indexURL,
             bundleIdentifier: bundleIdentifier,
             diagnosticEngine: engine

--- a/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/StaticHostableTransformerTests.swift
@@ -55,8 +55,7 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
         let indexHTMLData = try StaticHostableTransformer.indexHTMLData(in: testTemplateURL, with: basePath, fileManager: fileManager)
         
         let dataURL = targetBundleURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
-        let dataProvider = try LocalFileSystemDataProvider(rootURL: dataURL)
-        let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
+        let transformer = StaticHostableTransformer(dataDirectory: dataURL, fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
         
         try transformer.transform()
         
@@ -144,7 +143,6 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
         _ = try await action.perform(logHandle: .none)
 
         let dataURL = targetBundleURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName)
-        let dataProvider = try LocalFileSystemDataProvider(rootURL: dataURL)
 
         let testTemplateURL = try createTemporaryDirectory().appendingPathComponent("testTemplate")
         try Folder.testHTMLTemplateDirectory.write(to: testTemplateURL)
@@ -160,10 +158,10 @@ class StaticHostableTransformerTests: StaticHostingBaseTests {
 
         let fileManager = FileManager.default
         for (basePath, testValue) in basePaths {
-            let outputURL = try createTemporaryDirectory().appendingPathComponent("output")
+            let outputURL = try createTemporaryDirectory().appendingPathComponent("output/")
             let indexHTMLData = try StaticHostableTransformer.indexHTMLData(in: testTemplateURL, with: basePath, fileManager: FileManager.default)
           
-            let transformer = StaticHostableTransformer(dataProvider: dataProvider, fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
+            let transformer = StaticHostableTransformer(dataDirectory: dataURL, fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
 
             try transformer.transform()
 

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
@@ -133,6 +133,18 @@ class TestFileSystemTests: XCTestCase {
         │     ╰─ myfile2.txt
         ╰─ tmp/
         """)
+        
+        let filesIterator = fs.recursiveFiles(startingPoint: URL(fileURLWithPath: "/"))
+        XCTAssertEqual(filesIterator.prefix(2).map(\.path).sorted(), [
+            // Shallow files first
+            "/copy/myfile1.txt",
+            "/copy/myfile2.txt",
+        ])
+        XCTAssertEqual(filesIterator.dropFirst(2).map(\.path).sorted(), [
+            // Deeper files after
+            "/main/nested/myfile1.txt",
+            "/main/nested/myfile2.txt",
+        ])
     }
 
     
@@ -175,6 +187,10 @@ class TestFileSystemTests: XCTestCase {
         │     ╰─ myfile2.txt
         ╰─ tmp/
         """)
+        
+        XCTAssertEqual(fs.recursiveFiles(startingPoint: URL(fileURLWithPath: "/")).map(\.lastPathComponent), [
+            "myfile2.txt",
+        ])
     }
 
     func testRemoveFolders() throws {
@@ -239,6 +255,10 @@ class TestFileSystemTests: XCTestCase {
         │     ╰─ myfile2.txt
         ╰─ tmp/
         """)
+        
+        XCTAssertEqual(fs.recursiveFiles(startingPoint: URL(fileURLWithPath: "/")).map(\.lastPathComponent).sorted(), [
+            "myfile1.txt", "myfile2.txt",
+        ])
     }
     
     func testCreateDeeplyNestedDirectory() throws {
@@ -257,6 +277,8 @@ class TestFileSystemTests: XCTestCase {
         │              ╰─ six/
         ╰─ tmp/
         """)
+        
+        XCTAssertEqual(fs.recursiveFiles(startingPoint: URL(fileURLWithPath: "/")).map(\.lastPathComponent), [], "Only directories. No files.")
     }
     
     func testFileExists() throws {


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This deprecates `FileSystemProvider` and `RenderNodeProvider`. They each had their issues. 

The clearest sign that `FileSystemProvider` was a poor API is that both call sites had to reimplement tree traversal to use it:
- `FileSystemRenderNodeProvider` implemented its own breadth first traversal to iterate over the files.
- `StaticHostableTransformer` had ~80 LOC of private recursive functions to iterate over the files and determine what their relative paths are.

The issues with `RenderNodeProvider` are more subtle. Ignoring the issues with the API naming; 
- `getProblems()` was never called, so conforming types created diagnostics that was never presented to the user.
- The issues represented by `getProblems()` was unexpected errors rather that user-facing diagnostics, so `Problem` isn't an appropriate type for this information.
- There's only one type that conforms to `RenderNodeProvider` (not even other conforming types in tests). 

What the `NavigatorIndex.Builder` actually needs would have been better described by `some Sequence<RenderNode>`.

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ Not applicable
