### PR TITLE
Remove `mutating` from function that doesn't mutate anything

### DIFF
--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
@@ -17,7 +17,7 @@ extension AsyncAction {
     /// - Parameter logHandle: The log handle to write encountered warnings and errors to.
     ///
     /// - Throws: `ErrorsEncountered` if any errors are produced while performing the action.
-    public mutating func performAndHandleResult(logHandle: LogHandle = .standardOutput) async throws {
+    public func performAndHandleResult(logHandle: LogHandle = .standardOutput) async throws {
         var logHandle = logHandle
         // Perform the Action and collect the result
         let result = try await perform(logHandle: &logHandle)

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -674,7 +674,7 @@ extension Docc {
         }
 
         public func run() async throws {
-            var convertAction = try ConvertAction(fromConvertCommand: self)
+            let convertAction = try ConvertAction(fromConvertCommand: self)
             try await convertAction.performAndHandleResult()
         }
         

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
@@ -157,7 +157,7 @@ extension Docc.ProcessCatalog {
         }
         
         func run() async throws {
-            var action = try EmitGeneratedCurationAction(fromCommand: self)
+            let action = try EmitGeneratedCurationAction(fromCommand: self)
             try await action.performAndHandleResult()
         }
     }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
@@ -37,7 +37,7 @@ extension Docc {
         }
 
         public func run() async throws {
-            var indexAction = try IndexAction(fromIndexCommand: self)
+            let indexAction = try IndexAction(fromIndexCommand: self)
             try await indexAction.performAndHandleResult()
         }
     }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Init.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Init.swift
@@ -25,7 +25,7 @@ extension Docc {
         public var initOptions: InitOptions
         
         public func run() async throws {
-            var initAction = try InitAction(fromInitOptions: initOptions)
+            let initAction = try InitAction(fromInitOptions: initOptions)
             try await initAction.performAndHandleResult()
         }
     }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -169,7 +169,7 @@ extension Docc {
         
         public func run() async throws {
             // Initialize a `ConvertAction` from the current options in the `Convert` command.
-            var convertAction = MergeAction(
+            let convertAction = MergeAction(
                 archives: archives,
                 landingPageInfo: .synthesize(.init(name: synthesizedLandingPageName, kind: synthesizedLandingPageKind, style: synthesizedLandingPageTopicsStyle)),
                 outputURL: outputURL,

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
@@ -44,7 +44,7 @@ extension Docc {
         }
 
         public func run() async throws {
-            var previewAction = try PreviewAction(fromPreviewOptions: previewOptions)
+            let previewAction = try PreviewAction(fromPreviewOptions: previewOptions)
             try await previewAction.performAndHandleResult()
         }
     }

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/TransformForStaticHosting.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/TransformForStaticHosting.swift
@@ -63,7 +63,7 @@ extension Docc.ProcessArchive {
         }
         
         func run() async throws {
-            var action = try TransformForStaticHostingAction(fromCommand: self)
+            let action = try TransformForStaticHostingAction(fromCommand: self)
             try await action.performAndHandleResult()
         }
     }


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This removes `mutating` for a function that never raises mutates anything, removing the need to use a `var` at the call site.

## Dependencies

None.

## Testing

Nothing in particular. This isn't user-facing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
