### PR TITLE
Remove `throws` for function that doesn't raise any errors.

### DIFF
--- a/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
@@ -36,13 +36,13 @@ public struct DocumentationNodeConverter {
     /// - Parameters:
     ///   - node: The documentation node to convert.
     /// - Returns: The render node representation of the documentation node.
-    public func convert(_ node: DocumentationNode) throws -> RenderNode {
+    public func convert(_ node: DocumentationNode) -> RenderNode {
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return translator.visit(node.semantic) as! RenderNode
     }
     
     @available(*, deprecated, renamed: "convert(_:)", message: "Use 'convert(_:)' instead. This deprecated API will be removed after 6.1 is released")
     public func convert(_ node: DocumentationNode, at source: URL?) throws -> RenderNode {
-        return try convert(node)
+        return convert(node)
     }
 }

--- a/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
+++ b/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
@@ -27,7 +27,7 @@ class DocumentationContextConverterTests: XCTestCase {
         for identifier in context.knownPages {
             let documentationNode = try XCTUnwrap(try context.entity(with: identifier))
             
-            let renderNode1 = try perNodeConverter.convert(documentationNode)
+            let renderNode1 = perNodeConverter.convert(documentationNode)
             let renderNode2 = bulkNodeConverter.renderNode(for: documentationNode)
             
             // Compare the two nodes are identical

--- a/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
+++ b/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
@@ -170,7 +170,7 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
         // For reach topic encode its render node and verify the references are in alphabetical order.
         for reference in context.knownPages {
             let node = try context.entity(with: reference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             
             // Get the encoded JSON as string
             let encodedData = try renderNode.encodeToJSON(with: encoder, renderReferenceCache: cache)
@@ -228,7 +228,7 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
         // For reach topic encode its render node and verify the references are in alphabetical order.
         for reference in context.knownPages {
             let node = try context.entity(with: reference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             
             // Get the encoded JSON as string
             let encodedData = try renderNode.encodeToJSON(with: encoder)

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -957,7 +957,7 @@ Root
             
             for identifier in context.knownPages {
                 let entity = try context.entity(with: identifier)
-                let renderNode = try converter.convert(entity)
+                let renderNode = converter.convert(entity)
                 try builder.index(renderNode: renderNode)
             }
             
@@ -1673,7 +1673,7 @@ Root
         
         for identifier in context.knownPages {
             let entity = try context.entity(with: identifier)
-            let renderNode = try converter.convert(entity)
+            let renderNode = converter.convert(entity)
             try builder.index(renderNode: renderNode)
         }
         

--- a/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
@@ -67,7 +67,7 @@ class AnchorSectionTests: XCTestCase {
 
         // Verify collecting section render references
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
 
         let sectionReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/TechnologyX/Article#Article-Sub-Section"] as? TopicRenderReference)
         XCTAssertEqual(sectionReference.title, "Article Sub-Section")
@@ -125,7 +125,7 @@ class AnchorSectionTests: XCTestCase {
 
         // Verify collecting section render references
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
 
         let sectionReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/CoolFramework/CoolClass#Symbol-Sub-Section"] as? TopicRenderReference)
         XCTAssertEqual(sectionReference.title, "Symbol Sub-Section")
@@ -183,7 +183,7 @@ class AnchorSectionTests: XCTestCase {
 
         // Verify collecting section render references
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
 
         let sectionReference = try XCTUnwrap(renderNode.references["doc://org.swift.docc.example/documentation/CoolFramework#Module-Sub-Section"] as? TopicRenderReference)
         XCTAssertEqual(sectionReference.title, "Module Sub-Section")

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -3237,7 +3237,7 @@ let expected = """
         // Verify that the links are resolved in the render model.
         let bundle = try XCTUnwrap(context.bundle)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
         
         XCTAssertEqual(renderNode.topicSections.map(\.anchor), [
             "Another-topic-section"
@@ -5327,7 +5327,7 @@ let expected = """
         let node = try context.entity(with: reference)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         let externalReference = "doc://Dependency/documentation/ExternalModuleName"
         

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -490,7 +490,7 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssertEqual("doc://com.test.TestBed/documentation/TestBed/MyArticle", symbol.topics?.taskGroups.first?.links.first?.destination)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
         
         // Verify the article identifier is included in the task group for the render node.
         XCTAssertEqual("doc://com.test.TestBed/documentation/TestBed/MyArticle", renderNode.topicSections.first?.identifiers.first)

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -1003,7 +1003,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         for reference in context.knownPages {
             let node = try context.entity(with: reference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             entitySummaries.append(contentsOf: node.externallyLinkableElementSummaries(context: context, renderNode: renderNode, includeTaskGroups: false))
         }
         

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -125,7 +125,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             sourceLanguage: .swift
         )
         let node = try context.entity(with: sideClassReference)
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         // First assert that the external reference is included in the render node's references
         // and is defined as expected.
@@ -267,7 +267,7 @@ class ExternalReferenceResolverTests: XCTestCase {
                 "The test content should include a link for the external reference resolver to resolve"
             )
             
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             
             guard let symbolRenderReference = renderNode.references[expectedReference] as? TopicRenderReference else {
                 XCTFail("The external reference should be resolved and included among the Tutorial's references.")
@@ -310,7 +310,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         guard let symbolRenderReference = renderNode.references["doc://com.test.external/path/to/external/symbol"] as? TopicRenderReference else {
             XCTFail("The external reference should be resolved and included among the SideClass symbols's references.")
@@ -355,7 +355,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/article", sourceLanguage: .swift))
         
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         XCTAssertEqual(externalResolver.resolvedExternalPaths, ["/path/to/external/symbol"], "The authored link was resolved")
         
@@ -402,7 +402,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         guard let sampleRenderReference = renderNode.references["doc://com.test.external/path/to/external/sample"] as? TopicRenderReference else {
             XCTFail("The external reference should be resolved and included among the SideClass symbols's references.")
@@ -501,7 +501,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SomeSample", sourceLanguage: .swift))
         
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         XCTAssertEqual(context.assetManagers.keys.sorted(), ["org.swift.docc.sample"],
                        "The external bundle for the external asset shouldn't have it's own asset manager")
@@ -770,7 +770,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         // Get MyKit symbol
         let entity = try context.entity(with: .init(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
         
         let taskGroupLinks = try XCTUnwrap(renderNode.seeAlsoSections.first?.identifiers)
         // Verify the unresolved links are not included in the task group.
@@ -896,7 +896,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             sourceLanguage: .swift
         )
         let node = try context.entity(with: mixedLanguageFrameworkReference)
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         // Topic identifiers in the Swift variant of the `MixedLanguageFramework` symbol
         let swiftTopicIDs = renderNode.topicSections.flatMap(\.identifiers)
         
@@ -1039,7 +1039,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         do {
             let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/First", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
-            let rendered = try converter.convert(node)
+            let rendered = converter.convert(node)
             
             XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the automatic See Also section created based on the curation on the Root page.")
             let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
@@ -1053,7 +1053,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         do {
             let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Second", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
-            let rendered = try converter.convert(node)
+            let rendered = converter.convert(node)
             
             XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the automatic See Also section created based on the curation on the Root page.")
             let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)
@@ -1094,7 +1094,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let reference = try XCTUnwrap(context.soleRootModuleReference)
         let node = try context.entity(with: reference)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let rendered = try converter.convert(node)
+        let rendered = converter.convert(node)
         
         XCTAssertEqual(rendered.seeAlsoSections.count, 1, "The page should only have the authored See Also section.")
         let seeAlso = try XCTUnwrap(rendered.seeAlsoSections.first)

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -99,7 +99,7 @@ class ExternalLinkableTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestBundle/Tutorial", sourceLanguage: .swift))
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]
@@ -156,7 +156,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyClass")
@@ -200,7 +200,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "MyProtocol")
@@ -241,7 +241,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
@@ -276,7 +276,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "globalFunction(_:considering:)")
@@ -333,7 +333,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             var summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myFunction()")
@@ -438,7 +438,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "Bar")
@@ -497,7 +497,7 @@ class ExternalLinkableTests: XCTestCase {
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
             
             XCTAssertEqual(summary.title, "myStringFunction(_:)")
@@ -728,7 +728,7 @@ class ExternalLinkableTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
 
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyModule/MyClass/myFunc()", sourceLanguage: .swift))
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
 
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
         let pageSummary = summaries[0]

--- a/Tests/SwiftDocCTests/Model/PropertyListPossibleValuesSectionTests.swift
+++ b/Tests/SwiftDocCTests/Model/PropertyListPossibleValuesSectionTests.swift
@@ -87,14 +87,14 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         // Check that the `Possible Values` section is not rendered if the symbol don't define any possible value.
-        XCTAssertNil(try converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
+        XCTAssertNil(converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
     }
     
     func testUndocumentedPossibleValues() throws {
         let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let possibleValuesSection = try XCTUnwrap(try converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
+        let possibleValuesSection = try XCTUnwrap(converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
         let possibleValues: [PossibleValuesRenderSection.NamedValue] = possibleValuesSection.values
         
         // Check that if no possible values were documented they still show under the Possible Values section.

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1933,7 +1933,7 @@ Document
             let (bundle, context, reference) = try makeTestBundle(currentPlatforms: nil, referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
-            let renderNode = try DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
+            let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
             
             // Verify platform beta was plumbed all the way to the render JSON
             XCTAssertEqual(renderNode.metadata.platforms?.first?.isBeta, false)
@@ -1961,7 +1961,7 @@ Document
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
-            let renderNode = try DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
+            let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
             
             // Verify platform beta was plumbed all the way to the render JSON
             XCTAssertEqual(renderNode.metadata.platforms?.first?.isBeta, false)
@@ -1975,7 +1975,7 @@ Document
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
-            let renderNode = try DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
+            let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
             
             // Verify platform beta was plumbed all the way to the render JSON
             XCTAssertEqual(renderNode.metadata.platforms?.first?.isBeta, false)
@@ -1989,7 +1989,7 @@ Document
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
-            let renderNode = try DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
+            let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
 
             // Verify platform beta was plumbed all the way to the render JSON
             XCTAssertEqual(renderNode.metadata.platforms?.first(where: { $0.name == "macOS"})?.isBeta, true)
@@ -2003,7 +2003,7 @@ Document
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
-            let renderNode = try DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
+            let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
             
             // Verify platform beta was plumbed all the way to the render JSON
             XCTAssertEqual(renderNode.metadata.platforms?.first(where: { $0.name == "macOS" })?.isBeta, true)
@@ -2019,7 +2019,7 @@ Document
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
-            let renderNode = try DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
+            let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
             
             // Verify task group link is not in beta betas "iOS" is not being marked as beta
             XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)"] as? TopicRenderReference)?.isBeta, false)
@@ -3362,7 +3362,7 @@ Document
         XCTAssertEqual(documentationNode.availableVariantTraits.count, 2, "This page has Swift and Objective-C variants")
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(documentationNode)
+        let renderNode = converter.convert(documentationNode)
         
         let topicSectionsVariants = renderNode.topicSectionsVariants
         
@@ -3448,7 +3448,7 @@ Document
         }
         
         let nodeConverter = DocumentationNodeConverter(bundle: bundle, context: context)
-        try assertExpectedTopicSections(nodeConverter.convert(documentationNode))
+        assertExpectedTopicSections(nodeConverter.convert(documentationNode))
         
         let contextConverter = DocumentationContextConverter(
             bundle: bundle,
@@ -3497,7 +3497,7 @@ Document
         XCTAssertEqual(documentationNode.availableVariantTraits.count, 1)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(documentationNode)
+        let renderNode = converter.convert(documentationNode)
         
         let topicSection = renderNode.topicSectionsVariants.defaultValue
         
@@ -3516,7 +3516,7 @@ Document
             let node = try context.entity(with: root)
             
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             
             let swiftTopicSections = renderNode.topicSectionsVariants.defaultValue
             XCTAssertEqual(swiftTopicSections.flatMap { [$0.title!] + $0.identifiers }, [
@@ -3549,7 +3549,7 @@ Document
             let node = try context.entity(with: reference)
             
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             
             let swiftTopicSections = renderNode.topicSectionsVariants.defaultValue
             XCTAssertEqual(swiftTopicSections.flatMap { [$0.title!] + $0.identifiers }, [
@@ -3641,7 +3641,7 @@ Document
         let node = try context.entity(with: unnamedStructReference)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         XCTAssertEqual(renderNode.metadata.title, "struct (unnamed)")
         XCTAssertEqual(renderNode.metadata.navigatorTitle?.map(\.text).joined(), "struct (unnamed)")

--- a/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
@@ -60,7 +60,7 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
             let (_, bundle, context) = try loadBundle(from: tempURL)
             let node = try XCTUnwrap(context.documentationCache["plist:propertylistkey"])
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let renderNode = try converter.convert(node)
+            let renderNode = converter.convert(node)
             return try XCTUnwrap(renderNode.primaryContentSections.mapFirst(where: { $0 as? PropertyListDetailsRenderSection }))
         }
         

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -109,7 +109,7 @@ class RenderMetadataTests: XCTestCase {
         
         // Verify the rendered metadata contains the bystanders
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "MyKit")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["Foundation"])
     }
@@ -136,7 +136,7 @@ class RenderMetadataTests: XCTestCase {
 
         // Verify the rendered metadata contains the bystanders
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "OverlayTest")
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["BaseKit"])
     }

--- a/Tests/SwiftDocCTests/Rendering/TermListTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/TermListTests.swift
@@ -91,7 +91,7 @@ class TermListTests: XCTestCase {
         let entity = try context.entity(with: reference)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(entity)
+        let renderNode = converter.convert(entity)
         
         let overviewSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
         

--- a/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
@@ -458,7 +458,7 @@ class ListItemExtractorTests: XCTestCase {
         }
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let renderNode = try converter.convert(node)
+        let renderNode = converter.convert(node)
         
         let renderContent = try XCTUnwrap(findRenderContent(renderNode), "Didn't find any rendered content", file: file, line: line)
         let expectedRenderContent: [RenderBlockContent] = [


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This removes a `throws` for a function that never raises any errors, removing the need to `try` at the call site.

AFAIK this is source compatible because existing call sites only get a warning that the `try` isn't necessary. 

## Dependencies

None.

## Testing

Nothing in particular. This isn't user-facing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
