### PR TITLE
[6.1] Ensure that bundle identifiers are valid URL host components

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/ConvertService.swift
@@ -128,7 +128,7 @@ public struct ConvertService: DocumentationService {
             
             if let linkResolvingServer {
                 let resolver = try OutOfProcessReferenceResolver(
-                    bundleIdentifier: request.bundleInfo.identifier,
+                    bundleID: request.bundleInfo.id,
                     server: linkResolvingServer,
                     convertRequestIdentifier: messageIdentifier
                 )
@@ -267,7 +267,7 @@ public struct ConvertService: DocumentationService {
             .compactMap { (value, isDocumentationExtensionContent) -> (ResolvedTopicReference, RenderReferenceStore.TopicContent)? in
                 let (topicReference, article) = value
                 
-                guard let bundle = context.bundle, bundle.identifier == topicReference.bundleIdentifier else { return nil }
+                guard let bundle = context.bundle, bundle.id == topicReference.bundleID else { return nil }
                 let renderer = DocumentationContentRenderer(documentationContext: context, bundle: bundle)
                 
                 let documentationNodeKind: DocumentationNode.Kind = isDocumentationExtensionContent ? .unknownSymbol : .article

--- a/Sources/SwiftDocC/DocumentationService/Convert/Fallback Link Resolution/ConvertServiceFallbackResolver.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Fallback Link Resolution/ConvertServiceFallbackResolver.swift
@@ -26,7 +26,7 @@ protocol ConvertServiceFallbackResolver {
     /// The bundle identifier for the fallback resolver.
     ///
     /// The fallback resolver will only resolve links with this bundle identifier.
-    var bundleIdentifier: String { get }
+    var bundleID: DocumentationBundle.Identifier { get }
     
     // MARK: References
     

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -438,7 +438,7 @@ extension ResolvedTopicReference {
         let normalizedPath = NodeURLGenerator.fileSafeReferencePath(self, lowercased: true)
         
         return NavigatorIndex.Identifier(
-            bundleIdentifier: bundleIdentifier.lowercased(),
+            bundleIdentifier: bundleID.rawValue.lowercased(),
             path: "/" + normalizedPath,
             fragment: fragment,
             languageIdentifier: languageIdentifier

--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
@@ -346,12 +346,24 @@ fileprivate extension NSRegularExpression {
 public struct AssetReference: Hashable, Codable {
     /// The name of the asset.
     public var assetName: String
+    @available(*, deprecated, renamed: "bundleID", message: "Use 'bundleID' instead. This deprecated API will be removed after 6.2 is released")
+    public var bundleIdentifier: String {
+        bundleID.rawValue
+    }
+    
     /// The identifier of the bundle the asset is apart of.
-    public var bundleIdentifier: String
+    public let bundleID: DocumentationBundle.Identifier
     
     /// Creates a reference from a given asset name and the bundle it is apart of.
-    public init(assetName: String, bundleIdentifier: String) {
+    public init(assetName: String, bundleID: DocumentationBundle.Identifier) {
         self.assetName = assetName
-        self.bundleIdentifier = bundleIdentifier
+        self.bundleID = bundleID
+    }
+    @available(*, deprecated, renamed: "init(assetName:bundleID:)", message: "Use 'init(assetName:bundleID:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(assetName: String, bundleIdentifier: String) {
+        self.init(
+            assetName: assetName,
+            bundleID: .init(rawValue: bundleIdentifier)
+        )
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Context/Deprecated/DocumentationContext+Deprecated.swift
+++ b/Sources/SwiftDocC/Infrastructure/Context/Deprecated/DocumentationContext+Deprecated.swift
@@ -18,8 +18,19 @@ extension DocumentationContext {
     
     @available(*, deprecated, renamed: "configuration.externalDocumentationConfiguration.sources", message: "Use 'configuration.externalDocumentationConfiguration.sources' instead. This deprecated API will be removed after Swift 6.2 is released.")
     public var externalDocumentationSources: [BundleIdentifier: ExternalDocumentationSource] {
-        get { configuration.externalDocumentationConfiguration.sources }
-        set { configuration.externalDocumentationConfiguration.sources = newValue }
+        get {
+            var result = [BundleIdentifier: ExternalDocumentationSource]()
+            for (key, value) in configuration.externalDocumentationConfiguration.sources {
+                result[key.rawValue] = value
+            }
+            return result
+        }
+        set {
+            configuration.externalDocumentationConfiguration.sources.removeAll()
+            for (key, value) in newValue {
+                configuration.externalDocumentationConfiguration.sources[.init(rawValue: key)] = value
+            }
+        }
     }
     
     @available(*, deprecated, renamed: "configuration.externalDocumentationConfiguration.globalSymbolResolver", message: "Use 'configuration.externalDocumentationConfiguration.globalSymbolResolver' instead. This deprecated API will be removed after Swift 6.2 is released.")

--- a/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
@@ -76,7 +76,7 @@ extension DocumentationContext {
         /// A collection of configuration related to external sources of documentation.
         public struct ExternalDocumentationConfiguration {
             /// The lookup of external documentation sources by their bundle identifiers.
-            public var sources: [BundleIdentifier: ExternalDocumentationSource] = [:]
+            public var sources: [DocumentationBundle.Identifier: ExternalDocumentationSource] = [:]
             /// A type that resolves all symbols that are referenced in symbol graph files but can't be found in any of the locally available symbol graph files.
             public var globalSymbolResolver: GlobalExternalSymbolResolver?
             /// A list of URLs to documentation archives that the local documentation depends on.

--- a/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
@@ -161,7 +161,7 @@ package enum ConvertActionConverter {
         
         if FeatureFlags.current.isExperimentalLinkHierarchySerializationEnabled {
             do {
-                let serializableLinkInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.identifier)
+                let serializableLinkInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.id)
                 try outputConsumer.consume(linkResolutionInformation: serializableLinkInformation)
                 
                 if !emitDigest {
@@ -191,7 +191,7 @@ package enum ConvertActionConverter {
             break
         }
         
-        try outputConsumer.consume(buildMetadata: BuildMetadata(bundleDisplayName: bundle.displayName, bundleIdentifier: bundle.identifier))
+        try outputConsumer.consume(buildMetadata: BuildMetadata(bundleDisplayName: bundle.displayName, bundleID: bundle.id))
         
         // Log the finalized topic graph checksum.
         benchmark(add: Benchmark.TopicGraphHash(context: context))

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle+Identifier.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle+Identifier.swift
@@ -1,0 +1,67 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension DocumentationBundle {
+    /// A stable and locally unique identifier for a collection of documentation inputs.
+    public struct Identifier: RawRepresentable {
+        public let rawValue: String
+        
+        public init(rawValue: String) {
+            // To ensure that the identifier can be used as a valid "host" component of a resolved topic reference's url,
+            // replace any consecutive sequence of unsupported characters with a "-".
+            self.rawValue = rawValue
+                .components(separatedBy: Self.charactersToReplace)
+                .filter { !$0.isEmpty }
+                .joined(separator: "-")
+        }
+        
+        private static let charactersToReplace = CharacterSet.urlHostAllowed.inverted
+    }
+}
+
+extension DocumentationBundle.Identifier: Hashable {}
+extension DocumentationBundle.Identifier: Sendable {}
+
+// Support creating an identifier from a string literal.
+extension DocumentationBundle.Identifier: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(rawValue: value)
+    }
+}
+
+// Sort identifiers based on their raw string value.
+extension DocumentationBundle.Identifier: Comparable {
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+// Print as a single string value
+extension DocumentationBundle.Identifier: CustomStringConvertible {
+    public var description: String {
+        rawValue
+    }
+}
+
+// Encode and decode the identifier as a single string value.
+extension DocumentationBundle.Identifier: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self.init(rawValue: rawValue)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -57,11 +57,14 @@ public struct DocumentationBundle {
         info.displayName
     }
     
-    /// A identifier for this unit of documentation
-    ///
-    /// The string is typically in reverse DNS format using only the Roman alphabet in upper and lower case (A–Z, a–z), the dot (“.”), and the hyphen (“-”).
+    @available(*, deprecated, renamed: "id", message: "Use 'id' instead. This deprecated API will be removed after 6.2 is released")
     public var identifier: String {
-        info.identifier
+        id.rawValue
+    }
+    
+    /// The documentation bundle's stable and locally unique identifier.
+    public var id: DocumentationBundle.Identifier {
+        info.id
     }
 
     /**
@@ -107,7 +110,6 @@ public struct DocumentationBundle {
 
     /// A custom JSON settings file used to theme renderer output.
     public let themeSettings: URL?
-    
     /// A URL prefix to be appended to the relative presentation URL.
     ///
     /// This is used when a built documentation is hosted in a known location.
@@ -142,9 +144,9 @@ public struct DocumentationBundle {
         self.customHeader = customHeader
         self.customFooter = customFooter
         self.themeSettings = themeSettings
-        self.rootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: "/", sourceLanguage: .swift)
-        self.documentationRootReference = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.documentationFolder, sourceLanguage: .swift)
-        self.tutorialTableOfContentsContainer = ResolvedTopicReference(bundleIdentifier: info.identifier, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
+        self.rootReference = ResolvedTopicReference(bundleID: info.id, path: "/", sourceLanguage: .swift)
+        self.documentationRootReference = ResolvedTopicReference(bundleID: info.id, path: NodeURLGenerator.Path.documentationFolder, sourceLanguage: .swift)
+        self.tutorialTableOfContentsContainer = ResolvedTopicReference(bundleID: info.id, path: NodeURLGenerator.Path.tutorialsFolder, sourceLanguage: .swift)
         self.tutorialsContainerReference = tutorialTableOfContentsContainer.appendingPath(urlReadablePath(info.displayName))
         self.articlesDocumentationRootReference = documentationRootReference.appendingPath(urlReadablePath(info.displayName))
     }

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -354,7 +354,7 @@ public struct DocumentationConverter: DocumentationConverterProtocol {
         
         if FeatureFlags.current.isExperimentalLinkHierarchySerializationEnabled {
             do {
-                let serializableLinkInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.identifier)
+                let serializableLinkInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.id)
                 try outputConsumer.consume(linkResolutionInformation: serializableLinkInformation)
                 
                 if !emitDigest {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationCurator.swift
@@ -80,7 +80,7 @@ struct DocumentationCurator {
         }
         
         // Check if the link has been externally resolved already.
-        if let bundleID = unresolved.topicURL.components.host,
+        if let bundleID = unresolved.topicURL.components.host.map({ DocumentationBundle.Identifier(rawValue: $0) }),
            context.configuration.externalDocumentationConfiguration.sources[bundleID] != nil || context.configuration.convertServiceConfiguration.fallbackResolver != nil {
             if case .success(let resolvedExternalReference) = context.externallyResolvedLinks[unresolved.topicURL] {
                 return resolvedExternalReference
@@ -94,7 +94,7 @@ struct DocumentationCurator {
         let sourceArticlePath = NodeURLGenerator.Path.article(bundleName: bundle.displayName, articleName: articleFilename).stringValue
         
         let reference = ResolvedTopicReference(
-            bundleIdentifier: resolved.bundleIdentifier,
+            bundleID: resolved.bundleID,
             path: sourceArticlePath,
             sourceLanguages: resolved.sourceLanguages)
         

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -51,8 +51,13 @@ import SymbolKit
 public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalExternalSymbolResolver {
     private let externalLinkResolvingClient: ExternalLinkResolving
     
+    @available(*, deprecated, renamed: "id", message: "Use 'id' instead. This deprecated API will be removed after 6.2 is released")
+    public var bundleIdentifier: String {
+        bundleID.rawValue
+    }
+    
     /// The bundle identifier for the reference resolver in the other process.
-    public let bundleIdentifier: String
+    public let bundleID: DocumentationBundle.Identifier
     
     /// Creates a new reference resolver that interacts with another executable.
     ///
@@ -77,20 +82,27 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
             throw Error.invalidBundleIdentifierOutputFromExecutable(processLocation)
         }
         
-        self.bundleIdentifier = decodedBundleIdentifier
+        self.bundleID = .init(rawValue: decodedBundleIdentifier)
         self.externalLinkResolvingClient = longRunningProcess
     }
 
+    @available(*, deprecated, renamed: "init(bundleID:server:convertRequestIdentifier:)", message: "Use 'init(bundleID:server:convertRequestIdentifier:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(bundleIdentifier: String, server: DocumentationServer, convertRequestIdentifier: String?) throws {
+        self.bundleID = .init(rawValue: bundleIdentifier)
+        self.externalLinkResolvingClient = LongRunningService(
+            server: server, convertRequestIdentifier: convertRequestIdentifier)
+    }
+    
     /// Creates a new reference resolver that interacts with a documentation service.
     ///
     /// The documentation service is expected to be able to handle messages of kind "resolve-reference".
     ///
     /// - Parameters:
-    ///   - bundleIdentifier: The bundle identifier the server can resolve references for.
+    ///   - bundleID: The bundle identifier the server can resolve references for.
     ///   - server: The server to send link resolution requests to.
     ///   - convertRequestIdentifier: The identifier that the resolver will use for convert requests that it sends to the server.
-    public init(bundleIdentifier: String, server: DocumentationServer, convertRequestIdentifier: String?) throws {
-        self.bundleIdentifier = bundleIdentifier
+    public init(bundleID: DocumentationBundle.Identifier, server: DocumentationServer, convertRequestIdentifier: String?) throws {
+        self.bundleID = bundleID
         self.externalLinkResolvingClient = LongRunningService(
             server: server, convertRequestIdentifier: convertRequestIdentifier)
     }
@@ -103,7 +115,7 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
             return resolved
             
         case let .unresolved(unresolvedReference):
-            guard unresolvedReference.bundleIdentifier == bundleIdentifier else {
+            guard unresolvedReference.bundleID == bundleID else {
                 fatalError("""
                     Attempted to resolve a local reference externally: \(unresolvedReference.description.singleQuoted).
                     DocC should never pass a reference to an external resolver unless it matches that resolver's bundle identifier.
@@ -135,7 +147,7 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
         guard let resolvedInformation = try? resolveInformationForSymbolIdentifier(preciseIdentifier) else { return nil }
         
         let reference = ResolvedTopicReference(
-            bundleIdentifier: "com.externally.resolved.symbol",
+            bundleID: "com.externally.resolved.symbol",
             path: "/\(preciseIdentifier)",
             sourceLanguages: sourceLanguages(for: resolvedInformation)
         )
@@ -243,7 +255,7 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
     
     private func resolvedReference(for resolvedInformation: ResolvedInformation) -> ResolvedTopicReference {
         return ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             path: resolvedInformation.url.path,
             fragment: resolvedInformation.url.fragment,
             sourceLanguages: sourceLanguages(for: resolvedInformation)
@@ -485,7 +497,7 @@ extension OutOfProcessReferenceResolver {
             case .symbol(let identifier):
                 return "symbol: \(identifier.singleQuoted)"
             case .asset(let asset):
-                return "asset with name: \(asset.assetName), bundle identifier: \(asset.bundleIdentifier)"
+                return "asset with name: \(asset.assetName), bundle identifier: \(asset.bundleID)"
             }
         }
     }
@@ -767,13 +779,13 @@ extension OutOfProcessReferenceResolver: ConvertServiceFallbackResolver {
     }
     
     func resolveInformationForAsset(named assetName: String) throws -> DataAsset {
-        let assetReference = AssetReference(assetName: assetName, bundleIdentifier: bundleIdentifier)
+        let assetReference = AssetReference(assetName: assetName, bundleID: bundleID)
         if let asset = assetCache[assetReference] {
             return asset
         }
         
         let response = try externalLinkResolvingClient.sendAndWait(
-            request: Request.asset(AssetReference(assetName: assetName, bundleIdentifier: bundleIdentifier))
+            request: Request.asset(AssetReference(assetName: assetName, bundleID: bundleID))
         ) as Response
         
         switch response {

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
@@ -98,7 +98,7 @@ final class ExternalPathHierarchyResolver {
             else {
                 return nil
             }
-            return ResolvedTopicReference(bundleIdentifier: bundleID, path: url.path, fragment: url.fragment, sourceLanguage: .swift)
+            return ResolvedTopicReference(bundleID: .init(rawValue: bundleID), path: url.path, fragment: url.fragment, sourceLanguage: .swift)
         }
         let dependencies = RenderReferenceDependencies(
             topicReferences: topicReferences,
@@ -126,7 +126,7 @@ final class ExternalPathHierarchyResolver {
         symbols.reserveCapacity(linkDestinationSummaries.count)
         for entity in linkDestinationSummaries {
             let reference = ResolvedTopicReference(
-                bundleIdentifier: entity.referenceURL.host!,
+                bundleID: .init(rawValue: entity.referenceURL.host!),
                 path: entity.referenceURL.path,
                 fragment: entity.referenceURL.fragment,
                 sourceLanguage: entity.language
@@ -150,7 +150,7 @@ final class ExternalPathHierarchyResolver {
                     continue
                 }
                 let identifier = identifiers[index]
-                self.resolvedReferences[identifier] = ResolvedTopicReference(bundleIdentifier: fileRepresentation.bundleID, path: url.path, fragment: url.fragment, sourceLanguage: .swift)
+                self.resolvedReferences[identifier] = ResolvedTopicReference(bundleID: fileRepresentation.bundleID, path: url.path, fragment: url.fragment, sourceLanguage: .swift)
             }
         }
         // Finally, the Identifier -> Symbol mapping can be constructed by iterating over the nodes and looking up the reference for each USR.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
@@ -92,10 +92,10 @@ public class LinkResolver {
         }
         
         // Check if this is a link to an external documentation source that should have previously been resolved in `DocumentationContext.preResolveExternalLinks(...)`
-        if let bundleID = unresolvedReference.bundleIdentifier,
-           !context._registeredBundles.contains(where: { $0.identifier == bundleID || urlReadablePath($0.displayName) == bundleID })
+        if let bundleID = unresolvedReference.bundleID,
+           !context._registeredBundles.contains(where: { $0.id == bundleID || urlReadablePath($0.displayName) == bundleID.rawValue })
         {
-            return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No external resolver registered for \(bundleID.singleQuoted)."))
+            return .failure(unresolvedReference, TopicReferenceResolutionErrorInfo("No external resolver registered for '\(bundleID)'."))
         }
         
         do {
@@ -169,11 +169,11 @@ private final class FallbackResolverBasedLinkResolver {
     
     private func resolve(_ unresolvedReference: UnresolvedTopicReference, in parent: ResolvedTopicReference, fromSymbolLink isCurrentlyResolvingSymbolLink: Bool, context: DocumentationContext) -> TopicReferenceResolutionResult? {
         // Check if a fallback reference resolver should resolve this
-        let referenceBundleIdentifier = unresolvedReference.bundleIdentifier ?? parent.bundleIdentifier
+        let referenceBundleID = unresolvedReference.bundleID ?? parent.bundleID
         guard let fallbackResolver = context.configuration.convertServiceConfiguration.fallbackResolver,
               // This uses an underscored internal variant of `registeredBundles` to avoid deprecation warnings and remain compatible with legacy data providers.
-              let knownBundleIdentifier = context._registeredBundles.first(where: { $0.identifier == referenceBundleIdentifier || urlReadablePath($0.displayName) == referenceBundleIdentifier })?.identifier,
-              fallbackResolver.bundleIdentifier == knownBundleIdentifier
+              let knownBundleID = context._registeredBundles.first(where: { $0.id == referenceBundleID || urlReadablePath($0.displayName) == referenceBundleID.rawValue })?.id,
+              fallbackResolver.bundleID == knownBundleID
         else {
             return nil
         }
@@ -184,7 +184,7 @@ private final class FallbackResolverBasedLinkResolver {
         var allCandidateURLs = [URL]()
         
         let alreadyResolved = ResolvedTopicReference(
-            bundleIdentifier: referenceBundleIdentifier,
+            bundleID: referenceBundleID,
             path: unresolvedReference.path.prependingLeadingSlash,
             fragment: unresolvedReference.topicURL.components.fragment,
             sourceLanguages: parent.sourceLanguages
@@ -192,7 +192,7 @@ private final class FallbackResolverBasedLinkResolver {
         allCandidateURLs.append(alreadyResolved.url)
         
         // This uses an underscored internal variant of `bundle(identifier:)` to avoid deprecation warnings and remain compatible with legacy data providers.
-        let currentBundle = context._bundle(identifier: knownBundleIdentifier)!
+        let currentBundle = context._bundle(identifier: knownBundleID.rawValue)!
         if !isCurrentlyResolvingSymbolLink {
             // First look up articles path
             allCandidateURLs.append(contentsOf: [

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
@@ -148,7 +148,7 @@ public struct SerializableLinkResolutionInformation: Codable {
     // This type is public so that it can be an argument to a function in `ConvertOutputConsumer`
     
     var version: SemanticVersion
-    var bundleID: String
+    var bundleID: DocumentationBundle.Identifier
     var pathHierarchy: PathHierarchy.FileRepresentation
     // Separate storage of node data because the path hierarchy doesn't know the resolved references for articles.
     var nonSymbolPaths: [Int: String]
@@ -158,7 +158,7 @@ extension PathHierarchyBasedLinkResolver {
     /// Create a file representation of the link resolver.
     ///
     /// The file representation can be decoded in later documentation builds to resolve external links to the content where the link resolver was originally created for.
-    func prepareForSerialization(bundleID: String) throws -> SerializableLinkResolutionInformation {
+    func prepareForSerialization(bundleID: DocumentationBundle.Identifier) throws -> SerializableLinkResolutionInformation {
         var nonSymbolPaths: [Int: String] = [:]
         let hierarchyFileRepresentation = PathHierarchy.FileRepresentation(pathHierarchy) { identifiers in
             nonSymbolPaths.reserveCapacity(identifiers.count)

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -25,10 +25,10 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     /// Remove all matches from a given documentation bundle from the link resolver.
-    func unregisterBundle(identifier: BundleIdentifier) {
+    func unregisterBundle(identifier: DocumentationBundle.Identifier) {
         var newMap = BidirectionalMap<ResolvedIdentifier, ResolvedTopicReference>()
         for (id, reference) in resolvedReferenceMap {
-            if reference.bundleIdentifier == identifier {
+            if reference.bundleID == identifier {
                 pathHierarchy.removeNodeWithID(id)
             } else {
                 newMap[id] = reference
@@ -301,7 +301,7 @@ final class PathHierarchyBasedLinkResolver {
                 }
                 
                 return ResolvedTopicReference(
-                    bundleIdentifier: bundle.documentationRootReference.bundleIdentifier,
+                    bundleID: bundle.documentationRootReference.bundleID,
                     path: NodeURLGenerator.Path.documentationFolder + path,
                     sourceLanguages: symbol.sourceLanguages
                 )

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -107,7 +107,7 @@ enum GeneratedDocumentationTopics {
         
         // Create the collection topic reference
         let collectionReference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: NodeURLGenerator.Path.documentationCuration(
                 parentPath: parent.path,
                 articleName: title

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/ResolvedTopicReference+Symbol.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/ResolvedTopicReference+Symbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,7 +20,7 @@ extension ResolvedTopicReference {
         let path = symbolReference.path.isEmpty ? "" : "/" + symbolReference.path
         
         self.init(
-            bundleIdentifier: bundle.documentationRootReference.bundleIdentifier,
+            bundleID: bundle.documentationRootReference.bundleID,
             path: bundle.documentationRootReference.appendingPath(moduleName + path).path,
             fragment: nil,
             sourceLanguages: symbolReference.interfaceLanguages

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/UnresolvedTopicReference+Symbol.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/UnresolvedTopicReference+Symbol.swift
@@ -18,7 +18,7 @@ extension UnresolvedTopicReference {
     init?(symbolReference: SymbolReference, bundle: DocumentationBundle) {
         guard var components = URLComponents(string: symbolReference.path) else { return nil }
         components.scheme = ResolvedTopicReference.urlScheme
-        components.host = bundle.identifier
+        components.host = bundle.id.rawValue
         if !components.path.hasPrefix("/") {
             components.path.insert("/", at: components.path.startIndex)
         }

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -18,8 +18,13 @@ extension DocumentationBundle {
         /// The display name of the bundle.
         public var displayName: String
         
+        @available(*, deprecated, renamed: "id", message: "Use 'id' instead. This deprecated API will be removed after 6.2 is released")
+        public var identifier: String {
+            id.rawValue
+        }
+        
         /// The unique identifier of the bundle.
-        public var identifier: String
+        public var id: DocumentationBundle.Identifier
         
         /// The version of the bundle.
         @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
@@ -38,11 +43,11 @@ extension DocumentationBundle {
         internal var featureFlags: BundleFeatureFlags?
 
         /// The keys that must be present in an Info.plist file in order for doc compilation to proceed.
-        static let requiredKeys: Set<CodingKeys> = [.displayName, .identifier]
+        static let requiredKeys: Set<CodingKeys> = [.displayName, .id]
         
         package enum CodingKeys: String, CodingKey, CaseIterable {
             case displayName = "CFBundleDisplayName"
-            case identifier = "CFBundleIdentifier"
+            case id = "CFBundleIdentifier"
             case defaultCodeListingLanguage = "CDDefaultCodeListingLanguage"
             case defaultAvailability = "CDAppleDefaultAvailability"
             case defaultModuleKind = "CDDefaultModuleKind"
@@ -52,7 +57,7 @@ extension DocumentationBundle {
                 switch self {
                 case .displayName:
                     return "--fallback-display-name"
-                case .identifier:
+                case .id:
                     return "--fallback-bundle-identifier"
                 case .defaultCodeListingLanguage:
                     return "--default-code-listing-language"
@@ -83,10 +88,28 @@ extension DocumentationBundle {
         /// Creates a new documentation bundle information value.
         /// - Parameters:
         ///   - displayName: The display name of the bundle.
-        ///   - identifier:  The unique identifier of the bundle.
+        ///   - id:  The unique identifier of the bundle.
         ///   - defaultCodeListingLanguage: The default language identifier for code listings in the bundle.
         ///   - defaultAvailability: The default availability for the various modules in the bundle.
         ///   - defaultModuleKind: The default kind for the various modules in the bundle.
+        public init(
+            displayName: String,
+            id: DocumentationBundle.Identifier,
+            defaultCodeListingLanguage: String?,
+            defaultAvailability: DefaultAvailability?,
+            defaultModuleKind: String?
+        ) {
+            self.init(
+                displayName: displayName,
+                id: id,
+                defaultCodeListingLanguage: defaultCodeListingLanguage,
+                defaultModuleKind: defaultModuleKind,
+                defaultAvailability: defaultAvailability,
+                featureFlags: nil
+            )
+        }
+        
+        @available(*, deprecated, renamed: "init(displayName:id:defaultCodeListingLanguage:defaultAvailability:defaultModuleKind:)", message: "Use 'Info.init(displayName:id:defaultCodeListingLanguage:defaultAvailability:defaultModuleKind:)' instead. This deprecated API will be removed after 6.2 is released")
         public init(
             displayName: String,
             identifier: String,
@@ -94,11 +117,13 @@ extension DocumentationBundle {
             defaultAvailability: DefaultAvailability?,
             defaultModuleKind: String?
         ) {
-            self.displayName = displayName
-            self.identifier = identifier
-            self.defaultCodeListingLanguage = defaultCodeListingLanguage
-            self.defaultAvailability = defaultAvailability
-            self.defaultModuleKind = defaultModuleKind
+            self.init(
+                displayName: displayName,
+                id: .init(rawValue: identifier),
+                defaultCodeListingLanguage: defaultCodeListingLanguage,
+                defaultAvailability: defaultAvailability,
+                defaultModuleKind: defaultModuleKind
+            )
         }
         
         /// Creates documentation bundle information from the given Info.plist data, falling back to the values
@@ -199,13 +224,13 @@ extension DocumentationBundle {
             // If present, we can use `Info.displayName` as a fallback
             // for `Info.identifier`.
             if givenKeys.contains(.displayName) {
-                givenKeys.insert(.identifier)
+                givenKeys.insert(.id)
             }
             
             // If present, we can use the `derivedDisplayName`
             // as a fallback for the `Info.displayName` and `Info.identifier`.
             if derivedDisplayName != nil {
-                givenKeys.formUnion([.displayName, .identifier])
+                givenKeys.formUnion([.displayName, .id])
             }
             
             let missingKeys = Self.requiredKeys.subtracting(givenKeys)
@@ -221,7 +246,7 @@ extension DocumentationBundle {
             // It's safe to unwrap `derivedDisplayName` because it will only be accessed if neither the decoding container nor the bundle discovery options
             // contain a display name. If they do but that value fails to decode, that error would be raised before accessing `derivedDisplayName`.
             self.displayName = try decodeOrFallbackIfPresent(String.self, with: .displayName) ?? derivedDisplayName!
-            self.identifier = try decodeOrFallbackIfPresent(String.self, with: .identifier) ?? self.displayName
+            self.id = try decodeOrFallbackIfPresent(Identifier.self, with: .id) ?? .init(rawValue: self.displayName)
             
             // Finally, decode the optional keys if they're present.
             
@@ -233,14 +258,14 @@ extension DocumentationBundle {
 
         init(
             displayName: String,
-            identifier: String,
+            id: DocumentationBundle.Identifier,
             defaultCodeListingLanguage: String? = nil,
             defaultModuleKind: String? = nil,
             defaultAvailability: DefaultAvailability? = nil,
             featureFlags: BundleFeatureFlags? = nil
         ) {
             self.displayName = displayName
-            self.identifier = identifier
+            self.id = id
             self.defaultCodeListingLanguage = defaultCodeListingLanguage
             self.defaultModuleKind = defaultModuleKind
             self.defaultAvailability = defaultAvailability
@@ -281,7 +306,7 @@ extension BundleDiscoveryOptions {
             switch key {
             case .displayName:
                 value = fallbackDisplayName
-            case .identifier:
+            case .id:
                 value = fallbackIdentifier
             case .defaultCodeListingLanguage:
                 value = fallbackDefaultCodeListingLanguage

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -311,7 +311,7 @@ public extension DocumentationNode {
         renderNode: RenderNode,
         includeTaskGroups: Bool = true
     ) -> [LinkDestinationSummary] {
-        guard let bundle = context.bundle, bundle.identifier == reference.bundleIdentifier else {
+        guard let bundle = context.bundle, bundle.id == reference.bundleID else {
             // Don't return anything for external references that don't have a bundle in the context.
             return []
         }

--- a/Sources/SwiftDocC/Model/BuildMetadata.swift
+++ b/Sources/SwiftDocC/Model/BuildMetadata.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,16 +23,29 @@ public struct BuildMetadata: Codable {
     /// The display name of the documentation bundle that DocC built.
     public var bundleDisplayName: String
     
+    @available(*, deprecated, renamed: "bundleID", message: "Use 'bundleID' instead. This deprecated API will be removed after 6.2 is released")
+    public var bundleIdentifier: String {
+        bundleID.rawValue
+    }
+    
     /// The bundle identifier of the documentation bundle that DocC built.
-    public var bundleIdentifier: String
+    public let bundleID: DocumentationBundle.Identifier
     
     /// Creates a build metadata value for a documentation bundle built by DocC.
     ///
     /// - Parameters:
     ///   - bundleDisplayName: The display name of the documentation bundle.
-    ///   - bundleIdentifier: The bundle identifier of the documentation bundle.
-    public init(bundleDisplayName: String, bundleIdentifier: String) {
+    ///   - bundleID: The bundle identifier of the documentation bundle.
+    public init(bundleDisplayName: String, bundleID: DocumentationBundle.Identifier) {
         self.bundleDisplayName = bundleDisplayName
-        self.bundleIdentifier = bundleIdentifier
+        self.bundleID = bundleID
+    }
+    
+    @available(*, deprecated, renamed: "init(bundleDisplayName:bundleID:)", message: "Use 'init(bundleDisplayName:bundleID:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(bundleDisplayName: String, bundleIdentifier: String) {
+        self.init(
+            bundleDisplayName: bundleDisplayName,
+            bundleID: .init(rawValue: bundleIdentifier)
+        )
     }
 }

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -140,7 +140,7 @@ extension TopicReferenceResolutionErrorInfo {
 /// > Important: This type has copy-on-write semantics and wraps an underlying class to store
 /// > its data.
 public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomStringConvertible {
-    typealias ReferenceBundleIdentifier = String
+    typealias ReferenceBundleIdentifier = DocumentationBundle.Identifier
     private struct ReferenceKey: Hashable {
         var path: String
         var fragment: String?
@@ -151,20 +151,20 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     private static var sharedPool = Synchronized([ReferenceBundleIdentifier: [ReferenceKey: ResolvedTopicReference]]())
     
     /// Clears cached references belonging to the bundle with the given identifier.
-    /// - Parameter bundleIdentifier: The identifier of the bundle to which the method should clear belonging references.
-    static func purgePool(for bundleIdentifier: String) {
-        sharedPool.sync { $0.removeValue(forKey: bundleIdentifier) }
+    /// - Parameter id: The identifier of the bundle to which the method should clear belonging references.
+    static func purgePool(for id: ReferenceBundleIdentifier) {
+        sharedPool.sync { $0.removeValue(forKey: id) }
     }
     
     /// Enables reference caching for any identifiers created with the given bundle identifier.
-    static func enableReferenceCaching(for bundleIdentifier: ReferenceBundleIdentifier) {
+    static func enableReferenceCaching(for id: ReferenceBundleIdentifier) {
         sharedPool.sync { sharedPool in
-            if !sharedPool.keys.contains(bundleIdentifier) {
-                sharedPool[bundleIdentifier] = [:]
+            if !sharedPool.keys.contains(id) {
+                sharedPool[id] = [:]
             }
         }
     }
-
+    
     /// The URL scheme for `doc://` links.
     public static let urlScheme = "doc"
     
@@ -176,9 +176,14 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     /// The storage for the resolved topic reference's state.
     let _storage: Storage
     
-    /// The identifier of the bundle that owns this documentation topic.
+    @available(*, deprecated, renamed: "bundleID", message: "Use 'bundleID' instead. This deprecated API will be removed after 6.2 is released")
     public var bundleIdentifier: String {
-        return _storage.bundleIdentifier
+        bundleID.rawValue
+    }
+    
+    /// The identifier of the bundle that owns this documentation topic.
+    public var bundleID: DocumentationBundle.Identifier {
+        _storage.bundleID
     }
     
     /// The absolute path from the bundle to this topic, delimited by `/`.
@@ -207,31 +212,39 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     }
     
     /// - Note: The `path` parameter is escaped to a path readable string.
-    public init(bundleIdentifier: String, path: String, fragment: String? = nil, sourceLanguage: SourceLanguage) {
-        self.init(bundleIdentifier: bundleIdentifier, path: path, fragment: fragment, sourceLanguages: [sourceLanguage])
+    public init(bundleID: DocumentationBundle.Identifier, path: String, fragment: String? = nil, sourceLanguage: SourceLanguage) {
+        self.init(bundleID: bundleID, path: path, fragment: fragment, sourceLanguages: [sourceLanguage])
     }
     
-    public init(bundleIdentifier: String, path: String, fragment: String? = nil, sourceLanguages: Set<SourceLanguage>) {
+    public init(bundleID: DocumentationBundle.Identifier, path: String, fragment: String? = nil, sourceLanguages: Set<SourceLanguage>) {
         self.init(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             urlReadablePath: urlReadablePath(path),
             urlReadableFragment: fragment.map(urlReadableFragment(_:)),
             sourceLanguages: sourceLanguages
         )
     }
+    @available(*, deprecated, renamed: "init(id:path:fragment:sourceLanguage:)", message: "Use 'init(id:path:fragment:sourceLanguage:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(bundleIdentifier: String, path: String, fragment: String? = nil, sourceLanguage: SourceLanguage) {
+        self.init(bundleIdentifier: bundleIdentifier, path: path, fragment: fragment, sourceLanguages: [sourceLanguage])
+    }
+    @available(*, deprecated, renamed: "init(id:path:fragment:sourceLanguages:)", message: "Use 'init(id:path:fragment:sourceLanguages:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init(bundleIdentifier: String, path: String, fragment: String? = nil, sourceLanguages: Set<SourceLanguage>) {
+        self.init(bundleID: .init(rawValue: bundleIdentifier), path: path, fragment: fragment, sourceLanguages: sourceLanguages)
+    }
     
-    private init(bundleIdentifier: String, urlReadablePath: String, urlReadableFragment: String? = nil, sourceLanguages: Set<SourceLanguage>) {
+    private init(bundleID: DocumentationBundle.Identifier, urlReadablePath: String, urlReadableFragment: String? = nil, sourceLanguages: Set<SourceLanguage>) {
         precondition(!sourceLanguages.isEmpty, "ResolvedTopicReference.sourceLanguages cannot be empty")
         // Check for a cached instance of the reference
         let key = ReferenceKey(path: urlReadablePath, fragment: urlReadableFragment, sourceLanguages: sourceLanguages)
-        let cached = Self.sharedPool.sync { $0[bundleIdentifier]?[key] }
+        let cached = Self.sharedPool.sync { $0[bundleID]?[key] }
         if let resolved = cached {
             self = resolved
             return
         }
         
         _storage = Storage(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             path: urlReadablePath,
             fragment: urlReadableFragment,
             sourceLanguages: sourceLanguages
@@ -240,7 +253,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         // Cache the reference
         Self.sharedPool.sync { sharedPool in
             // If we have a shared pool for this bundle identifier, cache the reference
-            sharedPool[bundleIdentifier]?[key] = self
+            sharedPool[bundleID]?[key] = self
         }
     }
     
@@ -285,7 +298,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
 
         decoder.registerReferences([url.absoluteString])
         
-        self.init(bundleIdentifier: bundleIdentifier, path: url.path, fragment: url.fragment, sourceLanguage: interfaceLanguage)
+        self.init(bundleID: .init(rawValue: bundleIdentifier), path: url.path, fragment: url.fragment, sourceLanguage: interfaceLanguage)
     }
     
     /// Creates a new topic reference with the given fragment.
@@ -304,7 +317,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     /// - Returns: The resulting topic reference.
     public func withFragment(_ fragment: String?) -> ResolvedTopicReference {
         let newReference = ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             path: path,
             fragment: fragment.map(urlReadableFragment),
             sourceLanguages: sourceLanguages
@@ -321,7 +334,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     /// - Returns: The resulting topic reference.
     public func appendingPath(_ path: String) -> ResolvedTopicReference {
         let newReference = ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             urlReadablePath: url.appendingPathComponent(urlReadablePath(path), isDirectory: false).path,
             sourceLanguages: sourceLanguages
         )
@@ -342,7 +355,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         }
         let newPath = url.appendingPathComponent(referencePath, isDirectory: false).path
         let newReference = ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             urlReadablePath: newPath,
             urlReadableFragment: reference.fragment.map(urlReadableFragment),
             sourceLanguages: sourceLanguages
@@ -354,7 +367,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     public func removingLastPathComponent() -> ResolvedTopicReference {
         let newPath = String(pathComponents.dropLast().joined(separator: "/").dropFirst())
         let newReference = ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             urlReadablePath: newPath,
             urlReadableFragment: fragment,
             sourceLanguages: sourceLanguages
@@ -374,7 +387,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         }
         
         return ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             urlReadablePath: path,
             urlReadableFragment: fragment,
             sourceLanguages: combinedSourceLanguages
@@ -391,7 +404,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         }
         
         return ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
+            bundleID: bundleID,
             urlReadablePath: path,
             urlReadableFragment: fragment,
             sourceLanguages: sourceLanguages
@@ -447,7 +460,7 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
     ///
     /// This is a reference type which allows ``ResolvedTopicReference`` to have copy-on-write behavior.
     class Storage {
-        let bundleIdentifier: String
+        let bundleID: DocumentationBundle.Identifier
         let path: String
         let fragment: String?
         let sourceLanguages: Set<SourceLanguage>
@@ -460,20 +473,20 @@ public struct ResolvedTopicReference: Hashable, Codable, Equatable, CustomString
         let absoluteString: String
         
         init(
-            bundleIdentifier: String,
+            bundleID: DocumentationBundle.Identifier,
             path: String,
             fragment: String? = nil,
             sourceLanguages: Set<SourceLanguage>
         ) {
-            self.bundleIdentifier = bundleIdentifier
+            self.bundleID = bundleID
             self.path = path
             self.fragment = fragment
             self.sourceLanguages = sourceLanguages
-            self.identifierPathAndFragment = "\(bundleIdentifier)\(path)\(fragment ?? "")"
+            self.identifierPathAndFragment = "\(bundleID)\(path)\(fragment ?? "")"
             
             var components = URLComponents()
             components.scheme = ResolvedTopicReference.urlScheme
-            components.host = bundleIdentifier
+            components.host = bundleID.rawValue
             components.path = path
             components.fragment = fragment
             self.url = components.url!
@@ -515,9 +528,14 @@ public struct UnresolvedTopicReference: Hashable, CustomStringConvertible {
     /// The URL as originally spelled.
     public let topicURL: ValidatedURL
     
-    /// The bundle identifier, if one was provided in the host name component of the original URL.
+    @available(*, deprecated, renamed: "bundleID", message: "Use 'bundleID' instead. This deprecated API will be removed after 6.2 is released")
     public var bundleIdentifier: String? {
-        return topicURL.components.host
+        bundleID?.rawValue
+    }
+    
+    /// The bundle identifier, if one was provided in the host name component of the original URL.
+    public var bundleID: DocumentationBundle.Identifier? {
+        topicURL.components.host.map { .init(rawValue: $0) }
     }
     
     /// The path of the unresolved reference.
@@ -574,26 +592,25 @@ public struct UnresolvedTopicReference: Hashable, CustomStringConvertible {
     }
 }
 
-/**
- A reference to an auxiliary resource such as an image.
- */
+/// A reference to an auxiliary resource such as an image.
 public struct ResourceReference: Hashable {
-    /**
-     The documentation bundle identifier for the bundle in which this resource resides.
-     */
-    public let bundleIdentifier: String
+    @available(*, deprecated, renamed: "bundleID", message: "Use 'bundleID' instead. This deprecated API will be removed after 6.2 is released")
+    public var bundleIdentifier: String {
+        bundleID.rawValue
+    }
+    
+    /// The documentation bundle identifier for the bundle in which this resource resides.
+    public let bundleID: DocumentationBundle.Identifier
 
-    /**
-     The path of the resource local to its bundle.
-     */
+    /// The path of the resource local to its bundle.
     public let path: String
 
     /// Creates a new resource reference.
     /// - Parameters:
-    ///   - bundleIdentifier: The documentation bundle identifier for the bundle in which this resource resides.
+    ///   - bundleID: The documentation bundle identifier for the bundle in which this resource resides.
     ///   - path: The path of the resource local to its bundle.
-    init(bundleIdentifier: String, path: String) {
-        self.bundleIdentifier = bundleIdentifier
+    init(bundleID: DocumentationBundle.Identifier, path: String) {
+        self.bundleID = bundleID
         self.path = path.removingPercentEncoding ?? path
     }
 
@@ -601,7 +618,7 @@ public struct ResourceReference: Hashable {
     var url: URL {
         var components = URLComponents()
         components.scheme = ResolvedTopicReference.urlScheme
-        components.host = bundleIdentifier
+        components.host = bundleID.rawValue
         components.path = "/" + path
         return components.url!
     }

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -336,7 +336,7 @@ public class DocumentationContentRenderer {
         if kind == .section {
             // Sections don't have their own abstract so take the one of the container symbol.
             let containerReference = ResolvedTopicReference(
-                bundleIdentifier: reference.bundleIdentifier,
+                bundleID: reference.bundleID,
                 path: reference.path,
                 sourceLanguages: reference.sourceLanguages
             )
@@ -507,14 +507,14 @@ public class DocumentationContentRenderer {
                 }
                 
                 // For external links, verify they've resolved successfully and return `nil` otherwise.
-                if linkHost != reference.bundleIdentifier {
+                if linkHost != reference.bundleID.rawValue {
                     if let url = ValidatedURL(destination), case .success(let externalReference) = documentationContext.externallyResolvedLinks[url] {
                         return externalReference
                     }
                     return nil
                 }
                 return ResolvedTopicReference(
-                    bundleIdentifier: reference.bundleIdentifier,
+                    bundleID: reference.bundleID,
                     path: destination.path,
                     sourceLanguages: node.availableSourceLanguages
                 )

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
@@ -161,7 +161,7 @@ struct RenderHierarchyTranslator {
         
         if let tutorial = (try? context.entity(with: tutorialReference).semantic) as? Tutorial, let assessments = tutorial.assessments, !assessments.questions.isEmpty {
             // Add hardcoded assessment section.
-            let assessmentReference = ResolvedTopicReference(bundleIdentifier: tutorialReference.bundleIdentifier, path: tutorialReference.path, fragment: RenderHierarchyTranslator.assessmentsAnchor, sourceLanguage: .swift)
+            let assessmentReference = ResolvedTopicReference(bundleID: tutorialReference.bundleID, path: tutorialReference.path, fragment: RenderHierarchyTranslator.assessmentsAnchor, sourceLanguage: .swift)
             renderHierarchyTutorial.landmarks.append(RenderHierarchyLandmark(reference: RenderReferenceIdentifier(assessmentReference.absoluteString), kind: .assessment))
             
             let urlGenerator = PresentationURLGenerator(context: context, baseURL: bundle.baseURL)

--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -81,10 +81,10 @@ public struct RenderContext {
         
         let assets = documentationContext.assetManagers
             .reduce(into: [AssetReference: DataAsset]()) { (storage, element) in
-                let (bundleIdentifier, assetManager) = element
+                let (bundleID, assetManager) = element
             
                 for (name, asset) in assetManager.storage {
-                    storage[AssetReference(assetName: name, bundleIdentifier: bundleIdentifier)] = asset
+                    storage[AssetReference(assetName: name, bundleID: bundleID)] = asset
                 }
             }
         

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -56,7 +56,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
             return nil
         }
         
-        let fileReference = ResourceReference(bundleIdentifier: code.fileReference.bundleIdentifier, path: fileIdentifier)
+        let fileReference = ResourceReference(bundleID: code.fileReference.bundleID, path: fileIdentifier)
         guard let fileContents = fileContents(with: fileReference) else {
             return nil
         }
@@ -1714,8 +1714,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
             return nil
         }
         
-        let media = ResourceReference(bundleIdentifier: oldMedia.bundleIdentifier, path: mediaIdentifier)
-        guard let resolvedAssets = renderContext?.store.content(forAssetNamed: media.path, bundleIdentifier: identifier.bundleIdentifier)
+        let media = ResourceReference(bundleID: oldMedia.bundleID, path: mediaIdentifier)
+        guard let resolvedAssets = renderContext?.store.content(forAssetNamed: media.path, bundleID: identifier.bundleID)
                                 ?? context.resolveAsset(named: media.path, in: identifier)
         else {
             return nil
@@ -2003,7 +2003,7 @@ fileprivate typealias BundleModuleIdentifier = String
 
 extension BundleModuleIdentifier {
     fileprivate init(bundle: DocumentationBundle, moduleName: String) {
-        self = "\(bundle.identifier):\(moduleName)"
+        self = "\(bundle.id):\(moduleName)"
     }
 }
 

--- a/Sources/SwiftDocC/Model/Rendering/RenderReferenceStore.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderReferenceStore.swift
@@ -38,8 +38,13 @@ public struct RenderReferenceStore: Codable {
     }
     
     /// Returns asset information for the given asset name.
+    public func content(forAssetNamed assetName: String, bundleID: DocumentationBundle.Identifier) -> DataAsset? {
+        assets[AssetReference(assetName: assetName, bundleID: bundleID)]
+    }
+    
+    @available(*, deprecated, renamed: "content(forAssetNamed:bundleID:)", message: "Use 'content(forAssetNamed:bundleID:)' instead. This deprecated API will be removed after 6.2 is released")
     public func content(forAssetNamed assetName: String, bundleIdentifier: String) -> DataAsset? {
-        assets[AssetReference(assetName: assetName, bundleIdentifier: bundleIdentifier)]
+        content(forAssetNamed: assetName, bundleID: .init(rawValue: bundleIdentifier))
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalMarkupReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalMarkupReferenceWalker.swift
@@ -14,10 +14,10 @@ import Markdown
 /// Walks a markup tree and collects any links external to a given bundle.
 struct ExternalMarkupReferenceWalker: MarkupVisitor {
     /// The local bundle ID, used to identify and skip absolute fully qualified local links.
-    var localBundleID: BundleIdentifier
+    var localBundleID: DocumentationBundle.Identifier
     
     /// After walking a markup tree, all encountered external links are collected grouped by the bundle ID.
-    var collectedExternalLinks = [BundleIdentifier: Set<ValidatedURL>]()
+    var collectedExternalLinks = [DocumentationBundle.Identifier: Set<ValidatedURL>]()
 
     /// Descends down the given elements' children.
     mutating func defaultVisit(_ markup: Markup) {
@@ -31,7 +31,7 @@ struct ExternalMarkupReferenceWalker: MarkupVisitor {
         // Only process documentation links to external bundles
         guard let destination = link.destination,
               let url = ValidatedURL(parsingAuthoredLink: destination)?.requiring(scheme: ResolvedTopicReference.urlScheme),
-              let bundleID = url.components.host,
+              let bundleID = url.components.host.map({ DocumentationBundle.Identifier(rawValue: $0) }),
               bundleID != localBundleID
         else {
             return

--- a/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
+++ b/Sources/SwiftDocC/Semantics/ExternalLinks/ExternalReferenceWalker.swift
@@ -41,7 +41,7 @@ struct ExternalReferenceWalker: SemanticVisitor {
     private var markupResolver: ExternalMarkupReferenceWalker
     
     /// Collected unresolved external references, grouped by the bundle ID.
-    var collectedExternalReferences: [BundleIdentifier: [UnresolvedTopicReference]] {
+    var collectedExternalReferences: [DocumentationBundle.Identifier: [UnresolvedTopicReference]] {
         return markupResolver.collectedExternalLinks.mapValues { links in
             links.map(UnresolvedTopicReference.init(topicURL:))
         }
@@ -49,7 +49,7 @@ struct ExternalReferenceWalker: SemanticVisitor {
     
     /// Creates a new semantic walker that collects links to other documentation sources.
     /// - Parameter localBundleID: The local bundle ID, used to identify and skip absolute fully qualified local links.
-    init(localBundleID: BundleIdentifier) {
+    init(localBundleID: DocumentationBundle.Identifier) {
         self.markupResolver = ExternalMarkupReferenceWalker(localBundleID: localBundleID)
     }
     

--- a/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
@@ -19,7 +19,7 @@ public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {
     
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argumentValue)
+            ResourceReference(bundleID: bundle.id, path: argumentValue)
         }
     )
     public private(set) var source: ResourceReference

--- a/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
@@ -21,7 +21,7 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argumentValue)
+            ResourceReference(bundleID: bundle.id, path: argumentValue)
         }
     )
     public private(set) var source: ResourceReference
@@ -44,7 +44,7 @@ public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {
     /// An image to be shown when the video isn't playing.
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argumentValue)
+            ResourceReference(bundleID: bundle.id, path: argumentValue)
         }
     )
     public private(set) var poster: ResourceReference? = nil

--- a/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
@@ -60,7 +60,7 @@ public final class CallToAction: Semantic, AutomaticDirectiveConvertible {
     /// The location of the associated link, as a reference to a file in this documentation bundle.
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argumentValue)
+            ResourceReference(bundleID: bundle.id, path: argumentValue)
         }
     )
     public var file: ResourceReference? = nil
@@ -173,7 +173,7 @@ extension CallToAction {
                     ]
                 ))
             } else {
-                self.file = ResourceReference(bundleIdentifier: file.bundleIdentifier, path: file.url.lastPathComponent)
+                self.file = ResourceReference(bundleID: file.bundleID, path: file.url.lastPathComponent)
             }
         }
 

--- a/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
@@ -28,7 +28,7 @@ public final class PageImage: Semantic, AutomaticDirectiveConvertible {
     /// The base file name of an image in your documentation catalog.
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argumentValue)
+            ResourceReference(bundleID: bundle.id, path: argumentValue)
         }
     )
     public private(set) var source: ResourceReference

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -544,13 +544,13 @@ fileprivate extension URL {
 extension Image {
     func reference(in bundle: DocumentationBundle) -> ResourceReference? {
         guard let source else {
-            return ResourceReference(bundleIdentifier: bundle.identifier, path: "")
+            return ResourceReference(bundleID: bundle.id, path: "")
         }
         
         if let url = URL(string: source), url.isLikelyWebURL {
             return nil
         } else {
-            return ResourceReference(bundleIdentifier: bundle.identifier, path: source)
+            return ResourceReference(bundleID: bundle.id, path: source)
         }
     }
 }

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
@@ -67,7 +67,7 @@ public final class Code: Semantic, DirectiveConvertible {
         Semantic.Analyses.HasOnlyKnownDirectives<Code>(severityIfFound: .warning, allowedDirectives: [ImageMedia.directiveName, VideoMedia.directiveName]).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
         
         guard let requiredFileReference = Semantic.Analyses.HasArgument<Code, Semantics.File>(severityIfNotFound: .warning).analyze(directive, arguments: arguments, problems: &problems) else { return nil }
-        let fileReference = ResourceReference(bundleIdentifier: bundle.identifier, path: requiredFileReference)
+        let fileReference = ResourceReference(bundleID: bundle.id, path: requiredFileReference)
         
         guard let requiredFileName = Semantic.Analyses.HasArgument<Code, Semantics.Name>(severityIfNotFound: .warning).analyze(directive, arguments: arguments, problems: &problems) else { return nil }
         
@@ -83,7 +83,7 @@ public final class Code: Semantic, DirectiveConvertible {
         let (optionalPreview, _) = Semantic.Analyses.HasExactlyOneImageOrVideoMedia<Code>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
         
         let optionalPreviousFileReference = Semantic.Analyses.HasArgument<Code, Semantics.PreviousFile>(severityIfNotFound: nil).analyze(directive, arguments: arguments, problems: &problems).map { argument in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argument)
+            ResourceReference(bundleID: bundle.id, path: argument)
         }
         
         self.init(originalMarkup: directive, fileReference: fileReference, fileName: requiredFileName, previousFileReference: optionalPreviousFileReference, shouldResetDiff: shouldResetDiff, preview: optionalPreview)

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -23,7 +23,7 @@ public final class Tutorial: Semantic, AutomaticDirectiveConvertible, Abstracted
     /// Project files to download to get started with the ``Tutorial``.
     @DirectiveArgumentWrapped(
         parseArgument: { bundle, argumentValue in
-            ResourceReference(bundleIdentifier: bundle.identifier, path: argumentValue)
+            ResourceReference(bundleID: bundle.id, path: argumentValue)
         }
     )
     public private(set) var projectFiles: ResourceReference? = nil

--- a/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/DocumentationContextGroup.md
+++ b/Sources/SwiftDocC/SwiftDocC.docc/SwiftDocC/DocumentationContextGroup.md
@@ -33,7 +33,7 @@ Use ``DocumentationContext/entity(with:)`` to access a documentation node by its
 
 ```swift
 let reference = ResolvedTopicReference(
-    bundleIdentifier: "com.mybundle",
+    bundleID: "com.mybundle",
     path: "/documentation/ValidationKit/EmailValidator",
     fragment: nil,
     sourceLanguage: .swift)

--- a/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
+++ b/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
@@ -116,14 +116,14 @@ public struct InfoPlist: File, DataRepresentable {
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: DocumentationBundle.Info.CodingKeys.self)
             displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
-            identifier = try container.decodeIfPresent(String.self, forKey: .identifier)
+            identifier = try container.decodeIfPresent(String.self, forKey: .id)
             defaultAvailability = try container.decodeIfPresent([String : [DefaultAvailability.ModuleAvailability]].self, forKey: .defaultAvailability)
         }
         
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: DocumentationBundle.Info.CodingKeys.self)
             try container.encodeIfPresent(displayName, forKey: .displayName)
-            try container.encodeIfPresent(identifier, forKey: .identifier)
+            try container.encodeIfPresent(identifier, forKey: .id)
             try container.encodeIfPresent(defaultAvailability, forKey: .defaultAvailability)
         }
     }
@@ -309,7 +309,7 @@ extension Folder {
 }
 
 private func makeMinimalTestRenderNode(path: String) -> RenderNode {
-    let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.test", path: path, sourceLanguage: .swift)
+    let reference = ResolvedTopicReference(bundleID: "org.swift.test", path: path, sourceLanguage: .swift)
     let rawReference = reference.url.absoluteString
     let title = path.components(separatedBy: "/").last ?? path
     

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -160,7 +160,7 @@ public struct ConvertAction: AsyncAction {
         }
         
         if let outOfProcessResolver {
-            configuration.externalDocumentationConfiguration.sources[outOfProcessResolver.bundleIdentifier] = outOfProcessResolver
+            configuration.externalDocumentationConfiguration.sources[outOfProcessResolver.bundleID] = outOfProcessResolver
             configuration.externalDocumentationConfiguration.globalSymbolResolver = outOfProcessResolver
         }
         configuration.externalDocumentationConfiguration.dependencyArchives = dependencies
@@ -276,7 +276,7 @@ public struct ConvertAction: AsyncAction {
             workingDirectory: temporaryFolder,
             fileManager: fileManager)
 
-        let indexer = try Indexer(outputURL: temporaryFolder, bundleIdentifier: bundle.identifier)
+        let indexer = try Indexer(outputURL: temporaryFolder, bundleID: bundle.id)
 
         let context = try DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
         
@@ -288,7 +288,7 @@ public struct ConvertAction: AsyncAction {
             indexer: indexer,
             enableCustomTemplates: experimentalEnableCustomTemplates,
             transformForStaticHostingIndexHTML: transformForStaticHosting ? indexHTML : nil,
-            bundleIdentifier: bundle.identifier
+            bundleID: bundle.id
         )
 
         if experimentalModifyCatalogWithGeneratedCuration, let catalogURL = rootURL {
@@ -422,7 +422,7 @@ public struct ConvertAction: AsyncAction {
                 context: context,
                 indexer: nil,
                 transformForStaticHostingIndexHTML: nil,
-                bundleIdentifier: bundle.identifier
+                bundleID: bundle.id
             )
 
             try outputConsumer.consume(benchmarks: Benchmark.main)

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -34,7 +34,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
         indexer: ConvertAction.Indexer?,
         enableCustomTemplates: Bool = false,
         transformForStaticHostingIndexHTML: URL?,
-        bundleIdentifier: BundleIdentifier?
+        bundleID: DocumentationBundle.Identifier?
     ) {
         self.targetFolder = targetFolder
         self.bundleRootFolder = bundleRootFolder
@@ -47,7 +47,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
         )
         self.indexer = indexer
         self.enableCustomTemplates = enableCustomTemplates
-        self.assetPrefixComponent = bundleIdentifier?.split(separator: "/").joined(separator: "-")
+        self.assetPrefixComponent = bundleID?.rawValue.split(separator: "/").joined(separator: "-")
     }
     
     func consume(problems: [Problem]) throws {
@@ -79,45 +79,45 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
         }
 
         // TODO: Supporting a single bundle for the moment.
-        let bundleIdentifier = bundle.identifier
-        assert(bundleIdentifier == self.assetPrefixComponent, "Unexpectedly encoding assets for a bundle other than the one this output consumer was created for.")
+        let bundleID = bundle.id
+        assert(bundleID.rawValue == self.assetPrefixComponent, "Unexpectedly encoding assets for a bundle other than the one this output consumer was created for.")
         
         // Create images directory if needed.
         let imagesDirectory = targetFolder
             .appendingPathComponent("images", isDirectory: true)
-            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+            .appendingPathComponent(bundleID.rawValue, isDirectory: true)
         if !fileManager.directoryExists(atPath: imagesDirectory.path) {
             try fileManager.createDirectory(at: imagesDirectory, withIntermediateDirectories: true, attributes: nil)
         }
         
         // Copy all registered images to the output directory.
-        for imageAsset in context.registeredImageAssets(forBundleID: bundleIdentifier) {
+        for imageAsset in context.registeredImageAssets(for: bundleID) {
             try copyAsset(imageAsset, to: imagesDirectory)
         }
         
         // Create videos directory if needed.
         let videosDirectory = targetFolder
             .appendingPathComponent("videos", isDirectory: true)
-            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+            .appendingPathComponent(bundleID.rawValue, isDirectory: true)
         if !fileManager.directoryExists(atPath: videosDirectory.path) {
             try fileManager.createDirectory(at: videosDirectory, withIntermediateDirectories: true, attributes: nil)
         }
         
         // Copy all registered videos to the output directory.
-        for videoAsset in context.registeredVideoAssets(forBundleID: bundleIdentifier) {
+        for videoAsset in context.registeredVideoAssets(for: bundleID) {
             try copyAsset(videoAsset, to: videosDirectory)
         }
         
         // Create downloads directory if needed.
         let downloadsDirectory = targetFolder
             .appendingPathComponent(DownloadReference.locationName, isDirectory: true)
-            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+            .appendingPathComponent(bundleID.rawValue, isDirectory: true)
         if !fileManager.directoryExists(atPath: downloadsDirectory.path) {
             try fileManager.createDirectory(at: downloadsDirectory, withIntermediateDirectories: true, attributes: nil)
         }
 
         // Copy all downloads into the output directory.
-        for downloadAsset in context.registeredDownloadsAssets(forBundleID: bundleIdentifier) {
+        for downloadAsset in context.registeredDownloadsAssets(for: bundleID) {
             try copyAsset(downloadAsset, to: downloadsDirectory)
         }
 

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/Indexer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/Indexer.swift
@@ -32,13 +32,13 @@ extension ConvertAction {
         /// Creates an indexer that asynchronously indexes nodes and creates the index file on disk.
         /// - Parameters:
         ///   - outputURL: The target directory to create the index file.
-        ///   - bundleIdentifier: The identifier of the bundle being indexed.
-        init(outputURL: URL, bundleIdentifier: String) throws {
+        ///   - bundleID: The identifier of the bundle being indexed.
+        init(outputURL: URL, bundleID: DocumentationBundle.Identifier) throws {
             let indexURL = outputURL.appendingPathComponent("index", isDirectory: true)
             indexBuilder = Synchronized<NavigatorIndex.Builder>(
                 NavigatorIndex.Builder(renderNodeProvider: nil,
                     outputURL: indexURL,
-                    bundleIdentifier: bundleIdentifier,
+                    bundleIdentifier: bundleID.rawValue,
                     sortRootChildrenByName: true,
                     groupByLanguage: true
                 )

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
@@ -103,7 +103,7 @@ struct MergeAction: AsyncAction {
         let languages = combinedIndex.interfaceLanguages.keys.map { SourceLanguage(id: $0) }
         let language = languages.sorted().first ?? .swift
         
-        let reference = ResolvedTopicReference(bundleIdentifier: landingPageName.replacingWhitespaceAndPunctuation(with: "-"), path: "/documentation", sourceLanguage: language)
+        let reference = ResolvedTopicReference(bundleID: .init(rawValue: landingPageName), path: "/documentation", sourceLanguage: language)
         
         let rootRenderReferences = try readRootNodeRenderReferencesIn(dataDirectory: targetURL.appendingPathComponent("data", isDirectory: true))
         

--- a/Tests/SwiftDocCTests/Benchmark/ExternalTopicsHashTests.swift
+++ b/Tests/SwiftDocCTests/Benchmark/ExternalTopicsHashTests.swift
@@ -20,7 +20,7 @@ class ExternalTopicsGraphHashTests: XCTestCase {
     /// A resolver returning mock symbols.
     class TestSymbolResolver: GlobalExternalSymbolResolver {
         func symbolReferenceAndEntity(withPreciseIdentifier preciseIdentifier: String) -> (ResolvedTopicReference, LinkResolver.ExternalEntity)? {
-            let reference = ResolvedTopicReference(bundleIdentifier: "com.test.symbols", path: "/\(preciseIdentifier)", sourceLanguage: SourceLanguage.swift)
+            let reference = ResolvedTopicReference(bundleID: "com.test.symbols", path: "/\(preciseIdentifier)", sourceLanguage: SourceLanguage.swift)
             let entity = LinkResolver.ExternalEntity(
                 topicRenderReference: TopicRenderReference(
                     identifier: .init(preciseIdentifier),
@@ -55,7 +55,7 @@ class ExternalTopicsGraphHashTests: XCTestCase {
         
         // Add external links and verify the checksum is always the same
         let hashes: [String] = try (0...10).map { _ -> MetricValue? in
-            let (_, _, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleIdentifier: externalResolver]) { url in
+            let (_, _, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
             try """
             # ``SideKit/SideClass``
 
@@ -64,8 +64,8 @@ class ExternalTopicsGraphHashTests: XCTestCase {
             ## Topics
                 
             ### External references
-            - <doc://\(externalResolver.bundleIdentifier)/path/to/external/symbol1>
-            - <doc://\(externalResolver.bundleIdentifier)/path/to/external/symbol2>
+            - <doc://\(externalResolver.bundleID)/path/to/external/symbol1>
+            - <doc://\(externalResolver.bundleID)/path/to/external/symbol2>
             """.write(to: url.appendingPathComponent("documentation/sideclass.md"), atomically: true, encoding: .utf8)
             }
             
@@ -93,7 +93,7 @@ class ExternalTopicsGraphHashTests: XCTestCase {
         
         // Add external links and verify the checksum is always the same
         let hashes: [String] = try (0...10).map { _ -> MetricValue? in
-            let (_, _, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleIdentifier: externalResolver], externalSymbolResolver: externalSymbolResolver) { url in
+            let (_, _, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleID: externalResolver], externalSymbolResolver: externalSymbolResolver) { url in
             try """
             # ``SideKit/SideClass``
 
@@ -102,8 +102,8 @@ class ExternalTopicsGraphHashTests: XCTestCase {
             ## Topics
                 
             ### External references
-            - <doc://\(externalResolver.bundleIdentifier)/path/to/external/symbol1>
-            - <doc://\(externalResolver.bundleIdentifier)/path/to/external/symbol2>
+            - <doc://\(externalResolver.bundleID)/path/to/external/symbol1>
+            - <doc://\(externalResolver.bundleID)/path/to/external/symbol2>
             """.write(to: url.appendingPathComponent("documentation/sideclass.md"), atomically: true, encoding: .utf8)
             }
             
@@ -131,7 +131,7 @@ class ExternalTopicsGraphHashTests: XCTestCase {
         let externalResolver = self.externalResolver
 
         // Load a bundle with external links
-        let (_, _, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleIdentifier: externalResolver]) { url in
+        let (_, _, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
         try """
         # ``SideKit/SideClass``
 
@@ -140,8 +140,8 @@ class ExternalTopicsGraphHashTests: XCTestCase {
         ## Topics
             
         ### External references
-        - <doc://\(externalResolver.bundleIdentifier)/path/to/external/symbol1>
-        - <doc://\(externalResolver.bundleIdentifier)/path/to/external/symbol2>
+        - <doc://\(externalResolver.bundleID)/path/to/external/symbol1>
+        - <doc://\(externalResolver.bundleID)/path/to/external/symbol2>
         """.write(to: url.appendingPathComponent("documentation/sideclass.md"), atomically: true, encoding: .utf8)
         }
     

--- a/Tests/SwiftDocCTests/Benchmark/TopicAnchorHashTests.swift
+++ b/Tests/SwiftDocCTests/Benchmark/TopicAnchorHashTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,7 +50,7 @@ class TopicAnchorHashTests: XCTestCase {
         }
         
         // Add a new section to verify that the hash will change
-        let newReference = ResolvedTopicReference(bundleIdentifier: "com.bundle.id", path: "/documentation/new#section", sourceLanguage: .swift)
+        let newReference = ResolvedTopicReference(bundleID: "com.bundle.id", path: "/documentation/new#section", sourceLanguage: .swift)
         context.nodeAnchorSections[newReference] = AnchorSection(reference: newReference, title: "New Sub-section")
 
         // Now verify that the topic anchor hash changed after the change

--- a/Tests/SwiftDocCTests/Benchmark/TopicGraphHashTests.swift
+++ b/Tests/SwiftDocCTests/Benchmark/TopicGraphHashTests.swift
@@ -51,7 +51,7 @@ class TopicGraphHashTests: XCTestCase {
         }
         
         // Here we'll add a completely new node and curated it in the topic graph
-        let newNode = TopicGraph.Node(reference: .init(bundleIdentifier: #function, path: "/newSymbol", sourceLanguage: .swift), kind: .article, source: .external, title: "External Article")
+        let newNode = TopicGraph.Node(reference: .init(bundleID: #function, path: "/newSymbol", sourceLanguage: .swift), kind: .article, source: .external, title: "External Article")
         context.topicGraph.addNode(newNode)
         // We can force unwrap below because we're guaranteed to find at least one node which is not `newNode`
         context.topicGraph.addEdge(from: context.topicGraph.nodes.values.first(where: { existingNode -> Bool in
@@ -105,7 +105,7 @@ class TopicGraphHashTests: XCTestCase {
         }
         
         // Get MyKit symbol
-        let entity = try context.entity(with: .init(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
+        let entity = try context.entity(with: .init(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         let taskGroupLinks = try XCTUnwrap((entity.semantic as? Symbol)?.topics?.taskGroups.first?.links.compactMap({ $0.destination }))
         
         // Verify the task group links have been resolved and are still present in the link list.
@@ -117,7 +117,7 @@ class TopicGraphHashTests: XCTestCase {
         ])
         
         // Verify correct hierarchy under `MyKit` in the topic graph dump including external symbols.
-        let myKitRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let myKitRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         let myKitNode = try XCTUnwrap(context.topicGraph.nodeWithReference(myKitRef))
         
         let expectedHierarchyWithExternalSymbols = """

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,7 @@ import Markdown
 class RenderNodeCodableTests: XCTestCase {
     
     var bareRenderNode = RenderNode(
-        identifier: .init(bundleIdentifier: "com.bundle", path: "/", sourceLanguage: .swift),
+        identifier: .init(bundleID: "com.bundle", path: "/", sourceLanguage: .swift),
         kind: .article
     )
     
@@ -146,10 +146,10 @@ class RenderNodeCodableTests: XCTestCase {
             subdirectory: "Test Resources"
         )!
         
-        let bundleID = #function
+        let bundleID: DocumentationBundle.Identifier = #function
         
         let renderNodeWithUniqueBundleID = try String(contentsOf: exampleRenderNodeJSON)
-        .replacingOccurrences(of: "org.swift.docc.example", with: bundleID)
+            .replacingOccurrences(of: "org.swift.docc.example", with: bundleID.rawValue)
         
         _ = try JSONDecoder().decode(RenderNode.self, from: Data(renderNodeWithUniqueBundleID.utf8))
         
@@ -189,7 +189,7 @@ class RenderNodeCodableTests: XCTestCase {
         )
         
         let reference = ResolvedTopicReference(
-            bundleIdentifier: "org.swift.docc.example",
+            bundleID: "org.swift.docc.example",
             path: "/documentation/test/customTopicSectionStyle",
             fragment: nil,
             sourceLanguage: .swift

--- a/Tests/SwiftDocCTests/Converter/Rewriter/RenderNodeVariantOverridesApplierTests.swift
+++ b/Tests/SwiftDocCTests/Converter/Rewriter/RenderNodeVariantOverridesApplierTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -77,7 +77,7 @@ class RenderNodeVariantOverridesApplierTests: XCTestCase {
                 renderNode.addVariantOverride(
                     pointerComponents: ["identifier"],
                     value: ResolvedTopicReference(
-                        bundleIdentifier: "new-bundle-identifier",
+                        bundleID: "new-bundle-identifier",
                         path: "/path",
                         fragment: nil,
                         sourceLanguage: .objectiveC
@@ -193,7 +193,7 @@ class RenderNodeVariantOverridesApplierTests: XCTestCase {
     ) throws {
         var renderNode = RenderNode(
             identifier: ResolvedTopicReference(
-                bundleIdentifier: "bundle-identifier",
+                bundleID: "bundle-identifier",
                 path: "",
                 fragment: nil,
                 sourceLanguage: .swift

--- a/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
+++ b/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import XCTest
 class TopicRenderReferenceEncoderTests: XCTestCase {
 
     func testRenderNodeSkipsReferences() throws {
-        var node = RenderNode(identifier: .init(bundleIdentifier: "bundle", path: "/documentation/MyClass", sourceLanguage: .swift), kind: .article)
+        var node = RenderNode(identifier: .init(bundleID: "bundle", path: "/documentation/MyClass", sourceLanguage: .swift), kind: .article)
         node.references = [
             "reference1": TopicRenderReference(identifier: .init("reference1"), title: "myFunction", abstract: [], url: "/documentation/MyClass/myFunction", kind: .symbol, estimatedTime: nil),
         ]
@@ -51,7 +51,7 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
     
     func testTopicReferenceEncoder() throws {
         // Create a render node
-        var node = RenderNode(identifier: .init(bundleIdentifier: "bundle", path: "/documentation/MyClass", sourceLanguage: .swift), kind: .article)
+        var node = RenderNode(identifier: .init(bundleID: "bundle", path: "/documentation/MyClass", sourceLanguage: .swift), kind: .article)
         node.references = [
             "reference1": TopicRenderReference(identifier: .init("reference1"), title: "myFunction", abstract: [], url: "/documentation/MyClass/myFunction", kind: .symbol, estimatedTime: nil),
         ]
@@ -124,7 +124,7 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
         // Create many render nodes.
         let nodes = (0..<1000)
             .map({ i -> RenderNode in
-                var node = RenderNode(identifier: .init(bundleIdentifier: "bundle", path: "/documentation/MyClass\(i)", sourceLanguage: .swift), kind: .article)
+                var node = RenderNode(identifier: .init(bundleID: "bundle", path: "/documentation/MyClass\(i)", sourceLanguage: .swift), kind: .article)
                 node.references = references
                 return node
             })

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -84,7 +84,7 @@ class DiagnosticTests: XCTestCase {
         let content = "Test a ``Reference`` in a sentence."
         let markup = Document(parsing: content, source: URL(string: "/tmp/foo.symbols.json"), options: .parseSymbolLinks)
         
-        var resolver = ReferenceResolver(context: context, bundle: bundle, rootReference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
+        var resolver = ReferenceResolver(context: context, bundle: bundle, rootReference: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
         
         // Resolve references
         _ = resolver.visitMarkup(markup)

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -17,7 +17,7 @@ import SwiftDocCTestUtilities
 class ConvertServiceTests: XCTestCase {
     private let testBundleInfo = DocumentationBundle.Info(
         displayName: "TestBundle",
-        identifier: "identifier"
+        id: "identifier"
     )
     
     func testConvertSinglePage() throws {
@@ -918,7 +918,7 @@ class ConvertServiceTests: XCTestCase {
                     )
                     
                 case .asset(let assetReference):
-                    switch (assetReference.assetName, assetReference.bundleIdentifier) {
+                    switch (assetReference.assetName, assetReference.bundleID) {
                     case (let assetName, "identifier") where ["before.swift", "after.swift"].contains(assetName):
                         var asset = DataAsset()
                         asset.register(
@@ -1089,7 +1089,7 @@ class ConvertServiceTests: XCTestCase {
                     return nil
                     
                 case .asset(let assetReference):
-                    switch (assetReference.assetName, assetReference.bundleIdentifier) {
+                    switch (assetReference.assetName, assetReference.bundleID) {
                     case (let assetName, "identifier") where expectedAssetNames.contains(assetName):
                         var asset = DataAsset()
                         asset.register(
@@ -1730,7 +1730,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
-                identifier: "com.test.bundle"
+                id: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             documentPathsToConvert: [],
@@ -1881,7 +1881,7 @@ class ConvertServiceTests: XCTestCase {
                     }
                     
                 case .asset(let assetReference):
-                    switch (assetReference.assetName, assetReference.bundleIdentifier) {
+                    switch (assetReference.assetName, assetReference.bundleID) {
                     case ("image.png", "com.test.bundle"):
                         var asset = DataAsset()
                         asset.register(
@@ -2019,7 +2019,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
-                identifier: "org.swift.example"
+                id: "org.swift.example"
             ),
             externalIDsToConvert: ["s:32MyKit3FooV"],
             documentPathsToConvert: [],
@@ -2128,7 +2128,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
-                identifier: "com.test.bundle"
+                id: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework40EnumerationWithSingleUnresolvableDocLinkO"],
             documentPathsToConvert: [],
@@ -2166,7 +2166,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
-                identifier: "com.test.bundle"
+                id: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework15TestEnumerationO06NesteddE0O0D6StructV06deeplyfD31FunctionWithUnresolvableDocLinkyyF"],
             documentPathsToConvert: [],
@@ -2205,7 +2205,7 @@ class ConvertServiceTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundleDisplayName",
-                identifier: "com.test.bundle"
+                id: "com.test.bundle"
             ),
             externalIDsToConvert: ["s:21SmallTestingFramework43EnumerationWithSingleUnresolvableSymbolLinkO"],
             documentPathsToConvert: [],
@@ -2331,7 +2331,7 @@ class ConvertServiceTests: XCTestCase {
         let bundleURL = tempURL.appendingPathComponent("unit-test.docc")
         
         let requestWithDifferentBundleID = ConvertRequest(
-            bundleInfo: DocumentationBundle.Info(displayName: "DisplayName", identifier: "com.example.something-else"),
+            bundleInfo: DocumentationBundle.Info(displayName: "DisplayName", id: "com.example.something-else"),
             externalIDsToConvert: [],
             bundleLocation: bundleURL,
             symbolGraphs: [],
@@ -2341,7 +2341,7 @@ class ConvertServiceTests: XCTestCase {
         XCTAssertEqual(try linkResolutionRequestsForConvertRequest(requestWithDifferentBundleID), [], "Shouldn't make any link resolution requests because the bundle IDs are different.")
         
         let requestWithSameBundleID = ConvertRequest(
-            bundleInfo: DocumentationBundle.Info(displayName: "DisplayName", identifier: "com.example.something"),
+            bundleInfo: DocumentationBundle.Info(displayName: "DisplayName", id: "com.example.something"),
             externalIDsToConvert: [],
             bundleLocation: bundleURL,
             symbolGraphs: [],

--- a/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/DocumentationServer+DefaultTests.swift
@@ -68,7 +68,7 @@ class DocumentationServer_DefaultTests: XCTestCase {
         let request = ConvertRequest(
             bundleInfo: DocumentationBundle.Info(
                 displayName: "TestBundle",
-                identifier: "identifier"
+                id: "identifier"
             ),
             externalIDsToConvert: ["s:5MyKit0A5ClassC10myFunctionyyF"],
             symbolGraphs: [symbolGraph],

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@ class IndexingTests: XCTestCase {
     // MARK: - Tutorial
     func testTutorial() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let tutorialReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+        let tutorialReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         let node = try context.entity(with: tutorialReference)
         let tutorial = node.semantic as! Tutorial
         var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: tutorialReference)
@@ -69,7 +69,7 @@ class IndexingTests: XCTestCase {
             .init(title: "Section 1", contentSection: [.contentAndMedia(content: contentSection)], stepsSection: [.paragraph(.init(inlineContent: [.text("This is a step.")]))], anchor: "section-1"),
             .init(title: "Section 2", contentSection: [.contentAndMedia(content: contentSection)], stepsSection: [.paragraph(.init(inlineContent: [.text("This is a step.")]))], anchor: "section-2"),
         ])
-        let tutorialReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/TestTutorial", sourceLanguage: .swift)
+        let tutorialReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/TestTutorial", sourceLanguage: .swift)
         let indexingRecords = try tutorialSectionsSection.indexingRecords(onPage: tutorialReference, references: [:])
         XCTAssertEqual(2, indexingRecords.count)
         
@@ -90,7 +90,7 @@ class IndexingTests: XCTestCase {
     
     func testArticle() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift)
+        let articleReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! TutorialArticle
         var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference)
@@ -188,7 +188,7 @@ class IndexingTests: XCTestCase {
     
     func testRootPageIndexingRecord() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+        let articleReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
         var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference)
@@ -221,7 +221,7 @@ class IndexingTests: XCTestCase {
             try updatedPlistData.write(to: plistURL)
         }
         
-        let articleReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
+        let articleReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
         var converter = RenderNodeTranslator(context: context, bundle: bundle, identifier: articleReference)

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -243,18 +243,18 @@ Root
     }
     
     func testLoadingNavigatorIndexDoesNotCacheReferences() throws {
-        let uniqueTestBundleIdentifier = #function
+        let uniqueTestBundleIdentifier: DocumentationBundle.Identifier = #function
         
         let targetURL = try createTemporaryDirectory()
         let indexURL = targetURL.appendingPathComponent("nav.index")
         
-        let root = generateSmallTree(bundleIdentifier: uniqueTestBundleIdentifier)
+        let root = generateSmallTree(bundleIdentifier: uniqueTestBundleIdentifier.rawValue)
         
         let original = NavigatorTree(root: root)
         try original.write(to: indexURL)
         _ = try NavigatorTree.read(
             from: indexURL,
-            bundleIdentifier: uniqueTestBundleIdentifier,
+            bundleIdentifier: uniqueTestBundleIdentifier.rawValue,
             atomically: true
         )
         
@@ -639,8 +639,8 @@ Root
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
-        let fromMemoryBuilder  = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: bundle.identifier, sortRootChildrenByName: true, groupByLanguage: true)
-        let fromDecodedBuilder = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: bundle.identifier, sortRootChildrenByName: true, groupByLanguage: true)
+        let fromMemoryBuilder  = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: bundle.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let fromDecodedBuilder = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: bundle.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
         fromMemoryBuilder.setup()
         fromDecodedBuilder.setup()
         
@@ -1194,7 +1194,7 @@ Root
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: bundle.identifier, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: bundle.id.rawValue, sortRootChildrenByName: true)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -1210,7 +1210,7 @@ Root
         
         let imageReference = try XCTUnwrap(renderIndex.references["plus.svg"])
         XCTAssertEqual(imageReference.asset.variants.values.map(\.path).sorted(), [
-            "/images/\(bundle.identifier)/plus.svg",
+            "/images/\(bundle.id)/plus.svg",
         ])
     }
     
@@ -1852,7 +1852,7 @@ Root
     
     func testNormalizedNavigatorIndexIdentifier() throws {
         let topicReference = ResolvedTopicReference(
-            bundleIdentifier: "org.swift.example",
+            bundleID: "org.swift.example",
             path: "/documentation/path/sub-path",
             fragment: nil,
             sourceLanguage: .swift
@@ -1869,7 +1869,7 @@ Root
         )
         
         let topicReferenceWithCapitalization = ResolvedTopicReference(
-            bundleIdentifier: "org.Swift.Example",
+            bundleID: "org.Swift.Example",
             path: "/documentation/Path/subPath",
             fragment: nil,
             sourceLanguage: .swift
@@ -1886,7 +1886,7 @@ Root
         )
         
         let topicReferenceWithFragment = ResolvedTopicReference(
-            bundleIdentifier: "org.Swift.Example",
+            bundleID: "org.Swift.Example",
             path: "/documentation/Path/subPath",
             fragment: "FRAGMENT",
             sourceLanguage: .swift

--- a/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -21,15 +21,15 @@ class AnchorSectionTests: XCTestCase {
         
         // Verify the sub-sections of the article have been collected in the context
         [
-            ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TechnologyX/Article", fragment: "Article-Sub-Section", sourceLanguage: .swift),
-            ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TechnologyX/Article", fragment: "Article-Sub-Sub-Section", sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TechnologyX/Article", fragment: "Article-Sub-Section", sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TechnologyX/Article", fragment: "Article-Sub-Sub-Section", sourceLanguage: .swift),
         ]
         .forEach { sectionReference in
             XCTAssertTrue(context.nodeAnchorSections.keys.contains(sectionReference))
         }
         
         // Load the module page
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/CoolFramework", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/CoolFramework", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         
         // Extract the links from the discussion
@@ -79,15 +79,15 @@ class AnchorSectionTests: XCTestCase {
         
         // Verify the sub-sections of the article have been collected in the context
         [
-            ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/CoolFramework/CoolClass", fragment: "Symbol-Sub-Section", sourceLanguage: .swift),
-            ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/CoolFramework/CoolClass", fragment: "Symbol-Sub-Sub-Section", sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/CoolFramework/CoolClass", fragment: "Symbol-Sub-Section", sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/CoolFramework/CoolClass", fragment: "Symbol-Sub-Sub-Section", sourceLanguage: .swift),
         ]
         .forEach { sectionReference in
             XCTAssertTrue(context.nodeAnchorSections.keys.contains(sectionReference))
         }
         
         // Load the module page
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/CoolFramework", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/CoolFramework", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         
         // Extract the links from the discussion
@@ -137,15 +137,15 @@ class AnchorSectionTests: XCTestCase {
         
         // Verify the sub-sections of the article have been collected in the context
         [
-            ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/CoolFramework", fragment: "Module-Sub-Section", sourceLanguage: .swift),
-            ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/CoolFramework", fragment: "Module-Sub-Sub-Section", sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/CoolFramework", fragment: "Module-Sub-Section", sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/CoolFramework", fragment: "Module-Sub-Sub-Section", sourceLanguage: .swift),
         ]
         .forEach { sectionReference in
             XCTAssertTrue(context.nodeAnchorSections.keys.contains(sectionReference))
         }
         
         // Load the article page
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TechnologyX/Article", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TechnologyX/Article", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         
         // Extract the links from the discussion

--- a/Tests/SwiftDocCTests/Infrastructure/AutoCapitalizationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutoCapitalizationTests.swift
@@ -66,7 +66,7 @@ class AutoCapitalizationTests: XCTestCase {
         
         XCTAssertEqual(context.problems.count, 0)
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         let parameterSections = symbol.parametersSectionVariants
@@ -113,7 +113,7 @@ class AutoCapitalizationTests: XCTestCase {
         
         XCTAssertEqual(context.problems.count, 0)
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         let parameterSections = symbol.parametersSectionVariants
@@ -156,7 +156,7 @@ class AutoCapitalizationTests: XCTestCase {
         
         XCTAssertEqual(context.problems.count, 0)
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -98,7 +98,7 @@ class AutomaticCurationTests: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = try XCTUnwrap(translator.visit(node.semantic) as? RenderNode, file: file, line: line)
         
@@ -136,7 +136,7 @@ class AutomaticCurationTests: XCTestCase {
             """.write(to: url.appendingPathComponent("sideclass.md"), atomically: true, encoding: .utf8)
         })
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
         // Compile the render node to flex the automatic curator
         let symbol = node.semantic as! Symbol
@@ -186,7 +186,7 @@ class AutomaticCurationTests: XCTestCase {
                 """.write(to: url.appendingPathComponent("documentation/sideclass.md"), atomically: true, encoding: .utf8)
             }
             
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
             // Compile docs and verify the generated Topics section
             let symbol = node.semantic as! Symbol
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -348,7 +348,7 @@ class AutomaticCurationTests: XCTestCase {
         
         // The first topic section
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
@@ -364,7 +364,7 @@ class AutomaticCurationTests: XCTestCase {
         
         // The second topic section
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassFour", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClassFour", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
@@ -377,7 +377,7 @@ class AutomaticCurationTests: XCTestCase {
         
         // The second topic section
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassSix", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClassSix", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
@@ -389,21 +389,21 @@ class AutomaticCurationTests: XCTestCase {
         
         // The automatically curated symbols shouldn't have a See Also section
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassEight", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClassEight", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             XCTAssertNil(renderNode.seeAlsoSections.first, "This symbol was automatically curated and shouldn't have a See Also section")
         }
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassNine", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClassNine", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
             XCTAssertNil(renderNode.seeAlsoSections.first, "This symbol was automatically curated and shouldn't have a See Also section")
         }
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClassTen", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClassTen", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
@@ -430,7 +430,7 @@ class AutomaticCurationTests: XCTestCase {
 
         do {
             // Get the framework render node
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
@@ -443,7 +443,7 @@ class AutomaticCurationTests: XCTestCase {
         
         do {
             // Get the `A` render node
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/A", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/A", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
             
@@ -483,7 +483,7 @@ class AutomaticCurationTests: XCTestCase {
         // Load the "MixedLanguageProtocol Implementations" API COllection
         let protocolImplementationsNode = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/MixedLanguageFramework/MixedLanguageClassConformingToProtocol/MixedLanguageProtocol-Implementations",
                 sourceLanguages: [.swift, .objectiveC]
             )
@@ -509,7 +509,7 @@ class AutomaticCurationTests: XCTestCase {
         
         let frameworkDocumentationNode = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/MixedLanguageFramework",
                 sourceLanguages: [.swift, .objectiveC]
             )
@@ -587,7 +587,7 @@ class AutomaticCurationTests: XCTestCase {
 
         let frameworkDocumentationNode = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/Whatsit",
                 sourceLanguages: [.objectiveC]
             )
@@ -613,7 +613,7 @@ class AutomaticCurationTests: XCTestCase {
 
         let classDocumentationNode = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/Whatsit/Whatsit",
                 sourceLanguages: [.objectiveC]
             )
@@ -648,7 +648,7 @@ class AutomaticCurationTests: XCTestCase {
 
         let containerDocumentationNode = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/ThirdOrder/SomeStruct",
                 sourceLanguages: [.swift]
             )
@@ -675,7 +675,7 @@ class AutomaticCurationTests: XCTestCase {
 
         let rootDocumentationNode = try context.entity(
             with: .init(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/CxxSymbols",
                 sourceLanguage: .objectiveC
             )
@@ -765,7 +765,7 @@ class AutomaticCurationTests: XCTestCase {
 
         let protocolDocumentationNode = try context.entity(
             with: .init(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/ShapeKit/OverloadedProtocol",
                 sourceLanguage: .swift))
 
@@ -819,7 +819,7 @@ class AutomaticCurationTests: XCTestCase {
 
         let protocolDocumentationNode = try context.entity(
             with: .init(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/ShapeKit/OverloadedProtocol",
                 sourceLanguage: .swift))
 
@@ -1244,7 +1244,7 @@ class AutomaticCurationTests: XCTestCase {
              let catalogURL = try exampleDocumentation.write(inside: createTemporaryDirectory())
              let (_, bundle, context) = try loadBundle(from: catalogURL)
 
-             let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SomeClass", sourceLanguage: .swift))
+             let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SomeClass", sourceLanguage: .swift))
 
              // Compile docs and verify the generated Topics section
              var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)

--- a/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
@@ -139,7 +139,7 @@ class BundleDiscoveryTests: XCTestCase {
         func checkExpectedFilesFoundIn(_ folder: File, file: StaticString = #file, line: UInt = #line) throws {
             let bundle = try parsedBundle(from: folder)
             
-            XCTAssertEqual(bundle.identifier, expectedBundle.identifier)
+            XCTAssertEqual(bundle.id, expectedBundle.id)
             XCTAssertEqual(bundle.displayName, expectedBundle.displayName)
             
             func assertEqualFiles(_ got: [URL], _ expected: [URL], file: StaticString = #file, line: UInt = #line) {
@@ -233,7 +233,7 @@ class BundleDiscoveryTests: XCTestCase {
         let (bundle, _) = try inputProvider.inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/"), options: bundleDiscoveryOptions)
         
         // The bundle information was overridden from the options
-        XCTAssertEqual(bundle.identifier, "org.swift.docc.example")
+        XCTAssertEqual(bundle.id, "org.swift.docc.example")
         XCTAssertEqual(bundle.displayName, "Test Bundle") // The fallback should not override this value
         
         // The additional symbol graph files are part of the bundle
@@ -265,7 +265,7 @@ class BundleDiscoveryTests: XCTestCase {
         let (bundle, _) = try inputProvider.inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/\(catalog.name)"), options: bundleDiscoveryOptions)
         
         // The bundle information was specified via the options
-        XCTAssertEqual(bundle.identifier, "com.fallback.bundle.identifier")
+        XCTAssertEqual(bundle.id, "com.fallback.bundle.identifier")
         XCTAssertEqual(bundle.displayName, "Fallback Display Name")
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleIdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleIdentifierTests.swift
@@ -1,0 +1,59 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+
+class DocumentationBundleIdentifierTests: XCTestCase {
+    private typealias Identifier = DocumentationBundle.Identifier
+    
+    func testInitialization() {
+        let id = Identifier(rawValue: "com.example.test")
+        XCTAssertEqual(id.rawValue, "com.example.test")
+        
+        let idWithSpace = Identifier(rawValue: "Package  Name")
+        XCTAssertEqual(idWithSpace.rawValue, "Package-Name", "The initializer transforms the value to a valid identifier")
+    }
+    
+    func testExpressibleByStringLiteral() {
+        let id: Identifier = "com.example.test"
+        XCTAssertEqual(id.rawValue, "com.example.test")
+        
+        let idWithSpace: Identifier = "Package  Name"
+        XCTAssertEqual(idWithSpace.rawValue, "Package-Name", "The initializer transforms the value to a valid identifier")
+    }
+    
+    func testEquatable() {
+        XCTAssertEqual(Identifier(rawValue: "A"), "A")
+        XCTAssertNotEqual(Identifier(rawValue: "A"), "B")
+    }
+    
+    func testComparable() {
+        XCTAssertLessThan(Identifier(rawValue: "B"), "C")
+        XCTAssertGreaterThan(Identifier(rawValue: "B"), "A")
+    }
+    
+    func testCustomStringConvertible() {
+        XCTAssertEqual(Identifier(rawValue: "com.example.test").description, "com.example.test")
+        XCTAssertEqual(Identifier(rawValue: "Package  Name").description, "Package-Name")
+        
+    }
+    
+    func testEncodesAsPlainString() throws {
+        let id = Identifier(rawValue: "com.example.test")
+        let encoded = try String(data: JSONEncoder().encode(id), encoding: .utf8)
+        XCTAssertEqual(encoded, "\"com.example.test\"")
+    }
+    
+    func testDecodingFromPlainString() throws {
+        let decoded = try JSONDecoder().decode(Identifier.self, from: Data("\"com.example.test\"".utf8))
+        XCTAssertEqual(decoded, "com.example.test")
+    }
+}

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationBundleInfoTests.swift
@@ -22,7 +22,7 @@ class DocumentationBundleInfoTests: XCTestCase {
         let info = try DocumentationBundle.Info(from: infoPlistData)
         
         XCTAssertEqual(info.displayName, "Test Bundle")
-        XCTAssertEqual(info.identifier, "org.swift.docc.example")
+        XCTAssertEqual(info.id.rawValue, "org.swift.docc.example")
         XCTAssertEqual(info.defaultCodeListingLanguage, "swift")
     }
 
@@ -82,7 +82,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Info Plist Display Name",
-                identifier: "com.info.Plist"
+                id: "com.info.Plist"
             )
         )
         
@@ -93,7 +93,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Fallback Display Name",
-                identifier: "com.fallback.Identifier"
+                id: "com.fallback.Identifier"
             )
         )
         
@@ -104,7 +104,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Fallback Display Name",
-                identifier: "com.info.Plist"
+                id: "com.info.Plist"
             )
         )
         
@@ -128,7 +128,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Info Plist Display Name",
-                identifier: "com.info.Plist"
+                id: "com.info.Plist"
             )
         )
     }
@@ -237,7 +237,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             info,
             DocumentationBundle.Info(
                 displayName: "Display Name",
-                identifier: "swift.org.Identifier",
+                id: "swift.org.Identifier",
                 defaultCodeListingLanguage: "swift",
                 defaultModuleKind: "Executable",
                 defaultAvailability: DefaultAvailability(
@@ -257,7 +257,7 @@ class DocumentationBundleInfoTests: XCTestCase {
     func testFallbackToInfoInBundleDiscoveryOptions() throws {
         let info = DocumentationBundle.Info(
             displayName: "Display Name",
-            identifier: "swift.org.Identifier",
+            id: "swift.org.Identifier",
             defaultCodeListingLanguage: "swift",
             defaultModuleKind: "Executable",
             defaultAvailability: DefaultAvailability(
@@ -341,7 +341,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Derived Display Name",
-                identifier: "Derived Display Name"
+                id: "Derived Display Name"
             )
         )
     }
@@ -366,7 +366,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Derived Display Name",
-                identifier: "org.swift.docc.example"
+                id: "org.swift.docc.example"
             )
         )
     }
@@ -390,7 +390,7 @@ class DocumentationBundleInfoTests: XCTestCase {
             ),
             DocumentationBundle.Info(
                 displayName: "Example",
-                identifier: "Example"
+                id: "Example"
             )
         )
     }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageLinkResolutionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageLinkResolutionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -31,7 +31,7 @@ class DocumentationContext_MixedLanguageLinkResolutionTests: XCTestCase {
                 let resolutionResult = context.resolve(
                     .unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(symbolPath: symbolPath))),
                     in: ResolvedTopicReference(
-                        bundleIdentifier: "org.swift.MixedLanguageFramework",
+                        bundleID: "org.swift.MixedLanguageFramework",
                         path: "/documentation/MixedLanguageFramework/\(parentPath)",
                         sourceLanguage: .swift
                     ),

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
@@ -46,7 +46,7 @@ class DocumentationContext_RootPageTests: XCTestCase {
         XCTAssertEqual(context.rootModules.map({ $0.url.path }), ["/documentation/ReleaseNotes"])
         
         // Verify the root was crawled
-        XCTAssertEqual(context.topicGraph.edges[ResolvedTopicReference(bundleIdentifier: "com.test.example", path: "/documentation/ReleaseNotes", sourceLanguage: .swift)]?.map({ $0.url.path }),
+        XCTAssertEqual(context.topicGraph.edges[ResolvedTopicReference(bundleID: "com.test.example", path: "/documentation/ReleaseNotes", sourceLanguage: .swift)]?.map({ $0.url.path }),
                        ["/documentation/TestBundle/ReleaseNotes-1.2"])
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -48,7 +48,7 @@ class DocumentationContextTests: XCTestCase {
         
         // Test resolving
         let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:/TestTutorial")!)
-        let parent = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "", sourceLanguage: .swift)
+        let parent = ResolvedTopicReference(bundleIdentifier: bundle.id.rawValue, path: "", sourceLanguage: .swift)
         
         guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
             XCTFail("Couldn't resolve \(unresolved)")
@@ -85,11 +85,11 @@ class DocumentationContextTests: XCTestCase {
     func testLoadEntity() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
-        let identifier = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+        let identifier = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         
-        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "some.other.bundle", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)))
+        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: "some.other.bundle", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)))
         
-        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/Test-Bundle/wrongIdentifier", sourceLanguage: .swift)))
+        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/Test-Bundle/wrongIdentifier", sourceLanguage: .swift)))
 
         let node = try context.entity(with: identifier)
                 
@@ -418,15 +418,15 @@ class DocumentationContextTests: XCTestCase {
         
     func testThrowsErrorForMissingResource() throws {
         let (_, context) = try testBundleAndContext()
-        XCTAssertThrowsError(try context.resource(with: ResourceReference(bundleIdentifier: "com.example.missing", path: "/missing.swift")), "Expected requesting an unknown file to result in an error.")
+        XCTAssertThrowsError(try context.resource(with: ResourceReference(bundleID: "com.example.missing", path: "/missing.swift")), "Expected requesting an unknown file to result in an error.")
     }
 
     func testThrowsErrorForQualifiedImagePaths() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let id = bundle.identifier
+        let id = bundle.id
 
-        let figure = ResourceReference(bundleIdentifier: id, path: "figure1.jpg")
-        let imageFigure = ResourceReference(bundleIdentifier: id, path: "images/figure1.jpg")
+        let figure = ResourceReference(bundleID: id, path: "figure1.jpg")
+        let imageFigure = ResourceReference(bundleID: id, path: "images/figure1.jpg")
 
         XCTAssertNoThrow(try context.resource(with: figure), "\(figure.path) expected in \(bundle.displayName)")
         XCTAssertThrowsError(try context.resource(with: imageFigure), "Images should be registered (and referred to) by their name, not by their path.")
@@ -436,11 +436,11 @@ class DocumentationContextTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
         let existingImageReference = ResourceReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "introposter"
         )
         let nonexistentImageReference = ResourceReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "nonexistent-image"
         )
         XCTAssertTrue(
@@ -453,11 +453,11 @@ class DocumentationContextTests: XCTestCase {
         )
         
         let correctImageReference = ResourceReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "figure1.jpg"
         )
         let incorrectImageReference = ResourceReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "images/figure1.jpg"
         )
         XCTAssertTrue(
@@ -517,7 +517,7 @@ class DocumentationContextTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
         let imagesRegistered = context
-            .registeredImageAssets(forBundleID: bundle.identifier)
+            .registeredImageAssets(for: bundle.id)
             .flatMap { $0.variants.map { $0.value.lastPathComponent } }
             .sorted()
         
@@ -561,12 +561,12 @@ class DocumentationContextTests: XCTestCase {
     func testDownloadAssets() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let downloadsBefore = context.registeredDownloadsAssets(forBundleID: bundle.identifier)
+        let downloadsBefore = context.registeredDownloadsAssets(for: bundle.id)
         XCTAssertEqual(downloadsBefore.count, 1)
         XCTAssertEqual(downloadsBefore.first?.variants.values.first?.lastPathComponent, "project.zip")
         
         guard var assetOriginal = context
-            .registeredImageAssets(forBundleID: bundle.identifier)
+            .registeredImageAssets(for: bundle.id)
             .first(where: { asset -> Bool in
                 return asset.variants.values.first(where: { url -> Bool in
                     return url.path.contains("intro.png")
@@ -581,7 +581,7 @@ class DocumentationContextTests: XCTestCase {
         context.updateAsset(named: "intro.png", asset: assetOriginal, in: bundle.rootReference)
         
         guard let assetUpdated = context
-            .registeredImageAssets(forBundleID: bundle.identifier)
+            .registeredImageAssets(for: bundle.id)
             .first(where: { asset -> Bool in
                 return asset.variants.values.first(where: { url -> Bool in
                     return url.path.contains("intro.png")
@@ -595,7 +595,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(assetUpdated.context, .download)
         
         // Verify the asset is accessible in the downloads collection.
-        var downloadsAfter = context.registeredDownloadsAssets(forBundleID: bundle.identifier)
+        var downloadsAfter = context.registeredDownloadsAssets(for: bundle.id)
         XCTAssertEqual(downloadsAfter.count, 2)
         downloadsAfter.removeAll(where: { $0.variants.values.first?.lastPathComponent == "project.zip" })
         XCTAssertEqual(downloadsAfter.count, 1)
@@ -1235,7 +1235,7 @@ class DocumentationContextTests: XCTestCase {
             let (bundle, context) = try loadBundle(catalog: testCatalog)
             let renderContext = RenderContext(documentationContext: context, bundle: bundle)
             
-            let identifier = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
             
             let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
@@ -1326,15 +1326,15 @@ let expected = """
         assertEqualDumps(context.dumpGraph(), expected)
         
         // Test correct symbol hierarchy in context
-        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
+        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
                        [["doc://org.swift.docc.example/documentation/MyKit"], ["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyProtocol"]])
         
-        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-33vaw", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
+        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-33vaw", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
                        [["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyClass"], ["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyProtocol", "doc://org.swift.docc.example/documentation/MyKit/MyClass"]])
     }
     
     func createNode(in context: DocumentationContext, bundle: DocumentationBundle, parent: ResolvedTopicReference, name: String) throws -> (DocumentationNode, TopicGraph.Node) {
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/\(name)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/\(name)", sourceLanguage: .swift)
         let node = DocumentationNode(reference: reference, kind: .article, sourceLanguage: .swift, name: .conceptual(title: name), markup: Document(parsing: "# \(name)"), semantic: nil)
         let tgNode = TopicGraph.Node(reference: reference, kind: .article, source: .external, title: name)
         
@@ -1349,7 +1349,7 @@ let expected = """
     func testSortingBreadcrumbsOfEqualDistanceToRoot() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
-        let mykit = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let mykit = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         
         ///
         /// Create nodes in alphabetical order
@@ -1383,7 +1383,7 @@ let expected = """
     func testSortingBreadcrumbsOfDifferentDistancesToRoot() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
-        let mykit = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let mykit = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         let tgMykitNode = try XCTUnwrap(context.topicGraph.nodeWithReference(mykit))
         
         ///
@@ -1431,7 +1431,7 @@ let expected = """
         })
         
         // Verify the node is a child of the module node when the graph is loaded.
-        let sideClassReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
+        let sideClassReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
         let parents = context.parents(of: sideClassReference)
         XCTAssertEqual(parents.map {$0.path}, ["/documentation/SideKit"])
     }
@@ -1452,7 +1452,7 @@ let expected = """
         }
         
         // Get a node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         // Get the breadcrumbs as paths
         let paths = context.finitePaths(to: node.reference).sorted { (path1, path2) -> Bool in
@@ -1513,8 +1513,8 @@ let expected = """
         }
         
         // Verify the non-overload collisions were resolved
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.enum.case", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.var", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.enum.case", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.var", sourceLanguage: .swift)))
     }
     
     func testModuleLanguageFallsBackToSwiftIfItHasNoSymbols() throws {
@@ -1642,9 +1642,9 @@ let expected = """
         }
         
         // Verify the non-overload collisions were resolved
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/tEst-9053a", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-959hd", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/tEst-9053a", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-959hd", sourceLanguage: .swift)))
     }
 
     func testUnknownSymbolKind() throws {
@@ -1656,7 +1656,7 @@ let expected = """
         }
         
         // Get a function node, verify its kind is unknown
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         XCTAssertEqual(node.kind, .unknown)
     }
     
@@ -1840,7 +1840,7 @@ let expected = """
         let problems = context.problems
         XCTAssertEqual(problems.count, 0, "Unexpected problems: \(problems.map(\.diagnostic.summary).sorted())")
         
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         let entity = try context.entity(with: moduleReference)
         
         let moduleSymbol = try XCTUnwrap(entity.semantic as? Symbol)
@@ -2023,9 +2023,9 @@ let expected = """
         XCTAssert(symbolGraphProblems.isEmpty, "There shouldn't be any errors or warnings in the symbol graphs")
         
         // Verify the non-overload collisions form different symbol graph files were resolved
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass-swift.class", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass-swift.class/path", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/sideClass-swift.var", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass-swift.class", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass-swift.class/path", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/sideClass-swift.var", sourceLanguage: .swift)))
     }
 
     func testUnresolvedSidecarDiagnostics() throws {
@@ -2097,7 +2097,7 @@ let expected = """
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/Symbol_Name", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/Symbol_Name", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         
         XCTAssertEqual((node.semantic as? Symbol)?.abstract?.plainText, "Extend a symbol with a space in its name.")
@@ -2147,7 +2147,7 @@ let expected = """
         XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/OldSymbol", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/OldSymbol", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             let deprecatedSection = try XCTUnwrap((node.semantic as? Symbol)?.deprecatedSummary)
@@ -2156,7 +2156,7 @@ let expected = """
         }
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             let deprecatedSection = try XCTUnwrap((node.semantic as? Article)?.deprecationSummary)
@@ -2312,17 +2312,17 @@ let expected = """
         }
 
         // Test that collision symbol reference was updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
         
         // Test that collision symbol child reference was updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/path", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/path", sourceLanguage: .swift)))
 
         // Test that nested collisions were updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property", sourceLanguage: .swift)))
         
         // Test that child of nested collision is updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path", sourceLanguage: .swift)))
         
         // Verify that the symbol index has been updated with the rewritten collision-corrected symbol paths
         XCTAssertEqual(context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10testnEE")?.path, "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property")
@@ -2445,14 +2445,14 @@ let expected = """
         }
 
         // Verify that the Tertiary framework has no symbol in the graph
-        XCTAssertNotNil(try? context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)))
-        XCTAssertNil(try? context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Tertiary", sourceLanguage: .swift)))
+        XCTAssertNotNil(try? context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)))
+        XCTAssertNil(try? context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Tertiary", sourceLanguage: .swift)))
     }
     
     func testDeclarationTokenKinds() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
-        let myFunc = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let myFunc = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         // Symbol graph declaration tokens, including more esoteric kinds like internalParam, externalParam, and unknown kinds.
         let tokens = (myFunc.symbol!.mixins[SymbolGraph.Symbol.DeclarationFragments.mixinKey] as? SymbolGraph.Symbol.DeclarationFragments)?
@@ -2600,7 +2600,7 @@ let expected = """
     func testNavigatorTitle() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         func renderNodeForPath(path: String) throws -> (DocumentationNode, RenderNode) {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
             let node = try context.entity(with: reference)
 
             let symbol = node.semantic as! Symbol
@@ -2655,7 +2655,7 @@ let expected = """
         let (_, _, context) = try loadBundle(from: catalogURL)
         
         let referenceForPath: (String) -> ResolvedTopicReference = { path in
-            return ResolvedTopicReference(bundleIdentifier: "com.test.collisions", path: "/documentation" + path, sourceLanguage: .swift)
+            return ResolvedTopicReference(bundleID: "com.test.collisions", path: "/documentation" + path, sourceLanguage: .swift)
         }
         
         // Verify that:
@@ -2705,14 +2705,14 @@ let expected = """
     }
     
     func testContextCachesReferences() throws {
-        let bundleID = #function
+        let bundleID: DocumentationBundle.Identifier = #function
         // Verify there is no pool bucket for the bundle we're about to test
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
         
         let (_, _, _) = try testBundleAndContext(copying: "TestBundle", excludingPaths: [], configureBundle: { rootURL in
             let infoPlistURL = rootURL.appendingPathComponent("Info.plist", isDirectory: false)
             try! String(contentsOf: infoPlistURL)
-                .replacingOccurrences(of: "org.swift.docc.example", with: bundleID)
+                .replacingOccurrences(of: "org.swift.docc.example", with: bundleID.rawValue)
                 .write(to: infoPlistURL, atomically: true, encoding: .utf8)
         })
 
@@ -2722,13 +2722,13 @@ let expected = """
         let beforeCount = try XCTUnwrap(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
         
         // Verify a given identifier exists in the pool by creating it and verifying it wasn't added to the pool
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         
         // Verify create the reference above did not add to the cache
         XCTAssertEqual(beforeCount, ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
         
         // Create a new reference for the same bundle that was not loaded with the context
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/tutorials/Test-Bundle/TestTutorial/\(#function)", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial/\(#function)", sourceLanguage: .swift)
         
         // Verify creating a new reference added to the ones loaded with the context
         XCTAssertNotEqual(beforeCount, ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
@@ -2742,7 +2742,7 @@ let expected = """
         // Get the SideKit/SideClass/init() node and verify it has an abstract and no discussion.
         // We're verifying that the metadata directive between the title and the abstract didn't cause
         // the content to overflow into the discussion.
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/init()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/init()", sourceLanguage: .swift))
         let markupModel = DocumentationMarkup(markup: node.markup)
         XCTAssertNotNil(markupModel.abstractSection)
         
@@ -2772,7 +2772,7 @@ let expected = """
     
     func testCreatingAnArticleNode() throws {
         // Create documentation node from markup
-        let reference = ResolvedTopicReference(bundleIdentifier: "com.testbundle", path: "/documentation/NewArticle", fragment: nil, sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "com.testbundle", path: "/documentation/NewArticle", fragment: nil, sourceLanguage: .swift)
         
         let source = """
         # New Article
@@ -2791,7 +2791,7 @@ let expected = """
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
         // Verify task group ranges are persisted for symbol docs
-        let symbolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         let symbol = try XCTUnwrap((try? context.entity(with: symbolReference))?.semantic as? Symbol)
         let symbolTopics = try XCTUnwrap(symbol.topics)
         symbolTopics.originalLinkRangesByGroup.forEach { group in
@@ -2799,7 +2799,7 @@ let expected = """
         }
         
         // Verify task group ranges are persisted for articles
-        let articleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
+        let articleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
         let article = try XCTUnwrap((try? context.entity(with: articleReference))?.semantic as? Article)
         let articleTopics = try XCTUnwrap(article.topics)
         articleTopics.originalLinkRangesByGroup.forEach { group in
@@ -3362,7 +3362,7 @@ let expected = """
             "'swiftOnlyMemberName' doesn't exist at '/ModuleName/ObjectiveCName'",
         ])
         
-        let reference = ResolvedTopicReference(bundleIdentifier: "unit-test", path: "/documentation/ModuleName/SwiftName", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "unit-test", path: "/documentation/ModuleName/SwiftName", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         let symbol = try XCTUnwrap(entity.semantic as? Symbol)
         let taskGroups = try XCTUnwrap(symbol.topics).taskGroups
@@ -3471,10 +3471,10 @@ let expected = """
             """.write(to: url.appendingPathComponent("fifthTestMember.md"), atomically: true, encoding: .utf8)
         }
         
-        let articleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ShapeKit/NewArticle", sourceLanguage: .swift)
+        let articleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ShapeKit/NewArticle", sourceLanguage: .swift)
         
         // Fetch the "OverloadedParentStruct" node
-        let reference1 = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ShapeKit/OverloadedParentStruct-1jr3p", sourceLanguage: .swift)
+        let reference1 = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ShapeKit/OverloadedParentStruct-1jr3p", sourceLanguage: .swift)
         let node1 = try context.entity(with: reference1)
         let symbol1 = try XCTUnwrap(node1.semantic as? Symbol)
         
@@ -3487,7 +3487,7 @@ let expected = """
         XCTAssertTrue(tgNode1.contains(articleReference))
         
         // Fetch the "fifthTestMember" node
-        let reference2 = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/\(fifthTestMemberPath)", sourceLanguage: .swift)
+        let reference2 = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/\(fifthTestMemberPath)", sourceLanguage: .swift)
        
         let node2 = try context.entity(with: reference2)
         let symbol2 = try XCTUnwrap(node2.semantic as? Symbol)
@@ -3570,7 +3570,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/someThing-90i4h", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/someThing-90i4h", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3579,7 +3579,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/something-2c4k6", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/something-2c4k6", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3588,7 +3588,7 @@ let expected = """
         
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.method", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.method", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3597,7 +3597,7 @@ let expected = """
         
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.subscript", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.subscript", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3606,7 +3606,7 @@ let expected = """
         
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.type.method", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.type.method", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3681,7 +3681,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyObjectiveCOption/first", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCOption/first", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3690,7 +3690,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyObjectiveCOption/secondCaseSwiftName", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCOption/secondCaseSwiftName", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3699,7 +3699,7 @@ let expected = """
         
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3708,7 +3708,7 @@ let expected = """
         
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethodSwiftName()", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethodSwiftName()", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3742,7 +3742,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyStruct/myStructProperty", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyStruct/myStructProperty", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3751,7 +3751,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedFramework/MyTypeAlias", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyTypeAlias", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3777,7 +3777,7 @@ let expected = """
         
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Something", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Something", sourceLanguage: .swift)
             
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -3885,7 +3885,7 @@ let expected = """
             let identifiers = context.problems.map(\.diagnostic.identifier)
             XCTAssertFalse(identifiers.contains(where: { $0 == "org.swift.docc.ArticleUncurated" }))
             
-            let rootReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Module", sourceLanguage: .swift)
+            let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
             let docNode = try context.entity(with: rootReference)
             let article = try XCTUnwrap(docNode.semantic as? Article)
             XCTAssertNil(article.topics)
@@ -3922,7 +3922,7 @@ let expected = """
             ]).write(inside: tempURL)
             let (_, bundle, context) = try loadBundle(from: bundleURL)
             
-            let rootReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Module", sourceLanguage: .swift)
+            let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
             let docNode = try context.entity(with: rootReference)
             let article = try XCTUnwrap(docNode.semantic as? Article)
             XCTAssertNotNil(article.topics)
@@ -3965,7 +3965,7 @@ let expected = """
         ]).write(inside: tempURL)
         let (_, bundle, context) = try loadBundle(from: bundleURL)
         
-        let rootReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Module", sourceLanguage: .swift)
+        let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
         let docNode = try context.entity(with: rootReference)
         let article = try XCTUnwrap(docNode.semantic as? Article)
         
@@ -3993,12 +3993,12 @@ let expected = """
                 .replacingOccurrences(of: " - <doc:article>", with: " - <doc:resolvable-article>")
                 .write(to: myKitURL, atomically: true, encoding: .utf8)
         }
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
 
         // Try resolving the new resolvable node
         switch context.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:resolvable-article")!)), in: moduleReference) {
         case .success(let resolvedReference):
-            XCTAssertEqual(resolvedReference.absoluteString, "doc://\(bundle.identifier)/documentation/Test-Bundle/resolvable-article")
+            XCTAssertEqual(resolvedReference.absoluteString, "doc://\(bundle.id)/documentation/Test-Bundle/resolvable-article")
             XCTAssertNoThrow(try context.entity(with: resolvedReference))
         case .failure(_, let errorMessage):
             XCTFail("Did not resolve resolvable link. Error: \(errorMessage)")
@@ -4147,12 +4147,12 @@ let expected = """
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
             // Verify the context contains the conflicting topic names
             // Article
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
             // Tutorial
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
             
             let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
-            let expected = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
+            let expected = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
 
             // Resolve from various locations in the bundle
             for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialTableOfContentsContainer] {
@@ -4184,14 +4184,14 @@ let expected = """
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
             // Verify the context contains the conflicting topic names
             // Article
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
             // Tutorial
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
             // Symbol
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)])
             
             let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
-            let expected = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
+            let expected = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
             
             let symbolReference = try XCTUnwrap(context.documentationCache.reference(symbolID: "s:12Minimal_docs4TestV"))
             
@@ -4244,9 +4244,9 @@ let expected = """
             // Load the bundle
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
             
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)
-            let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
-            let articleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)
+            let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
+            let articleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
 
             // Verify we resolve/not resolve non-symbols when calling directly context.resolve(...)
             // with an explicit preference.
@@ -4272,7 +4272,7 @@ let expected = """
 
             // Verify the context contains the conflicting topic names
             // Tutorial
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
             // Symbol
             XCTAssertNotNil(context.documentationCache[symbolReference])
             
@@ -4315,8 +4315,8 @@ let expected = """
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
             
             // Verify the module and symbol node kinds.
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/Minimal_docs", sourceLanguage: .swift)
-            let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Minimal_docs", sourceLanguage: .swift)
+            let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
 
             XCTAssertEqual(context.topicGraph.nodeWithReference(symbolReference)?.kind, .structure)
             XCTAssertEqual(context.topicGraph.nodeWithReference(moduleReference)?.kind, .module)
@@ -4443,7 +4443,7 @@ let expected = """
         XCTAssertEqual(
             context.documentationExtensionURL(
                 for: ResolvedTopicReference(
-                    bundleIdentifier: "org.swift.docc.example",
+                    bundleID: "org.swift.docc.example",
                     path: "/documentation/MyKit/MyClass",
                     fragment: nil,
                     sourceLanguage: .swift
@@ -4461,7 +4461,7 @@ let expected = """
         XCTAssertNil(
             context.documentationExtensionURL(
                 for: ResolvedTopicReference(
-                    bundleIdentifier: "org.swift.docc.example",
+                    bundleID: "org.swift.docc.example",
                     path: "/tutorials/TestOverview",
                     fragment: nil,
                     sourceLanguage: .swift
@@ -4686,7 +4686,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase", sourceLanguage: .swift)
         
         XCTAssertEqual(
             context.topicGraph.reverseEdgesGraph.cycles(from: reference).map { $0.map(\.lastPathComponent) },
@@ -4771,7 +4771,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
 
         for kindID in overloadableKindIDs {
             var seenIndices = Set<Int>()
@@ -4859,7 +4859,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
 
         for kindID in overloadableKindIDs {
             switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName-\(kindID.identifier)"))), in: moduleReference, fromSymbolLink: true) {
@@ -4991,7 +4991,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
 
         let overloadGroupNode: DocumentationNode
         let overloadGroupSymbol: Symbol
@@ -5068,7 +5068,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
 
         let overloadGroupNode: DocumentationNode
         let overloadGroupSymbol: Symbol
@@ -5143,7 +5143,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
 
         let overloadGroupNode: DocumentationNode
         let overloadGroupSymbol: Symbol
@@ -5213,7 +5213,7 @@ let expected = """
             ])
         ])
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
 
         let overloadGroupNode: DocumentationNode
         let overloadGroupSymbol: Symbol
@@ -5285,7 +5285,7 @@ let expected = """
                 
                 return entity.externallyLinkableElementSummaries(context: context, renderNode: renderNode, includeTaskGroups: false)
             }
-            let linkResolutionInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.identifier)
+            let linkResolutionInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.id)
             
             return (linkResolutionInformation, linkSummaries)
         }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -31,7 +31,7 @@ class DocumentationCuratorTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
         var crawler = DocumentationCurator.init(in: context, bundle: bundle)
-        let mykit = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
+        let mykit = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
 
         var symbolsWithCustomCuration = [ResolvedTopicReference]()
         var curatedRelationships = [ParentChild]()
@@ -98,7 +98,7 @@ class DocumentationCuratorTests: XCTestCase {
         let extensionFile = tempCatalogURL.appendingPathComponent("documentation/myfunction.md")
         
         var crawler = DocumentationCurator(in: context, bundle: bundle)
-        let mykit = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
+        let mykit = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
         
         XCTAssertNoThrow(try crawler.crawlChildren(of: mykit.reference, prepareForCuration: { _ in }, relateNodes: { _, _ in }))
         
@@ -285,7 +285,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve top-level symbol in module parent
         do {
             let symbolLink = SymbolLink(destination: "MyClass")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
             let reference = crawler.referenceFromSymbolLink(link: symbolLink, resolved: parent)
             XCTAssertEqual(reference?.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
         }
@@ -293,7 +293,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve top-level symbol in self
         do {
             let symbolLink = SymbolLink(destination: "MyClass")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             let reference = crawler.referenceFromSymbolLink(link: symbolLink, resolved: parent)
             XCTAssertEqual(reference?.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
         }
@@ -301,7 +301,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve top-level symbol in a child
         do {
             let symbolLink = SymbolLink(destination: "MyClass")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let reference = crawler.referenceFromSymbolLink(link: symbolLink, resolved: parent)
             XCTAssertEqual(reference?.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass")
         }
@@ -309,7 +309,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve child in its parent
         do {
             let symbolLink = SymbolLink(destination: "myFunction()")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             let reference = crawler.referenceFromSymbolLink(link: symbolLink, resolved: parent)
             XCTAssertEqual(reference?.absoluteString, "doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()")
         }
@@ -317,7 +317,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Do not resolve when not found
         do {
             let symbolLink = SymbolLink(destination: "myFunction")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
             let reference = crawler.referenceFromSymbolLink(link: symbolLink, resolved: parent)
             XCTAssertEqual(reference?.absoluteString, nil)
         }
@@ -325,7 +325,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Fail to resolve across modules
         do {
             let symbolLink = SymbolLink(destination: "MyClass")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift)
             XCTAssertNil(crawler.referenceFromSymbolLink(link: symbolLink, resolved: parent))
         }
     }
@@ -338,7 +338,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve and curate an article in module root (absolute link)
         do {
             let link = Link(destination: "doc:article")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
             guard let reference = crawler.referenceFromLink(link: link, resolved: parent, source: sourceRoot) else {
                 XCTFail("Did not resolve reference from link")
                 return
@@ -352,7 +352,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve/curate an article in module root (relative link)
         do {
             let link = Link(destination: "doc:article")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
             guard let reference = crawler.referenceFromLink(link: link, resolved: parent, source: sourceRoot) else {
                 XCTFail("Did not resolve reference from link")
                 return
@@ -366,7 +366,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve/curate article in the module root from within a child symbol
         do {
             let link = Link(destination: "doc:article")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             guard let reference = crawler.referenceFromLink(link: link, resolved: parent, source: sourceRoot) else {
                 XCTFail("Did not resolve reference from link")
                 return
@@ -380,7 +380,7 @@ class DocumentationCuratorTests: XCTestCase {
         // Resolve/curate absolute link from a different module parent
         do {
             let link = Link(destination: "doc:documentation/Test-Bundle/article")
-            let parent = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
+            let parent = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
             XCTAssertNotNil(crawler.referenceFromLink(link: link, resolved: parent, source: sourceRoot))
         }
     }
@@ -427,7 +427,7 @@ class DocumentationCuratorTests: XCTestCase {
         }
         
         var crawler = DocumentationCurator.init(in: context, bundle: bundle)
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift)
         
         try crawler.crawlChildren(of: reference, prepareForCuration: {_ in }) { (_, _) in }
 
@@ -482,7 +482,7 @@ class DocumentationCuratorTests: XCTestCase {
     func testMixedManualAndAutomaticCuration() throws {
         let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/TopClass/NestedEnum/SecondLevelNesting", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/TopClass/NestedEnum/SecondLevelNesting", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         let symbol = try XCTUnwrap(entity.semantic as? Symbol)
         
@@ -497,7 +497,7 @@ class DocumentationCuratorTests: XCTestCase {
         
         // Verify that the ONLY curation for `TopClass/name` is the manual curation under `MyArticle`
         // and the automatic curation under `TopClass` is not present.
-        let nameReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/TopClass/name", sourceLanguage: .swift)
+        let nameReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/TopClass/name", sourceLanguage: .swift)
         XCTAssertEqual(context.finitePaths(to: nameReference).map({ $0.map(\.path) }), [
             ["/documentation/TestBed", "/documentation/TestBed/TopClass", "/documentation/TestBed/TopClass-API-Collection"],
             ["/documentation/TestBed", "/documentation/TestBed/TopClass", "/documentation/TestBed/TopClass/NestedEnum", "/documentation/TestBed/TopClass/NestedEnum/SecondLevelNesting", "/documentation/TestBed/MyArticle"],
@@ -505,7 +505,7 @@ class DocumentationCuratorTests: XCTestCase {
 
         // Verify that the BOTH manual curations for `TopClass/age` are preserved
         // even if one of the manual curations overlaps with the inheritance edge from the symbol graph.
-        let ageReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/TopClass/age", sourceLanguage: .swift)
+        let ageReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/TopClass/age", sourceLanguage: .swift)
         XCTAssertEqual(context.finitePaths(to: ageReference).map({ $0.map(\.path) }), [
             ["/documentation/TestBed", "/documentation/TestBed/TopClass"],
             ["/documentation/TestBed", "/documentation/TestBed/TopClass", "/documentation/TestBed/TopClass-API-Collection"],
@@ -518,7 +518,7 @@ class DocumentationCuratorTests: XCTestCase {
     func testMultipleManualCurationIsPreserved() throws {
         let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/TestBed/DoublyManuallyCuratedClass/type()", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/DoublyManuallyCuratedClass/type()", sourceLanguage: .swift)
         
         XCTAssertEqual(context.finitePaths(to: reference).map({ $0.map({ $0.path }) }), [
             [

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationWorkspaceTests.swift
@@ -151,7 +151,7 @@ class DocumentationWorkspaceTests: XCTestCase {
             return DocumentationBundle(
                 info: DocumentationBundle.Info(
                     displayName: "Test" + suffix,
-                    identifier: "com.example.test" + suffix
+                    id: DocumentationBundle.Identifier(rawValue: "com.example.test" + suffix)
                 ),
                 symbolGraphURLs: [testSymbolGraphFile],
                 markupURLs: [testMarkupFile],

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -715,7 +715,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             
             return entity.externallyLinkableElementSummaries(context: dependencyContext, renderNode: renderNode, includeTaskGroups: false)
         }
-        let linkResolutionInformation = try dependencyContext.linkResolver.localResolver.prepareForSerialization(bundleID: dependencyBundle.identifier)
+        let linkResolutionInformation = try dependencyContext.linkResolver.localResolver.prepareForSerialization(bundleID: dependencyBundle.id)
         
         XCTAssertEqual(linkResolutionInformation.pathHierarchy.nodes.count - linkResolutionInformation.nonSymbolPaths.count, 5 /* 4 symbols & 1 module */)
         XCTAssertEqual(linkSummaries.count, 5 /* 4 symbols & 1 module */)
@@ -798,7 +798,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         
         // Check the relationships of 'SomeClass'
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: mainBundle.identifier, path: "/documentation/Main/SomeClass", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: mainBundle.id, path: "/documentation/Main/SomeClass", sourceLanguage: .swift)
             let entity = try mainContext.entity(with: reference)
             let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity))
             
@@ -822,7 +822,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         
         // Check the declaration of 'someFunction'
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: mainBundle.identifier, path: "/documentation/Main/SomeClass/someFunction(parameter:)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: mainBundle.id, path: "/documentation/Main/SomeClass/someFunction(parameter:)", sourceLanguage: .swift)
             let entity = try mainContext.entity(with: reference)
             let renderNode = try XCTUnwrap(mainConverter.renderNode(for: entity))
             
@@ -989,13 +989,13 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         }
     }
     
-   private func makeLinkResolversForTestBundle(named testBundleName: String, configuration: DocumentationContext.Configuration = .init()) throws -> LinkResolvers {
+    private func makeLinkResolversForTestBundle(named testBundleName: String, configuration: DocumentationContext.Configuration = .init()) throws -> LinkResolvers {
         let bundleURL = try XCTUnwrap(Bundle.module.url(forResource: testBundleName, withExtension: "docc", subdirectory: "Test Bundles"))
         let (_, bundle, context) = try loadBundle(from: bundleURL, configuration: configuration)
         
         let localResolver = try XCTUnwrap(context.linkResolver.localResolver)
         
-        let resolverInfo = try localResolver.prepareForSerialization(bundleID: bundle.identifier)
+        let resolverInfo = try localResolver.prepareForSerialization(bundleID: bundle.id)
         let resolverData = try JSONEncoder().encode(resolverInfo)
         let roundtripResolverInfo = try JSONDecoder().decode(SerializableLinkResolutionInformation.self, from: resolverData)
         

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -16,7 +16,7 @@ import SwiftDocCTestUtilities
 
 class ExternalReferenceResolverTests: XCTestCase {
     class TestExternalReferenceResolver: ExternalDocumentationSource {
-        var bundleIdentifier = "com.external.testbundle"
+        var bundleID: DocumentationBundle.Identifier = "com.external.testbundle"
         var expectedReferencePath = "/externally/resolved/path"
         var expectedFragment: String? = nil
         var resolvedEntityTitle = "Externally Resolved Title"
@@ -30,11 +30,11 @@ class ExternalReferenceResolverTests: XCTestCase {
             if let path = reference.url?.path {
                 resolvedExternalPaths.append(path)
             }
-            return .success(ResolvedTopicReference(bundleIdentifier: bundleIdentifier, path: expectedReferencePath, fragment: expectedFragment, sourceLanguage: resolvedEntityLanguage))
+            return .success(ResolvedTopicReference(bundleID: bundleID, path: expectedReferencePath, fragment: expectedFragment, sourceLanguage: resolvedEntityLanguage))
         }
         
         func entity(with reference: ResolvedTopicReference) -> LinkResolver.ExternalEntity {
-            guard reference.bundleIdentifier == bundleIdentifier else {
+            guard reference.bundleID == bundleID else {
                 fatalError("It is a programming mistake to retrieve an entity for a reference that the external resolver didn't resolve.")
             }
             
@@ -69,14 +69,14 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.external.testbundle/article")!)
-        let parent = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyClass", sourceLanguage: .swift)
+        let parent = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyClass", sourceLanguage: .swift)
 
         guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
             XCTFail("Couldn't resolve \(unresolved)")
             return
         }
         
-        XCTAssertEqual("com.external.testbundle", resolved.bundleIdentifier)
+        XCTAssertEqual("com.external.testbundle", resolved.bundleID)
         XCTAssertEqual("/externally/resolved/path", resolved.path)
         
         let expectedURL = URL(string: "doc://com.external.testbundle/externally/resolved/path")
@@ -88,7 +88,7 @@ class ExternalReferenceResolverTests: XCTestCase {
     // manually curate it. (94406023)
     func testExternalReferenceInOtherLanguageIsIncludedInTopicGroup() throws {
         let externalResolver = TestExternalReferenceResolver()
-        externalResolver.bundleIdentifier = "com.test.external"
+        externalResolver.bundleID = "com.test.external"
         externalResolver.expectedReferencePath = "/path/to/external/api"
         externalResolver.resolvedEntityTitle = "Name of API"
         externalResolver.resolvedEntityKind = .tutorialTableOfContents
@@ -98,7 +98,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         
         let (_, bundle, context) = try testBundleAndContext(
             copying: "TestBundle",
-            externalResolvers: [externalResolver.bundleIdentifier: externalResolver]
+            externalResolvers: [externalResolver.bundleID: externalResolver]
         ) { url in
             let sideClassExtension = """
                 # ``SideKit/SideClass``
@@ -120,7 +120,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let sideClassReference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/SideKit/SideClass",
             sourceLanguage: .swift
         )
@@ -165,7 +165,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let bundleIdentifier = bundle.identifier
         
         let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://\(bundleIdentifier)/ArticleThatDoesNotExistInLocally")!)
-        let parent = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "", sourceLanguage: .swift)
+        let parent = ResolvedTopicReference(bundleIdentifier: bundle.id.rawValue, path: "", sourceLanguage: .swift)
         
         do {
             context.configuration.externalDocumentationConfiguration.sources = [:]
@@ -178,11 +178,11 @@ class ExternalReferenceResolverTests: XCTestCase {
         
         do {
             class TestFallbackResolver: ConvertServiceFallbackResolver {
-                init(bundleIdentifier: String) {
-                    resolver.bundleIdentifier = bundleIdentifier
+                init(bundleID: DocumentationBundle.Identifier) {
+                    resolver.bundleID = bundleID
                 }
-                var bundleIdentifier: String {
-                    resolver.bundleIdentifier
+                var bundleID: DocumentationBundle.Identifier {
+                    resolver.bundleID
                 }
                 private var resolver = TestExternalReferenceResolver()
                 func resolve(_ reference: SwiftDocC.TopicReference) -> TopicReferenceResolutionResult {
@@ -197,7 +197,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             }
             
             context.configuration.externalDocumentationConfiguration.sources = [:]
-            context.configuration.convertServiceConfiguration.fallbackResolver = TestFallbackResolver(bundleIdentifier: "org.swift.docc.example")
+            context.configuration.convertServiceConfiguration.fallbackResolver = TestFallbackResolver(bundleID: "org.swift.docc.example")
             
             guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
                 XCTFail("The reference was unexpectedly unresolved.")
@@ -221,9 +221,9 @@ class ExternalReferenceResolverTests: XCTestCase {
     
     func testLoadEntityForExternalReference() throws {
         let (_, context) = try testBundleAndContext(named: "TestBundle", externalResolvers: ["com.external.testbundle" : TestExternalReferenceResolver()])
-        let identifier = ResolvedTopicReference(bundleIdentifier: "com.external.testbundle", path: "/externally/resolved/path", sourceLanguage: .swift)
+        let identifier = ResolvedTopicReference(bundleID: "com.external.testbundle", path: "/externally/resolved/path", sourceLanguage: .swift)
         
-        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleIdentifier: "some.other.bundle", path: identifier.path, sourceLanguage: .swift)))
+        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: "some.other.bundle", path: identifier.path, sourceLanguage: .swift)))
         XCTAssertThrowsError(try context.entity(with: identifier))
     }
     
@@ -246,22 +246,22 @@ class ExternalReferenceResolverTests: XCTestCase {
             let (resolvedEntityKind, renderNodeKind) = fixture
             
             let externalResolver = TestExternalReferenceResolver()
-            externalResolver.bundleIdentifier = "com.test.external"
+            externalResolver.bundleID = "com.test.external"
             externalResolver.expectedReferencePath = "/path/to/external/symbol"
             externalResolver.resolvedEntityTitle = "ClassName"
             externalResolver.resolvedEntityKind = resolvedEntityKind
             
-            let (bundle, context) = try testBundleAndContext(named: "TestBundle", externalResolvers: [externalResolver.bundleIdentifier: externalResolver])
+            let (bundle, context) = try testBundleAndContext(named: "TestBundle", externalResolvers: [externalResolver.bundleID: externalResolver])
             
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
             
             guard let fileURL = context.documentURL(for: node.reference) else {
                 XCTFail("Unable to find the file for \(node.reference.path)")
                 return
             }
             
-            let expectedReference = "doc://\(externalResolver.bundleIdentifier)\(externalResolver.expectedReferencePath)"
+            let expectedReference = "doc://\(externalResolver.bundleID)\(externalResolver.expectedReferencePath)"
             XCTAssertTrue(
                 try String(contentsOf: fileURL).contains("<\(expectedReference)>"),
                 "The test content should include a link for the external reference resolver to resolve"
@@ -283,7 +283,7 @@ class ExternalReferenceResolverTests: XCTestCase {
     
     func testReferenceFromRenderedPageHasFragments() throws {
         let externalResolver = TestExternalReferenceResolver()
-        externalResolver.bundleIdentifier = "com.test.external"
+        externalResolver.bundleID = "com.test.external"
         externalResolver.expectedReferencePath = "/path/to/external/symbol"
         externalResolver.resolvedEntityTitle = "ClassName"
         externalResolver.resolvedEntityKind = .class
@@ -293,7 +293,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             .init(kind: .identifier, spelling: "ClassName", preciseIdentifier: nil),
         ])
         
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleIdentifier: externalResolver]) { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
             try """
             # ``SideKit/SideClass``
 
@@ -308,7 +308,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
         let renderNode = try converter.convert(node)
         
@@ -330,7 +330,7 @@ class ExternalReferenceResolverTests: XCTestCase {
     
     func testExternalReferenceWithDifferentResolvedPath() throws {
         let externalResolver = TestExternalReferenceResolver()
-        externalResolver.bundleIdentifier = "com.test.external"
+        externalResolver.bundleID = "com.test.external"
         // Return a different path for this resolved reference
         externalResolver.expectedReferencePath = "/path/to/externally-resolved-symbol"
         externalResolver.resolvedEntityTitle = "ClassName"
@@ -349,11 +349,11 @@ class ExternalReferenceResolverTests: XCTestCase {
         ])
         
         var configuration = DocumentationContext.Configuration()
-        configuration.externalDocumentationConfiguration.sources = [externalResolver.bundleIdentifier: externalResolver]
+        configuration.externalDocumentationConfiguration.sources = [externalResolver.bundleID: externalResolver]
         let (bundle, context) = try loadBundle(catalog: tempFolder, configuration: configuration)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/article", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/article", sourceLanguage: .swift))
         
         let renderNode = try converter.convert(node)
         
@@ -380,12 +380,12 @@ class ExternalReferenceResolverTests: XCTestCase {
     
     func testSampleCodeReferenceHasSampleCodeRole() throws {
         let externalResolver = TestExternalReferenceResolver()
-        externalResolver.bundleIdentifier = "com.test.external"
+        externalResolver.bundleID = "com.test.external"
         externalResolver.expectedReferencePath = "/path/to/external/sample"
         externalResolver.resolvedEntityTitle = "Name of Sample"
         externalResolver.resolvedEntityKind = .sampleCode
         
-        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleIdentifier: externalResolver]) { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
             try """
             # ``SideKit/SideClass``
 
@@ -400,7 +400,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
         let renderNode = try converter.convert(node)
         
@@ -419,7 +419,7 @@ class ExternalReferenceResolverTests: XCTestCase {
     
     func testExternalTopicWithTopicImage() throws {
         let externalResolver = TestMultiResultExternalReferenceResolver()
-        externalResolver.bundleIdentifier = "com.test.external"
+        externalResolver.bundleID = "com.test.external"
         
         externalResolver.entitiesToReturn["/path/to/external-page-with-topic-image-1"] = .success(.init(
             referencePath: "/path/to/external-page-with-topic-image-1",
@@ -473,7 +473,7 @@ class ExternalReferenceResolverTests: XCTestCase {
             ),
         ]
         
-        let (_, bundle, context) = try testBundleAndContext(copying: "SampleBundle", excludingPaths: ["MySample.md", "MyLocalSample.md"], externalResolvers: [externalResolver.bundleIdentifier: externalResolver]) { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "SampleBundle", excludingPaths: ["MySample.md", "MyLocalSample.md"], externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
             try """
             # SomeSample
 
@@ -499,7 +499,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SomeSample", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SomeSample", sourceLanguage: .swift))
         
         let renderNode = try converter.convert(node)
         
@@ -612,7 +612,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         // Get MyKit symbol
-        let entity = try context.entity(with: .init(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
+        let entity = try context.entity(with: .init(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         let taskGroupLinks = try XCTUnwrap((entity.semantic as? Symbol)?.topics?.taskGroups.first?.links.compactMap({ $0.destination }))
         
         // Verify the task group links have been resolved and are still present in the link list.
@@ -644,7 +644,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         })
 
         // Verify the external symbol is included in external cache
-        let reference = ResolvedTopicReference(bundleIdentifier: "com.external.testbundle", path: "/externally/resolved/path", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "com.external.testbundle", path: "/externally/resolved/path", sourceLanguage: .swift)
         XCTAssertNil(context.documentationCache[reference])
         XCTAssertNotNil(context.externalCache[reference])
         
@@ -690,7 +690,7 @@ class ExternalReferenceResolverTests: XCTestCase {
                     }
                 }
                 // Note that this resolved reference doesn't have the same path as the unresolved reference.
-                return .success(.init(bundleIdentifier: "com.external.testbundle", path: "/resolved", sourceLanguage: .swift))
+                return .success(.init(bundleID: "com.external.testbundle", path: "/resolved", sourceLanguage: .swift))
             }
             
             func entity(with reference: ResolvedTopicReference) -> LinkResolver.ExternalEntity {
@@ -757,18 +757,18 @@ class ExternalReferenceResolverTests: XCTestCase {
         // Expected successful externally resolved reference.
         XCTAssertEqual(
             context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/resolvable")!],
-            TopicReferenceResolutionResult.success(ResolvedTopicReference(bundleIdentifier: "com.external.testbundle", path: "/resolved", fragment: nil, sourceLanguage: .swift))
+            TopicReferenceResolutionResult.success(ResolvedTopicReference(bundleID: "com.external.testbundle", path: "/resolved", fragment: nil, sourceLanguage: .swift))
         )
         XCTAssertEqual(
             context.externallyResolvedLinks[ValidatedURL(parsingExact: "doc://com.external.testbundle/resolved")!],
-            TopicReferenceResolutionResult.success(ResolvedTopicReference(bundleIdentifier: "com.external.testbundle", path: "/resolved", fragment: nil, sourceLanguage: .swift))
+            TopicReferenceResolutionResult.success(ResolvedTopicReference(bundleID: "com.external.testbundle", path: "/resolved", fragment: nil, sourceLanguage: .swift))
         )
         
         XCTAssert(context.problems.contains(where: { $0.diagnostic.summary.contains("Unit test: External resolve error.")}),
                   "The external reference resolver error message is included in that problem's error summary.")
         
         // Get MyKit symbol
-        let entity = try context.entity(with: .init(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
+        let entity = try context.entity(with: .init(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let renderNode = try converter.convert(entity)
         
@@ -810,7 +810,7 @@ class ExternalReferenceResolverTests: XCTestCase {
                 .write(to: myClassMDURL, atomically: true, encoding: .utf8)
         })
 
-        let myClassRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+        let myClassRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         let documentationNode = try context.entity(with: myClassRef)
         
         // Verify the external link was resolved in markup.
@@ -831,7 +831,7 @@ class ExternalReferenceResolverTests: XCTestCase {
     
     func testExternalArticlesAreIncludedInAllVariantsTopicsSection() throws {
         let externalResolver = TestMultiResultExternalReferenceResolver()
-        externalResolver.bundleIdentifier = "com.test.external"
+        externalResolver.bundleID = "com.test.external"
         
         externalResolver.entitiesToReturn["/path/to/external/swiftArticle"] = .success(
             .init(
@@ -871,7 +871,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         
         let (_, bundle, context) = try testBundleAndContext(
             copying: "MixedLanguageFramework",
-            externalResolvers: [externalResolver.bundleIdentifier: externalResolver]
+            externalResolvers: [externalResolver.bundleID: externalResolver]
         ) { url in
             let mixedLanguageFrameworkExtension = """
                 # ``MixedLanguageFramework``
@@ -891,7 +891,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let mixedLanguageFrameworkReference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MixedLanguageFramework",
             sourceLanguage: .swift
         )
@@ -962,12 +962,12 @@ class ExternalReferenceResolverTests: XCTestCase {
         let resolver = TestExternalReferenceResolver()
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
-        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleIdentifier: resolver])
+        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleID: resolver])
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SymbolName", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SymbolName", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             let deprecatedSection = try XCTUnwrap((node.semantic as? Symbol)?.deprecatedSummary)
@@ -976,7 +976,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             let deprecatedSection = try XCTUnwrap((node.semantic as? Article)?.deprecationSummary)
@@ -1018,7 +1018,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let resolver = TestExternalReferenceResolver()
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
-        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleIdentifier: resolver])
+        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleID: resolver])
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
@@ -1037,7 +1037,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/First", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/First", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let rendered = try converter.convert(node)
             
@@ -1051,7 +1051,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         }
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Second", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Second", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let rendered = try converter.convert(node)
             
@@ -1085,7 +1085,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let resolver = TestExternalReferenceResolver()
         
         let tempURL = try createTempFolder(content: [exampleDocumentation])
-        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleIdentifier: resolver])
+        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleID: resolver])
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
@@ -1170,12 +1170,12 @@ class ExternalReferenceResolverTests: XCTestCase {
         let resolver = TestExternalReferenceResolver()
 
         let tempURL = try createTempFolder(content: [exampleDocumentation])
-        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleIdentifier: resolver])
+        let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: [resolver.bundleID: resolver])
 
         XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
 
         // Load the DocumentationNode for the artist dictionary keys symbol.
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SymbolName", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SymbolName", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
 
         // Get the semantic symbol and the variants of the dictionary keys section.
@@ -1203,7 +1203,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         let externalResolver = TestExternalReferenceResolver()
         let (_, bundle, context) = try testBundleAndContext(
             copying: bundleName,
-            externalResolvers: [externalResolver.bundleIdentifier: externalResolver]
+            externalResolvers: [externalResolver.bundleID: externalResolver]
         ) { url in
             try documentationExtension.utf8Content.write(
                 to: url.appendingPathComponent(documentationExtension.name),
@@ -1214,7 +1214,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))", file: file, line: line)
 
         // Load the DocumentationNode for the artist dictionary keys symbol.
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
         let node = try context.entity(with: reference)
 
         // Get the semantic symbol and the variants of the dictionary keys section.

--- a/Tests/SwiftDocCTests/Infrastructure/Input Discovery/DocumentationInputsProviderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Input Discovery/DocumentationInputsProviderTests.swift
@@ -150,7 +150,7 @@ class DocumentationInputsProviderTests: XCTestCase {
                 options: .init()
             )
             XCTAssertEqual(foundInputs.displayName, "two")
-            XCTAssertEqual(foundInputs.identifier, "two")
+            XCTAssertEqual(foundInputs.id, "two")
         }
         
         // Without arbitrary directories as a fallback
@@ -240,7 +240,7 @@ class DocumentationInputsProviderTests: XCTestCase {
             ])
         )
         XCTAssertEqual(foundInputs.displayName, "Something")
-        XCTAssertEqual(foundInputs.identifier, "Something")
+        XCTAssertEqual(foundInputs.id, "Something")
         XCTAssertEqual(foundInputs.symbolGraphURLs.map(\.path), [
             "/path/to/Something.symbols.json",
         ])

--- a/Tests/SwiftDocCTests/Infrastructure/NodeTagsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/NodeTagsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -27,7 +27,7 @@ class NodeTagsTests: XCTestCase {
         let (_, bundle, context) = try loadBundle(from: tempURL)
         
         // Verify that `Test` is marked as SPI.
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)
         let node = try XCTUnwrap(context.entity(with: reference))
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         XCTAssertTrue(symbol.isSPI)
@@ -39,7 +39,7 @@ class NodeTagsTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.tags, [.spi])
 
         // Verify that the link to the node contains the SPI tag.
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
         let moduleNode = try XCTUnwrap(context.entity(with: moduleReference))
         let moduleSymbol = try XCTUnwrap(moduleNode.semantic as? Symbol)
 

--- a/Tests/SwiftDocCTests/Infrastructure/NodeURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/NodeURLGeneratorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,27 +50,27 @@ class NodeURLGeneratorTests: XCTestCase {
         let baseURL = URL(string: "file:///path/to/bundle/_testbundle-ctlj/products/documentation.builtbundle/com.example.testbundle/data/")!
         let generator = NodeURLGenerator(baseURL: baseURL)
         
-        let basicIdentifier = ResolvedTopicReference(bundleIdentifier: "com.example.testbundle",
+        let basicIdentifier = ResolvedTopicReference(bundleID: "com.example.testbundle",
                                                      path: "/folder/class/symbol",
                                                      fragment: nil,
                                                      sourceLanguage: .swift)
         
         XCTAssertEqual(generator.urlForReference(basicIdentifier).absoluteString, "file:///path/to/bundle/_testbundle-ctlj/products/documentation.builtbundle/com.example.testbundle/data/folder/class/symbol")
         
-        let symbolIdentifier = ResolvedTopicReference(bundleIdentifier: "com.example.testbundle",
+        let symbolIdentifier = ResolvedTopicReference(bundleID: "com.example.testbundle",
                                                       path: "/folder/class/.==",
                                                       fragment: nil,
                                                       sourceLanguage: .swift)
         XCTAssertEqual(generator.urlForReference(symbolIdentifier).absoluteString, "file:///path/to/bundle/_testbundle-ctlj/products/documentation.builtbundle/com.example.testbundle/data/folder/class/'.==")
         
-        let privateIdentifier = ResolvedTopicReference(bundleIdentifier: "com.example.testbundle",
+        let privateIdentifier = ResolvedTopicReference(bundleID: "com.example.testbundle",
                                                        path: "/folder/class/_privateMethod",
                                                        fragment: nil,
                                                        sourceLanguage: .objectiveC)
         XCTAssertEqual(generator.urlForReference(privateIdentifier).absoluteString, "file:///path/to/bundle/_testbundle-ctlj/products/documentation.builtbundle/com.example.testbundle/data/folder/class/_privateMethod")
         XCTAssertEqual(generator.urlForReference(privateIdentifier, lowercased: true).absoluteString, "file:///path/to/bundle/_testbundle-ctlj/products/documentation.builtbundle/com.example.testbundle/data/folder/class/_privatemethod")
         
-        let classIdentifier = ResolvedTopicReference(bundleIdentifier: "com.example.testbundle",
+        let classIdentifier = ResolvedTopicReference(bundleID: "com.example.testbundle",
                                                      path: "/folder/_privateclass/_privatesubclass",
                                                      fragment: nil,
                                                      sourceLanguage: .objectiveC)

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1112,7 +1112,7 @@ class PathHierarchyTests: XCTestCase {
         let tree = try XCTUnwrap(linkResolver.pathHierarchy)
         
         // Test finding the parent via the `fromTopicReference` integration shim.
-        let parentID = linkResolver.resolvedReferenceMap[ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)]!
+        let parentID = linkResolver.resolvedReferenceMap[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)]!
         XCTAssertNotNil(parentID)
         XCTAssertEqual(try tree.findSymbol(path: "globalFunction(_:considering:)", parent: parentID).identifier.precise, "s:5MyKit14globalFunction_11consideringy10Foundation4DataV_SitF")
         XCTAssertEqual(try tree.findSymbol(path: "MyKit/globalFunction(_:considering:)", parent: parentID).identifier.precise, "s:5MyKit14globalFunction_11consideringy10Foundation4DataV_SitF")

--- a/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
@@ -18,19 +18,19 @@ class PresentationURLGeneratorTests: XCTestCase {
         let generator = PresentationURLGenerator(context: context, baseURL: URL(string: "https://host:1024/webPrefix")!)
         
         // Test resolved tutorial reference
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(reference).absoluteString, "https://host:1024/webPrefix/tutorials/test-bundle/testtutorial")
         
         // Test resolved symbol reference
-        let symbol = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+        let symbol = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(symbol).absoluteString, "https://host:1024/webPrefix/documentation/mykit/myclass")
         
         // Test root
-        let root = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/", sourceLanguage: .swift)
+        let root = ResolvedTopicReference(bundleID: bundle.id, path: "/", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(root).absoluteString, "https://host:1024/webPrefix/documentation")
         
         // Fragment
-        let fragment = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: "test URL! FRAGMENT", sourceLanguage: .swift)
+        let fragment = ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: "test URL! FRAGMENT", sourceLanguage: .swift)
         XCTAssertEqual(generator.presentationURLForReference(fragment).absoluteString, "https://host:1024/webPrefix/path#test-URL-FRAGMENT")
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -100,7 +100,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -126,7 +126,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -152,7 +152,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -178,7 +178,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -203,7 +203,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -229,7 +229,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/myFunction()", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -377,7 +377,7 @@ class ReferenceResolverTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -409,7 +409,7 @@ class ReferenceResolverTests: XCTestCase {
     func testCuratedExtensionRemovesEmptyPage() throws {
         let (bundle, context) = try testBundleAndContext(named: "ModuleWithSingleExtension")
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
@@ -421,7 +421,7 @@ class ReferenceResolverTests: XCTestCase {
 
         // Make sure that the symbol added in the extension is still present in the topic graph,
         // even though its synthetic "extended symbol" parents are not
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift/Array/asdf", sourceLanguage: .swift)))
+        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift/Array/asdf", sourceLanguage: .swift)))
     }
 
     func testCuratedExtensionWithDanglingReference() throws {
@@ -445,15 +445,15 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(replacement.replacement, "`Swift/Array`")
 
         // Also make sure that the extension pages are still gone
-        let extendedModule = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)
+        let extendedModule = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)
         XCTAssertFalse(context.knownPages.contains(where: { $0 == extendedModule }))
 
-        let extendedStructure = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
+        let extendedStructure = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
         XCTAssertFalse(context.knownPages.contains(where: { $0 == extendedStructure }))
 
         // Load the RenderNode for the root article and make sure that the `Swift/Array` symbol link
         // is not rendered as a link
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
@@ -485,10 +485,10 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(replacement.replacement, "`Swift/Array`")
 
         // Also make sure that the extension pages are still gone
-        let extendedModule = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)
+        let extendedModule = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)
         XCTAssertFalse(context.knownPages.contains(where: { $0 == extendedModule }))
 
-        let extendedStructure = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
+        let extendedStructure = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
         XCTAssertFalse(context.knownPages.contains(where: { $0 == extendedStructure }))
     }
 
@@ -514,17 +514,17 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertFalse(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.removedExtensionLinkDestination" || $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
 
         // Because the `Swift/Array` extension has an extension article, the pages should not be marked as virtual
-        let extendedModule = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)
+        let extendedModule = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift", sourceLanguage: .swift)
         XCTAssert(context.knownPages.contains(where: { $0 == extendedModule }))
 
-        let extendedStructure = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
+        let extendedStructure = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift/Array", sourceLanguage: .swift)
         XCTAssert(context.knownPages.contains(where: { $0 == extendedStructure }))
     }
 
     func testCuratedExtensionWithAdditionalConformance() throws {
         let (bundle, context) = try testBundleAndContext(named: "ModuleWithConformanceAndExtension")
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithConformanceAndExtension/MyProtocol", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithConformanceAndExtension/MyProtocol", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
@@ -540,7 +540,7 @@ class ReferenceResolverTests: XCTestCase {
     func testExtensionWithEmptyDeclarationFragments() throws {
         let (bundle, context) = try testBundleAndContext(named: "ModuleWithEmptyDeclarationFragments")
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleWithEmptyDeclarationFragments", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithEmptyDeclarationFragments", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
 
@@ -738,8 +738,8 @@ class ReferenceResolverTests: XCTestCase {
     }
     
     func testEmitsDiagnosticsForEachDocumentationChunk() throws {
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: "com.example.test", path: "/documentation/ModuleName", sourceLanguage: .swift)
-        let reference = ResolvedTopicReference(bundleIdentifier: "com.example.test", path: "/documentation/ModuleName/Something", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: "com.example.test", path: "/documentation/ModuleName", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "com.example.test", path: "/documentation/ModuleName/Something", sourceLanguage: .swift)
         
         let inSourceComment = """
         Some description of this class

--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@ import XCTest
 class ResolvedTopicReferenceTests: XCTestCase {
     func testReferenceURL() {
         let firstTopicReference = ResolvedTopicReference(
-            bundleIdentifier: "bundleID",
+            bundleID: "bundleID",
             path: "/path/sub-path",
             fragment: "fragment",
             sourceLanguage: .swift
@@ -24,7 +24,7 @@ class ResolvedTopicReferenceTests: XCTestCase {
         XCTAssertEqual(firstTopicReference.absoluteString, "doc://bundleID/path/sub-path#fragment")
         
         let secondTopicReference = ResolvedTopicReference(
-            bundleIdentifier: "new-bundleID",
+            bundleID: "new-bundleID",
             path: "/new-path/sub-path",
             fragment: firstTopicReference.fragment,
             sourceLanguage: firstTopicReference.sourceLanguage
@@ -41,7 +41,7 @@ class ResolvedTopicReferenceTests: XCTestCase {
     func testAppendingReferenceWithEmptyPath() {
         // An empty path
         do {
-            let resolvedOriginal = ResolvedTopicReference(bundleIdentifier: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
+            let resolvedOriginal = ResolvedTopicReference(bundleID: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
             
             let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://host-name")!)
             XCTAssert(unresolved.path.isEmpty)
@@ -52,7 +52,7 @@ class ResolvedTopicReferenceTests: XCTestCase {
         
         // A path with no url path allowed characters
         do {
-            let resolvedOriginal = ResolvedTopicReference(bundleIdentifier: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
+            let resolvedOriginal = ResolvedTopicReference(bundleID: "bundleID", path: "/path/sub-path", fragment: "fragment", sourceLanguage: .swift)
             
             var components = URLComponents()
             components.scheme = "doc"
@@ -69,7 +69,7 @@ class ResolvedTopicReferenceTests: XCTestCase {
     
     func testStorageIsConcurrentlyAccessible() throws {
         let topicReference = ResolvedTopicReference(
-            bundleIdentifier: "com.apple.example",
+            bundleID: "com.apple.example",
             path: "/documentation/path/sub-path",
             fragment: nil,
             sourceLanguage: .swift

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolDisambiguationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolDisambiguationTests.swift
@@ -324,7 +324,7 @@ class SymbolDisambiguationTests: XCTestCase {
         let bundle = DocumentationBundle(
             info: DocumentationBundle.Info(
                 displayName: "SymbolDisambiguationTests",
-                identifier: "com.test.SymbolDisambiguationTests"),
+                id: "com.test.SymbolDisambiguationTests"),
             symbolGraphURLs: [swiftSymbolGraphURL, objcSymbolGraphURL],
             markupURLs: [],
             miscResourceURLs: []

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphLoaderTests.swift
@@ -1791,7 +1791,7 @@ class SymbolGraphLoaderTests: XCTestCase {
         let bundle = DocumentationBundle(
             info: DocumentationBundle.Info(
                 displayName: "Test",
-                identifier: "com.example.test"
+                id: "com.example.test"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: symbolGraphURLs,

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
@@ -24,10 +24,10 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         let sourceIdentifier = SymbolGraph.Symbol.Identifier(precise: "A", interfaceLanguage: SourceLanguage.swift.id)
         let targetIdentifier = SymbolGraph.Symbol.Identifier(precise: "B", interfaceLanguage: SourceLanguage.swift.id)
         
-        let sourceRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/A", sourceLanguage: .swift)
-        let targetRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/B", sourceLanguage: .swift)
+        let sourceRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/A", sourceLanguage: .swift)
+        let targetRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/B", sourceLanguage: .swift)
         
-        let moduleRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let moduleRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         
         let sourceSymbol = SymbolGraph.Symbol(identifier: sourceIdentifier, names: SymbolGraph.Symbol.Names(title: "A", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "A"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: sourceType, mixins: [:])
         let targetSymbol = SymbolGraph.Symbol(identifier: targetIdentifier, names: SymbolGraph.Symbol.Names(title: "B", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "B"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: targetType, mixins: [:])
@@ -130,8 +130,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         let sourceIdentifier = SymbolGraph.Symbol.Identifier(precise: "A", interfaceLanguage: SourceLanguage.swift.id)
         let targetIdentifier = SymbolGraph.Symbol.Identifier(precise: "B", interfaceLanguage: SourceLanguage.swift.id)
         
-        let sourceRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/A", sourceLanguage: .swift)
-        let moduleRef = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let sourceRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/A", sourceLanguage: .swift)
+        let moduleRef = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
         
         let sourceSymbol = SymbolGraph.Symbol(identifier: sourceIdentifier, names: SymbolGraph.Symbol.Names(title: "A", navigator: nil, subHeading: nil, prose: nil), pathComponents: ["MyKit", "A"], docComment: nil, accessLevel: .init(rawValue: "public"), kind: SymbolGraph.Symbol.Kind(parsedIdentifier: .class, displayName: "Class"), mixins: [:])
         

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -17,7 +17,7 @@ import Markdown
 // instead to verify a mix of successes and failures in the same test.
 
 class TestMultiResultExternalReferenceResolver: ExternalDocumentationSource {
-    var bundleIdentifier = "com.external.testbundle"
+    var bundleID: DocumentationBundle.Identifier = "com.external.testbundle"
     
     // The minimal information that the test resolver needs to create a resolved reference and documentation node
     struct EntityInfo {
@@ -52,13 +52,13 @@ class TestMultiResultExternalReferenceResolver: ExternalDocumentationSource {
             
             let entity = entityInfo(path: path)
             return .success(
-                ResolvedTopicReference(bundleIdentifier: bundleIdentifier,path: entity.referencePath,fragment: entity.fragment,sourceLanguage: entity.language)
+                ResolvedTopicReference(bundleID: bundleID, path: entity.referencePath,fragment: entity.fragment,sourceLanguage: entity.language)
             )
         }
     }
     
     func entity(with reference: ResolvedTopicReference) -> LinkResolver.ExternalEntity {
-        guard reference.bundleIdentifier == bundleIdentifier else {
+        guard reference.bundleID == bundleID else {
             fatalError("It is a programming mistake to retrieve an entity for a reference that the external resolver didn't resolve.")
         }
         return makeNode(for: entityInfo(path: reference.path), reference: reference)

--- a/Tests/SwiftDocCTests/Infrastructure/TopicGraphTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TopicGraphTests.swift
@@ -16,7 +16,7 @@ class TopicGraphTests: XCTestCase {
         /// Returns a ``ResolvedTopicReference`` with the given title, with a phony source language, kind, and source. These are not for testing specific relationships, only abstract graph connectivity.
         static func testNodeWithTitle(_ title: String) -> TopicGraph.Node {
             let urlSafeTitle = title.replacingOccurrences(of: " ", with: "_")
-            let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(urlSafeTitle)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(urlSafeTitle)", sourceLanguage: .swift)
             return TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(urlSafeTitle)")), title: title)
         }
         

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -98,7 +98,7 @@ class ExternalLinkableTests: XCTestCase {
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestBundle/Tutorial", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestBundle/Tutorial", sourceLanguage: .swift))
         let renderNode = try converter.convert(node)
         
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)
@@ -154,7 +154,7 @@ class ExternalLinkableTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -198,7 +198,7 @@ class ExternalLinkableTests: XCTestCase {
         }
         
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -239,7 +239,7 @@ class ExternalLinkableTests: XCTestCase {
         }
         
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -274,7 +274,7 @@ class ExternalLinkableTests: XCTestCase {
         }
         
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -331,7 +331,7 @@ class ExternalLinkableTests: XCTestCase {
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             var summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -415,16 +415,16 @@ class ExternalLinkableTests: XCTestCase {
             summary.references = summary.references?.compactMap { (original: RenderReference) -> RenderReference? in
                 guard var imageRef = original as? ImageReference else { return nil }
                 imageRef.asset.variants = imageRef.asset.variants.mapValues { variant in
-                    return imageRef.destinationURL(for: variant.lastPathComponent, prefixComponent: bundle.identifier)
+                    return imageRef.destinationURL(for: variant.lastPathComponent, prefixComponent: bundle.id.rawValue)
                 }
                 imageRef.asset.metadata = .init(uniqueKeysWithValues: imageRef.asset.metadata.map { key, value in
-                    return (imageRef.destinationURL(for: key.lastPathComponent, prefixComponent: bundle.identifier), value)
+                    return (imageRef.destinationURL(for: key.lastPathComponent, prefixComponent: bundle.id.rawValue), value)
                 })
                 return imageRef as RenderReference
             }
             
             
-            let encoded = try RenderJSONEncoder.makeEncoder(assetPrefixComponent: bundle.identifier).encode(summary)
+            let encoded = try RenderJSONEncoder.makeEncoder(assetPrefixComponent: bundle.id.rawValue).encode(summary)
             let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: encoded)
             XCTAssertEqual(decoded, summary)
         }
@@ -436,7 +436,7 @@ class ExternalLinkableTests: XCTestCase {
         
         // Check a symbol that's represented as a class in both Swift and Objective-C
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -495,7 +495,7 @@ class ExternalLinkableTests: XCTestCase {
         
         // Check the Swift version of a symbol that's represented differently in different languages
         do {
-            let symbolReference = ResolvedTopicReference(bundleIdentifier: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(bundleID: "org.swift.MixedLanguageFramework", path: "/documentation/MixedLanguageFramework/Bar/myStringFunction(_:)", sourceLanguage: .swift)
             let node = try context.entity(with: symbolReference)
             let renderNode = try converter.convert(node)
             let summary = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)[0]
@@ -627,7 +627,7 @@ class ExternalLinkableTests: XCTestCase {
         
         let decoded = try JSONDecoder().decode(LinkDestinationSummary.self, from: legacyData)
         
-        XCTAssertEqual(decoded.referenceURL, ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/ClassName", sourceLanguage: .swift).url)
+        XCTAssertEqual(decoded.referenceURL, ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/ClassName", sourceLanguage: .swift).url)
         XCTAssertEqual(decoded.platforms?.count, 1)
         XCTAssertEqual(decoded.platforms?.first?.name, "PlatformName")
         XCTAssertEqual(decoded.platforms?.first?.introduced, "1.0")
@@ -727,7 +727,7 @@ class ExternalLinkableTests: XCTestCase {
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyModule/MyClass/myFunc()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyModule/MyClass/myFunc()", sourceLanguage: .swift))
         let renderNode = try converter.convert(node)
 
         let summaries = node.externallyLinkableElementSummaries(context: context, renderNode: renderNode)

--- a/Tests/SwiftDocCTests/Model/DocumentationNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationNodeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -31,7 +31,7 @@ class DocumentationNodeTests: XCTestCase {
         
         let article = Article(markup: Document(parsing: articleSource, options: []), metadata: nil, redirects: nil, options: [:])
         let node = try DocumentationNode(
-            reference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc", path: "/blah", sourceLanguage: .swift),
+            reference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguage: .swift),
             article: article
         )
         XCTAssertEqual(node.anchorSections.count, 5)

--- a/Tests/SwiftDocCTests/Model/IdentifierTests.swift
+++ b/Tests/SwiftDocCTests/Model/IdentifierTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -65,7 +65,7 @@ class IdentifierTests: XCTestCase {
     }
     
     func testReusingReferences() {
-        let bundleID = #function
+        let bundleID: DocumentationBundle.Identifier = #function
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), "Cache for this bundle shouldn't exist because caching is not enabled by default")
         
         // Add one reference
@@ -73,15 +73,15 @@ class IdentifierTests: XCTestCase {
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), 0, "Should have an empty cache after enabling reference caching for this bundle")
         
         // Add the same reference repeatedly
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/path/to/page", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/path/to/page", sourceLanguage: .swift)
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), 1, "Should have an cached one reference because a reference with this bundle identifier was created")
         
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/path/to/page", sourceLanguage: .swift)
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/path/to/page", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/path/to/page", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/path/to/page", sourceLanguage: .swift)
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), 1, "Should still only have one cached reference because the same reference was created repeatedly")
         
         // Add another reference
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/path/to/other-page", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/path/to/other-page", sourceLanguage: .swift)
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), 2, "Should have cached another reference because two different references with this bundle identifier has been created")
         
         // Purge and repeat
@@ -91,29 +91,29 @@ class IdentifierTests: XCTestCase {
         ResolvedTopicReference.enableReferenceCaching(for: bundleID)
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), 0, "Should have an empty cache after enabling reference caching for this bundle")
         
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/path/to/page", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/path/to/page", sourceLanguage: .swift)
         XCTAssertEqual(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), 1, "Should have an cached one reference because a reference with this bundle identifier was created")
     }
     
     func testReferencesAreNotCachedByDefault() {
-        let bundleID = #function
+        let bundleID: DocumentationBundle.Identifier = #function
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), "References for this bundle shouldn't exist because caching is not enabled by default")
         
-        _ = ResolvedTopicReference(bundleIdentifier: bundleID, path: "/path/to/page", sourceLanguage: .swift)
+        _ = ResolvedTopicReference(bundleID: bundleID, path: "/path/to/page", sourceLanguage: .swift)
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID), "After creating a reference in this bundle, references still shouldn't exist because caching is not enabled by default")
     }
     
     func testReferenceInitialPathComponents() {
-        let ref1 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/", sourceLanguage: .swift)
+        let ref1 = ResolvedTopicReference(bundleID: "bundle", path: "/", sourceLanguage: .swift)
         XCTAssertEqual(ref1.pathComponents, ["/"])
-        let ref2 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/MyClass", sourceLanguage: .swift)
+        let ref2 = ResolvedTopicReference(bundleID: "bundle", path: "/MyClass", sourceLanguage: .swift)
         XCTAssertEqual(ref2.pathComponents, ["/", "MyClass"])
-        let ref3 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/MyClass/myFunction", sourceLanguage: .swift)
+        let ref3 = ResolvedTopicReference(bundleID: "bundle", path: "/MyClass/myFunction", sourceLanguage: .swift)
         XCTAssertEqual(ref3.pathComponents, ["/", "MyClass", "myFunction"])
     }
     
     func testReferenceUpdatedPathComponents() {
-        var ref1 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/", sourceLanguage: .swift)
+        var ref1 = ResolvedTopicReference(bundleID: "bundle", path: "/", sourceLanguage: .swift)
         XCTAssertEqual(ref1.pathComponents, ["/"])
         ref1 = ref1.appendingPath("MyClass")
         XCTAssertEqual(ref1.pathComponents, ["/", "MyClass"])
@@ -124,16 +124,16 @@ class IdentifierTests: XCTestCase {
     }
 
     func testReferenceInitialAbsoluteString() {
-        let ref1 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/", sourceLanguage: .swift)
+        let ref1 = ResolvedTopicReference(bundleID: "bundle", path: "/", sourceLanguage: .swift)
         XCTAssertEqual(ref1.absoluteString, "doc://bundle/")
-        let ref2 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/MyClass", sourceLanguage: .swift)
+        let ref2 = ResolvedTopicReference(bundleID: "bundle", path: "/MyClass", sourceLanguage: .swift)
         XCTAssertEqual(ref2.absoluteString, "doc://bundle/MyClass")
-        let ref3 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/MyClass/myFunction", sourceLanguage: .swift)
+        let ref3 = ResolvedTopicReference(bundleID: "bundle", path: "/MyClass/myFunction", sourceLanguage: .swift)
         XCTAssertEqual(ref3.absoluteString, "doc://bundle/MyClass/myFunction")
     }
     
     func testReferenceUpdatedAbsoluteString() {
-        var ref1 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/", sourceLanguage: .swift)
+        var ref1 = ResolvedTopicReference(bundleID: "bundle", path: "/", sourceLanguage: .swift)
         XCTAssertEqual(ref1.absoluteString, "doc://bundle/")
         ref1 = ref1.appendingPath("MyClass")
         XCTAssertEqual(ref1.absoluteString, "doc://bundle/MyClass")
@@ -144,7 +144,7 @@ class IdentifierTests: XCTestCase {
     }
     
     func testResolvedTopicReferenceDoesNotCopyStorageIfNotModified() {
-         let reference1 = ResolvedTopicReference(bundleIdentifier: "bundle", path: "/", sourceLanguage: .swift)
+        let reference1 = ResolvedTopicReference(bundleID: "bundle", path: "/", sourceLanguage: .swift)
          let reference2 = reference1
 
          XCTAssertEqual(
@@ -155,7 +155,7 @@ class IdentifierTests: XCTestCase {
     
     func testWithSourceLanguages() {
         let swiftReference = ResolvedTopicReference(
-            bundleIdentifier: "bundle",
+            bundleID: "bundle",
             path: "/",
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Model/LineHighlighterTests.swift
+++ b/Tests/SwiftDocCTests/Model/LineHighlighterTests.swift
@@ -14,7 +14,7 @@ import Markdown
 import SwiftDocCTestUtilities
 
 class LineHighlighterTests: XCTestCase {
-    static let bundleIdentifier = "org.swift.docc.LineHighlighterTests"
+    static let bundleID: DocumentationBundle.Identifier = "org.swift.docc.LineHighlighterTests"
     static let defaultOverview = TextFile(name: "TechnologyX.tutorial", utf8Content: """
         @Technology(name: "TechnologyX") {
            @Intro(title: "Technology X") {
@@ -42,7 +42,7 @@ class LineHighlighterTests: XCTestCase {
         codeFiles: [TextFile]
     ) -> Folder {
         Folder(name: "unit-test.docc", content: [
-            InfoPlist(displayName: "Line Highlighter Tests", identifier: bundleIdentifier),
+            InfoPlist(displayName: "Line Highlighter Tests", identifier: bundleID.rawValue),
             Folder(name: "Resources", content: [overview, tutorial] + codeFiles),
         ])
     }
@@ -51,7 +51,7 @@ class LineHighlighterTests: XCTestCase {
         let catalog = Self.makeCatalog(tutorial: tutorialFile, codeFiles: codeFiles)
         let (bundle, context) = try loadBundle(catalog: catalog)
         
-        let tutorialReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Line-Highlighter-Tests/Tutorial", fragment: nil, sourceLanguage: .swift)
+        let tutorialReference = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Line-Highlighter-Tests/Tutorial", fragment: nil, sourceLanguage: .swift)
         let tutorial = try context.entity(with: tutorialReference).semantic as! Tutorial
         let section = tutorial.sections.first!
         return LineHighlighter(context: context, tutorialSection: section, tutorialReference: tutorialReference).highlights
@@ -95,7 +95,7 @@ class LineHighlighterTests: XCTestCase {
         let results = try highlights(tutorialFile: tutorialFile, codeFiles: [code1])
         XCTAssertEqual(1, results.count)
         results.first.map { result in
-            XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code1.name), result.file)
+            XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code1.name), result.file)
             XCTAssertTrue(result.highlights.isEmpty)
         }
     }
@@ -124,7 +124,7 @@ class LineHighlighterTests: XCTestCase {
         let results = try highlights(tutorialFile: tutorialFile, codeFiles: [code0, code1])
         XCTAssertEqual(1, results.count)
         results.first.map { result in
-            XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code1.name), result.file)
+            XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code1.name), result.file)
             XCTAssertEqual(1, result.highlights.count)
             result.highlights.first.map { highlight in
                 XCTAssertEqual(2, highlight.line)
@@ -163,10 +163,10 @@ class LineHighlighterTests: XCTestCase {
         let results = try highlights(tutorialFile: tutorialFile, codeFiles: [code1, code2])
         XCTAssertEqual(2, results.count)
         
-        XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code1.name), results[0].file)
+        XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code1.name), results[0].file)
         XCTAssertTrue(results[0].highlights.isEmpty)
         
-        XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code2.name), results[1].file)
+        XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code2.name), results[1].file)
         XCTAssertTrue(results[1].highlights.isEmpty)
     }
     
@@ -193,7 +193,7 @@ class LineHighlighterTests: XCTestCase {
         let results = try highlights(tutorialFile: tutorialFile, codeFiles: [code0, code1])
         XCTAssertEqual(1, results.count)
         results.first.map { result in
-            XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code1.name), result.file)
+            XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code1.name), result.file)
             XCTAssertTrue(result.highlights.isEmpty)
         }
     }
@@ -226,10 +226,10 @@ class LineHighlighterTests: XCTestCase {
         
         XCTAssertEqual(2, results.count)
         
-        XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code1.name), results[0].file)
+        XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code1.name), results[0].file)
         XCTAssertTrue(results[0].highlights.isEmpty)
         
-        XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code2.name), results[1].file)
+        XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code2.name), results[1].file)
         XCTAssertTrue(results[1].highlights.isEmpty)
     }
     
@@ -265,10 +265,10 @@ class LineHighlighterTests: XCTestCase {
         
         XCTAssertEqual(2, results.count)
         
-        XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code0.name), results[0].file)
+        XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code0.name), results[0].file)
         XCTAssertTrue(results[0].highlights.isEmpty)
         
-        XCTAssertEqual(ResourceReference(bundleIdentifier: LineHighlighterTests.bundleIdentifier, path: code2.name), results[1].file)
+        XCTAssertEqual(ResourceReference(bundleID: LineHighlighterTests.bundleID, path: code2.name), results[1].file)
         XCTAssertEqual(1, results[1].highlights.count)
         results[1].highlights.first.map { highlight in
             XCTAssertEqual(2, highlight.line)

--- a/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
@@ -26,7 +26,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         // /// - Returns: `YES` if doing something was successful, or `NO` if an error occurred.
         // - (void)doSomethingWith:(NSInteger)someValue error:(NSError **)error;
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInObjectiveC/doSomething(with:)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ErrorParameters/MyClassInObjectiveC/doSomething(with:)", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             
@@ -47,7 +47,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         // /// - Returns: Some string. If an error occurs, this method returns `nil` and assigns an appropriate error object to the `error` parameter.
         // - (nullable NSString *)returnSomethingAndReturnError:(NSError **)error;
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInObjectiveC/returnSomething()", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ErrorParameters/MyClassInObjectiveC/returnSomething()", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             
@@ -68,7 +68,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         // /// - Throws: Some error if something does wrong
         // @objc public func doSomething(with someValue: Int) throws { }
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInSwift/doSomething(with:)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ErrorParameters/MyClassInSwift/doSomething(with:)", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             
@@ -93,7 +93,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         // /// - Throws: Some error if something does wrong
         // @objc public func returnSomething() throws -> String { "" }
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ErrorParameters/MyClassInSwift/returnSomething()", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ErrorParameters/MyClassInSwift/returnSomething()", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             
@@ -435,7 +435,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -492,7 +492,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -534,7 +534,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         

--- a/Tests/SwiftDocCTests/Model/PropertyListPossibleValuesSectionTests.swift
+++ b/Tests/SwiftDocCTests/Model/PropertyListPossibleValuesSectionTests.swift
@@ -83,7 +83,7 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
     
     func testAbsenceOfPossibleValues() throws {
         let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/DictionaryData/Artist", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Artist", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         // Check that the `Possible Values` section is not rendered if the symbol don't define any possible value.
@@ -92,7 +92,7 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
     
     func testUndocumentedPossibleValues() throws {
         let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let possibleValuesSection = try XCTUnwrap(try converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
         let possibleValues: [PossibleValuesRenderSection.NamedValue] = possibleValuesSection.values
@@ -116,7 +116,7 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
             """.write(to: url.appendingPathComponent("Month.md"), atomically: true, encoding: .utf8)
         }
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         let possibleValues = try XCTUnwrap(symbol.possibleValuesSectionVariants.firstValue?.possibleValues)
         
@@ -136,7 +136,7 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
             """.write(to: url.appendingPathComponent("Month.md"), atomically: true, encoding: .utf8)
         }
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         let possibleValues = try XCTUnwrap(symbol.possibleValuesSectionVariants.firstValue?.possibleValues)
         

--- a/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -68,7 +68,7 @@ class RenderContentMetadataTests: XCTestCase {
     
     func testRenderingTables() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
         | Column 1  | Column 2 |
@@ -109,7 +109,7 @@ class RenderContentMetadataTests: XCTestCase {
 
     func testRenderingTableSpans() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
         | one | two | three |
@@ -162,7 +162,7 @@ class RenderContentMetadataTests: XCTestCase {
 
     func testRenderingTableColumnAlignments() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
         | one | two | three | four |
@@ -204,7 +204,7 @@ class RenderContentMetadataTests: XCTestCase {
     /// Verifies that a table with `nil` alignments and a table with all-unset alignments still compare as equal.
     func testRenderedTableEquality() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
         | Column 1  | Column 2 |
@@ -230,7 +230,7 @@ class RenderContentMetadataTests: XCTestCase {
     /// Verifies that two tables with otherwise-identical contents but different column alignments compare as unequal.
     func testRenderedTableInequality() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let decodedTableWithUnsetColumns: RenderBlockContent.Table
         do {
@@ -277,7 +277,7 @@ class RenderContentMetadataTests: XCTestCase {
     
     func testStrikethrough() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
         ~~Striken~~ text.
@@ -300,7 +300,7 @@ class RenderContentMetadataTests: XCTestCase {
     
     func testHeadingAnchorShouldBeEncoded() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
         ## テスト

--- a/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
@@ -14,7 +14,7 @@ import XCTest
 class RenderHierarchyTranslatorTests: XCTestCase {
     func test() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let technologyReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift)
+        let technologyReference = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
         
         var translator = RenderHierarchyTranslator(context: context, bundle: bundle)
         let renderHierarchyVariants = translator.visitTutorialTableOfContentsNode(technologyReference)?.hierarchyVariants
@@ -102,7 +102,7 @@ class RenderHierarchyTranslatorTests: XCTestCase {
         }
         
         // Get a translated render node
-        let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+        let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         let node = try context.entity(with: identifier)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: identifier)
         let renderNode = translator.visit(node.semantic) as! RenderNode

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class RenderNodeDiffingBundleTests: XCTestCase {
     let testBundleName = "TestBundle"
-    let testBundleIdentifier = "org.swift.docc.example"
+    let testBundleID: DocumentationBundle.Identifier = "org.swift.docc.example"
     
     func testDiffSymbolFromBundleWithDiscussionSectionRemoved() throws {
         let pathToSymbol = "/documentation/MyKit"
@@ -29,7 +29,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
 
@@ -57,7 +57,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToArticle,
                                                            modification: modification)
 
@@ -90,7 +90,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToArticle,
                                                            modification: modification)
         
@@ -122,7 +122,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
         
@@ -151,7 +151,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
 
@@ -189,7 +189,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
         
@@ -228,7 +228,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
         
@@ -264,7 +264,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         }
         
         let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
-                                                           bundleIdentifier: testBundleIdentifier,
+                                                           bundleID: testBundleID,
                                                            topicReferencePath: pathToArticle,
                                                            modification: modification)
         
@@ -299,12 +299,12 @@ class RenderNodeDiffingBundleTests: XCTestCase {
     }
     
     func getDiffsFromModifiedDocument(bundleName: String,
-                                      bundleIdentifier: String,
+                                      bundleID: DocumentationBundle.Identifier,
                                       topicReferencePath: String,
                                       modification: @escaping (URL) throws -> ()
     ) throws -> JSONPatchDifferences {
         let (bundleOriginal, contextOriginal) = try testBundleAndContext(named: bundleName)
-        let nodeOriginal = try contextOriginal.entity(with: ResolvedTopicReference(bundleIdentifier: bundleIdentifier,
+        let nodeOriginal = try contextOriginal.entity(with: ResolvedTopicReference(bundleID: bundleID,
                                                                                    path: topicReferencePath,
                                                                                    sourceLanguage: .swift))
         var renderContext = RenderContext(documentationContext: contextOriginal, bundle: bundleOriginal)
@@ -316,7 +316,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         let (_, bundleModified, contextModified) = try testBundleAndContext(copying: bundleName) { url in
             try modification(url)
         }
-        let nodeModified = try contextModified.entity(with: ResolvedTopicReference(bundleIdentifier: bundleIdentifier,
+        let nodeModified = try contextModified.entity(with: ResolvedTopicReference(bundleID: bundleID,
                                                                                    path: topicReferencePath,
                                                                                    sourceLanguage: .swift))
         renderContext = RenderContext(documentationContext: contextModified, bundle: bundleModified)

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import Markdown
 
 class RenderNodeSerializationTests: XCTestCase {
     func testRoundTrip() throws {
-        let inputIdentifier = ResolvedTopicReference(bundleIdentifier: "com.example.docc", path: "/example", sourceLanguage: .swift)
+        let inputIdentifier = ResolvedTopicReference(bundleID: "com.example.docc", path: "/example", sourceLanguage: .swift)
         var inputNode = RenderNode(identifier: inputIdentifier, kind: .tutorial)
         
         let introSection = IntroRenderSection(title: "Basic Augmented Reality App")
@@ -93,7 +93,7 @@ class RenderNodeSerializationTests: XCTestCase {
     
     func testBundleRoundTrip() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -116,7 +116,7 @@ class RenderNodeSerializationTests: XCTestCase {
     
     func testTutorialArticleRoundTrip() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
         
         guard let articleDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, article not found as first child.")
@@ -141,7 +141,7 @@ class RenderNodeSerializationTests: XCTestCase {
         typealias JSONDictionary = [String: Any]
         
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -193,7 +193,7 @@ class RenderNodeSerializationTests: XCTestCase {
 
     func testDiffAvailability() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
         
         guard let articleDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, article not found as first child.")

--- a/Tests/SwiftDocCTests/Model/ResourceReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Model/ResourceReferenceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import XCTest
 
 class ResourceReferenceTests: XCTestCase {
     func testPathWithSectionFragment() throws {
-        let ref = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/Test-Bundle/Tutorial1", sourceLanguage: .swift)
+        let ref = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/Test-Bundle/Tutorial1", sourceLanguage: .swift)
         XCTAssertEqual(ref.absoluteString, "doc://org.swift.docc.example/Test-Bundle/Tutorial1")
         
         let refAdvanced = ref.withFragment("fragment")

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -466,7 +466,7 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
             """.write(to: url.appendingPathComponent("bar.md"), atomically: true, encoding: .utf8)
         }
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MixedLanguageFramework/Bar", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedLanguageFramework/Bar", sourceLanguage: .swift))
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
         XCTAssert(context.problems.isEmpty, "Encountered unexpected problems: \(context.problems)")

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -17,7 +17,7 @@ import SwiftDocCTestUtilities
 class SemaToRenderNodeTests: XCTestCase {
     func testCompileTutorial() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -46,7 +46,7 @@ class SemaToRenderNodeTests: XCTestCase {
             XCTAssertFalse(jsonString.contains("This is a comment"))
         }
         
-        XCTAssertEqual(renderNode.identifier, ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+        XCTAssertEqual(renderNode.identifier, ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         XCTAssertEqual(renderNode.sections.count, 4)
         guard let intro = renderNode.sections.first as? IntroRenderSection else {
@@ -404,7 +404,7 @@ class SemaToRenderNodeTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
         func assertTutorialWithPath(_ tutorialPath: String, hasBackground backgroundIdentifier: String) throws {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: tutorialPath, sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: tutorialPath, sourceLanguage: .swift))
             
             guard let tutorialDirective = node.markup as? BlockDirective else {
                 XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -432,7 +432,7 @@ class SemaToRenderNodeTests: XCTestCase {
     
     func testCompileTutorialArticle() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
         
         let article = node.semantic as! TutorialArticle
         
@@ -570,7 +570,7 @@ class SemaToRenderNodeTests: XCTestCase {
     }
     
     private func assertCompileOverviewWithNoVolumes(bundle: DocumentationBundle, context: DocumentationContext, expectedProblemsCount: Int = 0) throws {
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
         guard let tutorialTableOfContentsDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -807,7 +807,7 @@ class SemaToRenderNodeTests: XCTestCase {
             try text.write(to: overviewURL, atomically: true, encoding: .utf8)
         }
     
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
         guard let tutorialTableOfContentsDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial table-of-contents not found as first child.")
@@ -941,7 +941,7 @@ class SemaToRenderNodeTests: XCTestCase {
             try JSONEncoder().encode(graph).write(to: graphURL)
         }
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
         
         // Verify that `MyProtocol` the symbol is loaded in the topic graph, but the `MyProtocol` sidecar article was removed.
         let matches = context.knownPages.filter({ reference -> Bool in
@@ -1175,7 +1175,7 @@ class SemaToRenderNodeTests: XCTestCase {
     func testCompileSymbolWithExternalReferences() throws {
         class TestSymbolResolver: GlobalExternalSymbolResolver {
             func symbolReferenceAndEntity(withPreciseIdentifier preciseIdentifier: String) -> (ResolvedTopicReference, LinkResolver.ExternalEntity)? {
-                let reference = ResolvedTopicReference(bundleIdentifier: "com.test.external.symbols", path: "/\(preciseIdentifier)", sourceLanguage: .objectiveC)
+                let reference = ResolvedTopicReference(bundleID: "com.test.external.symbols", path: "/\(preciseIdentifier)", sourceLanguage: .objectiveC)
                 
                 let entity = LinkResolver.ExternalEntity(
                     topicRenderReference: TopicRenderReference(
@@ -1198,7 +1198,7 @@ class SemaToRenderNodeTests: XCTestCase {
             func resolve(_ reference: TopicReference) -> TopicReferenceResolutionResult {
                 .success(
                     ResolvedTopicReference(
-                        bundleIdentifier: "com.test.external",
+                        bundleID: "com.test.external",
                         path: reference.url!.path,
                         sourceLanguage: .swift
                     )
@@ -1326,7 +1326,7 @@ class SemaToRenderNodeTests: XCTestCase {
         // Check for constraints in render node
         
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -1346,7 +1346,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }.joined(), "Label is Text, Observer inherits NSObject, and S conforms to StringProtocol.")
         
         // Check for constraints in render references
-        let parent = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let parent = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let parentSymbol = parent.semantic as! Symbol
         var parentTranslator = RenderNodeTranslator(context: context, bundle: bundle, identifier: parent.reference)
@@ -1379,7 +1379,7 @@ class SemaToRenderNodeTests: XCTestCase {
     
     func testRenderConditionalConstraintsOnConformingType() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
@@ -1401,7 +1401,7 @@ class SemaToRenderNodeTests: XCTestCase {
     
     func testRenderConditionalConstraintsOnProtocol() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(symbol) as! RenderNode
@@ -1423,7 +1423,7 @@ class SemaToRenderNodeTests: XCTestCase {
     
     func testRenderReferenceResolving() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
@@ -1488,7 +1488,7 @@ class SemaToRenderNodeTests: XCTestCase {
     
     func testAvailabilityMetadata() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
@@ -1561,7 +1561,7 @@ class SemaToRenderNodeTests: XCTestCase {
                 }
             })
             
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
             
             // Compile docs and verify contents
             let symbol = node.semantic as! Symbol
@@ -1588,7 +1588,7 @@ class SemaToRenderNodeTests: XCTestCase {
     
     func testMediaReferencesWithSpaces() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TutorialMediaWithSpaces", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TutorialMediaWithSpaces", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -1649,7 +1649,7 @@ Document @1:1-11:19
                        markup.debugDescription(options: .printSourceLocations))
         
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/TestTutorial", sourceLanguage: .swift))
+        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestTutorial", sourceLanguage: .swift))
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [
             .paragraph(.init(inlineContent: [
@@ -1691,7 +1691,7 @@ Document
                        markup.debugDescription())
 
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/TestTutorial", sourceLanguage: .swift))
+        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestTutorial", sourceLanguage: .swift))
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [
                 .paragraph(.init(inlineContent: [
@@ -1714,7 +1714,7 @@ Document
     """
         
         let document = Document(parsing: markupSource, options: [])
-        let node = DocumentationNode(reference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc", path: "/blah", sourceLanguage: .swift), kind: .article, sourceLanguage: .swift, name: .conceptual(title: "Title"), markup: document, semantic: Semantic())
+        let node = DocumentationNode(reference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguage: .swift), kind: .article, sourceLanguage: .swift, name: .conceptual(title: "Title"), markup: document, semantic: Semantic())
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
@@ -1723,7 +1723,7 @@ Document
         
     func testCompileSymbolMetadata() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
         
         // Compile docs and verify contents
         let symbol = node.semantic as! Symbol
@@ -1831,7 +1831,7 @@ Document
         try content.write(to: targetURL.appendingPathComponent("article2.md"), atomically: true, encoding: .utf8)
 
         let (_, bundle, context) = try loadBundle(from: targetURL)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article2", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article2", sourceLanguage: .swift))
         let article = node.semantic as! Article
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return translator.visit(article) as! RenderNode
@@ -1924,7 +1924,7 @@ Document
             
             let (_, bundle, context) = try testBundleAndContext(named: "TestBundle", configuration: configuration)
             
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: referencePath, sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: referencePath, sourceLanguage: .swift)
             return (bundle, context, reference)
         }
         
@@ -2095,14 +2095,14 @@ Document
 
         // Make the referenced symbol deprecated
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             (node.semantic as? Symbol)?.availability = SymbolGraph.Symbol.Availability(availability: [
                 SymbolGraph.Symbol.Availability.AvailabilityItem(domain: .init(rawValue: "iOS"), introducedVersion: nil, deprecatedVersion: .init(major: 13, minor: 0, patch: 0), obsoletedVersion: nil, message: nil, renamed: nil, isUnconditionallyDeprecated: false, isUnconditionallyUnavailable: false, willEventuallyBeDeprecated: false),
             ])
         }
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = node.semantic as! Symbol
         
@@ -2118,7 +2118,7 @@ Document
 
         // Make the referenced symbol deprecated
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             (node.semantic as? Symbol)?.availability = SymbolGraph.Symbol.Availability(availability: [
                 SymbolGraph.Symbol.Availability.AvailabilityItem(domain: .init(rawValue: "iOS"), introducedVersion: .init(major: 13, minor: 0, patch: 0), deprecatedVersion: nil, obsoletedVersion: nil, message: nil, renamed: nil, isUnconditionallyDeprecated: false, isUnconditionallyUnavailable: false, willEventuallyBeDeprecated: false),
@@ -2126,7 +2126,7 @@ Document
             ])
         }
     
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = node.semantic as! Symbol
         
@@ -2142,7 +2142,7 @@ Document
 
         // Make the referenced symbol deprecated
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             (node.semantic as? Symbol)?.availability = SymbolGraph.Symbol.Availability(availability: [
                 SymbolGraph.Symbol.Availability.AvailabilityItem(domain: .init(rawValue: "iOS"), introducedVersion: .init(major: 13, minor: 0, patch: 0), deprecatedVersion: nil, obsoletedVersion: nil, message: nil, renamed: nil, isUnconditionallyDeprecated: true, isUnconditionallyUnavailable: false, willEventuallyBeDeprecated: false),
@@ -2150,7 +2150,7 @@ Document
             ])
         }
 
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = node.semantic as! Symbol
         
@@ -2165,7 +2165,7 @@ Document
         
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2185,7 +2185,7 @@ Document
     
     func testRenderMetadataExtendedModule() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2199,7 +2199,7 @@ Document
         
         // Verify that the render reference to a required symbol includes the 'required' key and the number of default implementations provided.
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideProtocol", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideProtocol", sourceLanguage: .swift))
             let symbol = node.semantic as! Symbol
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
@@ -2212,7 +2212,7 @@ Document
 
         // Verify that a required symbol includes a required metadata and default implementations
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideProtocol/func()", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideProtocol/func()", sourceLanguage: .swift))
             let symbol = node.semantic as! Symbol
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
@@ -2232,7 +2232,7 @@ Document
         
         // Verify that a required symbol does not include default implementations in Topics groups
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideProtocol/func()", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideProtocol/func()", sourceLanguage: .swift))
             let symbol = node.semantic as! Symbol
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(symbol) as! RenderNode
@@ -2247,7 +2247,7 @@ Document
         
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2276,7 +2276,7 @@ Document
         
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2295,7 +2295,7 @@ Document
     func testDocumentationRenderReferenceRoles() throws {
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2315,7 +2315,7 @@ Document
     func testTutorialsRenderReferenceRoles() throws {
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
         let symbol = node.semantic as! TutorialTableOfContents
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2335,7 +2335,7 @@ Document
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
 
         // Subheading with trailing "\n"
@@ -2357,7 +2357,7 @@ Document
     func testRenderManualSeeAlsoInArticles() throws {
         // Check for fragments in metadata in render node
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift))
         
         let article = node.semantic as! Article
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2380,7 +2380,7 @@ Document
     func testSafeSectionAnchorNames() throws {
         // Check that heading's anchor was safe-ified
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
@@ -2401,7 +2401,7 @@ Document
     func testDuplicateNavigatorTitleIsRemoved() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = node.semantic as! Symbol
 
@@ -2417,7 +2417,7 @@ Document
     func testNonDuplicateNavigatorTitleIsRendered() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = node.semantic as! Symbol
 
@@ -2474,7 +2474,7 @@ Document
             """.write(to: url.appendingPathComponent("TestOverview.tutorial"), atomically: true, encoding: .utf8)
         }
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
         guard let tutorialTableOfContentsDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial table-of-contents not found as first child.")
@@ -2495,7 +2495,7 @@ Document
         _ = translator.visit(tutorialTableOfContents)
         
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
             
             guard let technologyDirective = node.markup as? BlockDirective else {
                 XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -2566,7 +2566,7 @@ Document
             """.write(to: url.appendingPathComponent("TestTutorial.tutorial"), atomically: true, encoding: .utf8)
         }
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let technologyDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
@@ -2610,8 +2610,8 @@ Document
             XCTAssertEqual(Array(asides.content.dropFirst()), self.asidesStressTest)
         }
         
-        let dashReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Asides/dashAsides()", sourceLanguage: .swift)
-        let quoteReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Asides/quoteAsides()", sourceLanguage: .swift)
+        let dashReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Asides/dashAsides()", sourceLanguage: .swift)
+        let quoteReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Asides/quoteAsides()", sourceLanguage: .swift)
         
         try testReference(dashReference)
         try testReference(quoteReference)
@@ -2621,7 +2621,7 @@ Document
     func testOriginMetadata() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         let origin = try XCTUnwrap(symbol.origin)
@@ -2643,7 +2643,7 @@ Document
                 .write(to: url.appendingPathComponent("sidekit.symbols.json"), atomically: true, encoding: .utf8)
         })
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -2670,7 +2670,7 @@ Document
                 .write(to: url.appendingPathComponent("sidekit.symbols.json"), atomically: true, encoding: .utf8)
         })
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -2696,7 +2696,7 @@ Document
             return p.diagnostic.summary == "Resource 'my-inherited-image.png' couldn't be found"
         }))
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -2725,7 +2725,7 @@ Document
             """.write(to: url.appendingPathComponent("inherited.md"), atomically: true, encoding: .utf8)
         })
         
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -2870,7 +2870,7 @@ Document
                     .write(to: url.appendingPathComponent("sidekit.symbols.json"))
             })
             
-            let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+            let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
             let node = try context.entity(with: myFuncReference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             
@@ -2900,7 +2900,7 @@ Document
             problem.diagnostic.summary.contains("my-inherited-image.png")
         }))
 
-        let myFuncReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
+        let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
@@ -2935,7 +2935,7 @@ Document
     func testNonDocumentedSymbolNilAbstract() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
 
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
 
@@ -3050,7 +3050,7 @@ Document
             """.write(to: url.appendingPathComponent("documentation").appendingPathComponent("myprotocol.md"), atomically: true, encoding: .utf8)
         })
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
         
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -3091,9 +3091,9 @@ Document
             """.write(to: url.appendingPathComponent("documentation").appendingPathComponent("myprotocol.md"), atomically: true, encoding: .utf8)
         })
          
-        let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit", sourceLanguage: .swift)
-        let protocolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
-        let functionReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let protocolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
+        let functionReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift)
         
         // Verify the MyKit module
         
@@ -3175,13 +3175,13 @@ Document
         // Verify that the inherited symbol got a path that accounts for the collision between
         // the struct `B` and the property `b`.
         
-        let inheritedSymbolReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/A/B-swift.struct/!=(_:_:)", sourceLanguage: .swift)
+        let inheritedSymbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/A/B-swift.struct/!=(_:_:)", sourceLanguage: .swift)
         XCTAssertNoThrow(try context.entity(with: inheritedSymbolReference))
         
         // Verify that the inherited symbol is automatically curated with its correct
         // reference path under the inherited symbols API collection
         
-        let equatableImplementationsReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Minimal_docs/A/B-swift.struct/Equatable-Implementations", sourceLanguage: .swift)
+        let equatableImplementationsReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/A/B-swift.struct/Equatable-Implementations", sourceLanguage: .swift)
         let equatableImplementationsNode = try context.entity(with: equatableImplementationsReference)
         let equatableImplementationsArticle = try XCTUnwrap(equatableImplementationsNode.semantic as? Article)
         let group = try XCTUnwrap(equatableImplementationsArticle.automaticTaskGroups.first)
@@ -3213,7 +3213,7 @@ Document
             }
             """.write(to: url.appendingPathComponent("TestOverview.tutorial"), atomically: true, encoding: .utf8)
         }
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/tutorials/TestOverview", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         guard let technologyDirective = node.markup as? BlockDirective else {
             XCTFail("Unexpected document structure, tutorial not found as first child.")
             return
@@ -3258,7 +3258,7 @@ Document
         )
          
         let moduleReference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/Test-Bundle/article",
             sourceLanguage: .swift
         )
@@ -3301,7 +3301,7 @@ Document
         )
          
         let articleReference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/Test-Bundle/article",
             sourceLanguage: .swift
         )
@@ -3545,7 +3545,7 @@ Document
         }
         
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/GeometricalShapes/Circle", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/GeometricalShapes/Circle", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
@@ -3596,7 +3596,7 @@ Document
         
         let (bundle, context) = try testBundleAndContext()
         
-        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/TestThematicBreak", sourceLanguage: .swift))
+        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [

--- a/Tests/SwiftDocCTests/Model/TaskGroupTests.swift
+++ b/Tests/SwiftDocCTests/Model/TaskGroupTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -69,7 +69,7 @@ class SectionExtractionTests: XCTestCase {
     }
     
     private func testNode(with document: Document) -> DocumentationNode {
-        return DocumentationNode(reference: ResolvedTopicReference(bundleIdentifier: "org.swift.docc", path: "/blah", sourceLanguage: .swift), kind: .article, sourceLanguage: .swift, name: .conceptual(title: "Title"), markup: document, semantic: Semantic())
+        return DocumentationNode(reference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguage: .swift), kind: .article, sourceLanguage: .swift, name: .conceptual(title: "Title"), markup: document, semantic: Semantic())
     }
     
     func testSection() {

--- a/Tests/SwiftDocCTests/Rendering/AutomaticSeeAlsoTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AutomaticSeeAlsoTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -30,7 +30,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -61,7 +61,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -104,7 +104,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -121,7 +121,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         
         // Verify that articles get same automatic See Also sections as symbols
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Article) as! RenderNode
             
@@ -171,7 +171,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -184,7 +184,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
 
         // Verify that article without options directive still gets automatic See Also sections
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Article) as! RenderNode
             
@@ -235,7 +235,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         }
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         
@@ -248,7 +248,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
 
         // Verify that article without options directive still gets automatic See Also sections
         do {
-            let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
+            let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/sidearticle", sourceLanguage: .swift))
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic as! Article) as! RenderNode
             
@@ -286,7 +286,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         let (_, bundle, context) = try loadBundle(from: bundleURL)
         
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "MyKit", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "MyKit", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         

--- a/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
@@ -24,7 +24,7 @@ class AvailabilityRenderOrderTests: XCTestCase {
             try? FileManager.default.removeItem(at: bundleURL)
         }
 
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Availability/MyStruct", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Availability/MyStruct", sourceLanguage: .swift))
         
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode

--- a/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -40,7 +40,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -70,7 +70,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -99,7 +99,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -129,7 +129,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -159,7 +159,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -190,7 +190,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -220,7 +220,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
@@ -258,7 +258,7 @@ class ConstraintsRenderSectionTests: XCTestCase {
         }
 
         // Compile docs and verify contents
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -135,7 +135,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
     func testAlternateDeclarations() throws {
         let (bundle, context) = try testBundleAndContext(named: "AlternateDeclarations")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/AlternateDeclarations/MyClass/present(completion:)",
             sourceLanguage: .swift
         )
@@ -186,7 +186,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             // func overload1(param: Set<Int>) {}
             // func overload1(param: [Int: Int]) {}
             let reference = ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/FancyOverloads/overload1(param:)",
                 sourceLanguage: .swift
             )
@@ -237,7 +237,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             // func overload2(p1: (Int) -> Int?, p2: Int) {}
             // func overload2(p1: ((Int) -> Int)?, p2: Int) {} // <- overload group
             let reference = ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/FancyOverloads/overload2(p1:p2:)",
                 sourceLanguage: .swift
             )
@@ -292,7 +292,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             // func overload3<T: Hashable>(_ p: [T: T]) {}
             // func overload3<K: Hashable, V>(_ p: [K: V]) {}
             let reference = ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/FancyOverloads/overload3(_:)",
                 sourceLanguage: .swift
             )
@@ -342,7 +342,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
 
         for hash in ["7eht8", "8p1lo", "858ja"] {
             let reference = ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/FancyOverloads/overload3(_:)-\(hash)",
                 sourceLanguage: .swift
             )
@@ -379,7 +379,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
         // - myFunc() where T: Equatable
         // - myFunc() where T: Hashable // <- overload group
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/ConformanceOverloads/MyClass/myFunc()",
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -71,7 +71,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         // Test if the default availability is used for modules
         do {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -81,7 +81,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         // Test if the default availability is used for symbols with no explicit availability
         do {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-3743d", fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-3743d", fragment: nil, sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -91,7 +91,7 @@ class DefaultAvailabilityTests: XCTestCase {
 
         // Test if the default availability is NOT used for symbols with explicit availability
         do {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", fragment: nil, sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -185,7 +185,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         // Test if the module availability is not "beta" for the "macOS" platform (since 10.15.1 != 10.16)
         do {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
             let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -205,7 +205,7 @@ class DefaultAvailabilityTests: XCTestCase {
         let (_, bundle, context) = try testBundleAndContext(named: "TestBundle", configuration: configuration)
         
         do {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", fragment: nil, sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
             
             // Add some available and unavailable platforms to the symbol
@@ -336,7 +336,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         let node = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/CoolFramework/CoolClass/doUncoolThings(with:)",
                 sourceLanguage: .swift
             )
@@ -665,7 +665,7 @@ class DefaultAvailabilityTests: XCTestCase {
         XCTAssertNotNil(availability.first(where: { $0.domain?.rawValue == "iOS" }))
         XCTAssertEqual(availability.first(where: { $0.domain?.rawValue == "iOS" })?.introducedVersion, nil)
         // Verify we remove the version from the module availability information.
-        var identifier = ResolvedTopicReference(bundleIdentifier: "test", path: "/documentation/MyModule", fragment: nil, sourceLanguage: .swift)
+        var identifier = ResolvedTopicReference(bundleID: "test", path: "/documentation/MyModule", fragment: nil, sourceLanguage: .swift)
         var node = try context.entity(with: identifier)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: identifier)
         var renderNode = translator.visit(node.semantic) as! RenderNode
@@ -708,7 +708,7 @@ class DefaultAvailabilityTests: XCTestCase {
         XCTAssertEqual(availability.first(where: { $0.domain?.rawValue == "watchOS" })?.introducedVersion, nil)
         
         // Verify the module availability shows as expected.
-        identifier = ResolvedTopicReference(bundleIdentifier: "test", path: "/documentation/MyModule", fragment: nil, sourceLanguage: .swift)
+        identifier = ResolvedTopicReference(bundleID: "test", path: "/documentation/MyModule", fragment: nil, sourceLanguage: .swift)
         node = try context.entity(with: identifier)
         translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: identifier)
         renderNode = translator.visit(node.semantic) as! RenderNode

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -25,7 +25,7 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
 
     override func setUpWithError() throws {
         func renderSection(for bundle: DocumentationBundle, in context: DocumentationContext) throws -> ContentRenderSection {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", fragment: nil, sourceLanguage: .swift)
 
             let node = try context.entity(with: identifier)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -42,7 +42,7 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
         testBundleWithoutLanguageDefault = DocumentationBundle(
             info: DocumentationBundle.Info(
                 displayName: testBundleWithLanguageDefault.displayName,
-                identifier: testBundleWithLanguageDefault.identifier,
+                id: testBundleWithLanguageDefault.id,
                 defaultCodeListingLanguage: nil
             ),
             baseURL: testBundleWithLanguageDefault.baseURL,

--- a/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -32,7 +32,7 @@ class DeprecationSummaryTests: XCTestCase {
     /// and it's preferred over the original deprecation note in the code docs.
     func testAuthoredDeprecatedSummary() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/init()", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/init()", sourceLanguage: .swift))
         
         // Compile docs and verify contents
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -63,7 +63,7 @@ class DeprecationSummaryTests: XCTestCase {
         })
         
         // Verify the deprecation is still rendered.
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift))
         
         // Compile docs and verify contents
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -83,7 +83,7 @@ class DeprecationSummaryTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/CoolFramework/CoolClass",
                 sourceLanguage: .swift
             )
@@ -115,7 +115,7 @@ class DeprecationSummaryTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/CoolFramework/CoolClass/doUncoolThings(with:)",
                 sourceLanguage: .swift
             )
@@ -137,7 +137,7 @@ class DeprecationSummaryTests: XCTestCase {
       let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
       let node = try context.entity(
           with: ResolvedTopicReference(
-              bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
               path: "/documentation/CoolFramework/CoolClass/init()",
               sourceLanguage: .swift
           )
@@ -166,7 +166,7 @@ class DeprecationSummaryTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/CoolFramework/CoolClass/coolFunc()",
                 sourceLanguage: .swift
             )
@@ -195,7 +195,7 @@ class DeprecationSummaryTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/documentation/CoolFramework/CoolClass/init(config:cache:)",
                 sourceLanguage: .swift
             )

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -146,7 +146,7 @@ private extension DocumentationContentRendererTests {
     var nodeWithSubheadingAndNavigatorVariants: DocumentationNode {
         var node = DocumentationNode(
             reference: ResolvedTopicReference(
-                bundleIdentifier: "org.swift.example",
+                bundleID: "org.swift.example",
                 path: "/documentation/class",
                 fragment: nil,
                 sourceLanguage: .swift
@@ -198,7 +198,7 @@ private extension DocumentationContentRendererTests {
             ]),
             roleHeadingVariants: .init(swiftVariant: ""),
             platformNameVariants: .init(swiftVariant: nil),
-            moduleReference: ResolvedTopicReference(bundleIdentifier: "", path: "", sourceLanguage: .swift), // This information isn't used anywhere.
+            moduleReference: ResolvedTopicReference(bundleID: "", path: "", sourceLanguage: .swift), // This information isn't used anywhere.
             externalIDVariants: .init(swiftVariant: nil),
             accessLevelVariants: .init(swiftVariant: nil),
             availabilityVariants: .init(swiftVariant: Availability(availability: [])),

--- a/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,7 @@ import Markdown
 public class ExternalLinkTitleTests: XCTestCase {
     private func getTranslatorAndBlockContentForMarkup(_ markupSource: String) throws -> (translator: RenderNodeTranslator, content: [RenderBlockContent]) {
         let document = Document(parsing: markupSource, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let testReference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc", path: "/test", sourceLanguage: .swift)
+        let testReference = ResolvedTopicReference(bundleID: "org.swift.docc", path: "/test", sourceLanguage: .swift)
         let node = DocumentationNode(reference: testReference,
                                      kind: .article,
                                      sourceLanguage: .swift,

--- a/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
@@ -19,12 +19,12 @@ class MentionsRenderSectionTests: XCTestCase {
         enableFeatureFlag(\.isExperimentalMentionedInEnabled)
         let (bundle, context) = try createMentionedInTestBundle()
         let identifier = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MentionedIn/MyClass",
             sourceLanguage: .swift
         )
         let mentioningArticle = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MentionedIn/ArticleMentioningSymbol",
             sourceLanguage: .swift
         )
@@ -42,7 +42,7 @@ class MentionsRenderSectionTests: XCTestCase {
         enableFeatureFlag(\.isExperimentalMentionedInEnabled)
         let (bundle, context) = try createMentionedInTestBundle()
         let identifier = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MentionedIn/MyClass/myFunction()",
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ class PageKindTests: XCTestCase {
     private func generateRenderNodeFromBundle(bundleName: String, resolvedTopicPath: String) throws -> RenderNode {
         let (bundle, context) = try testBundleAndContext(named: bundleName)
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: resolvedTopicPath,
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -36,7 +36,7 @@ class PlatformAvailabilityTests: XCTestCase {
     func testPlatformAvailabilityFromArticle() throws {
         let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/AvailableArticle",
             sourceLanguage: .swift
         )
@@ -55,7 +55,7 @@ class PlatformAvailabilityTests: XCTestCase {
     func testPlatformAvailabilityFromExtension() throws {
         let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MyKit/MyClass",
             sourceLanguage: .swift
         )
@@ -73,7 +73,7 @@ class PlatformAvailabilityTests: XCTestCase {
     func testMultiplePlatformAvailabilityFromArticle() throws {
         let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/AvailabilityBundle/ComplexAvailable",
             sourceLanguage: .swift
         )
@@ -101,7 +101,7 @@ class PlatformAvailabilityTests: XCTestCase {
     func testArbitraryPlatformAvailability() throws {
         let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/AvailabilityBundle/ArbitraryPlatforms",
             sourceLanguage: .swift
         )
@@ -127,7 +127,7 @@ class PlatformAvailabilityTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext(named: "AvailabilityOverrideBundle")
 
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MyKit/MyClass",
             sourceLanguage: .swift
         )
@@ -166,7 +166,7 @@ class PlatformAvailabilityTests: XCTestCase {
         ]
         let (bundle, context) = try testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/AvailableArticle",
             sourceLanguage: .swift
         )
@@ -189,7 +189,7 @@ class PlatformAvailabilityTests: XCTestCase {
         ]
         let (bundle, context) = try testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/AvailabilityBundle/ComplexAvailable",
             sourceLanguage: .swift
         )
@@ -221,7 +221,7 @@ class PlatformAvailabilityTests: XCTestCase {
         ]
         let (bundle, context) = try testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MyKit/MyClass",
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RESTSymbolsTests.swift
@@ -332,7 +332,7 @@ class RESTSymbolsTests: XCTestCase {
                 ] + extraFiles
             )
             let (_, bundle, context) = try loadBundle(from: (try createTempFolder(content: [exampleDocumentation])))
-            let moduleReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName", sourceLanguage: .swift)
+            let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName", sourceLanguage: .swift)
             let moduleSymbol = try XCTUnwrap((try context.entity(with: moduleReference)).semantic as? Symbol)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleReference)
             let renderNode = translator.visit(moduleSymbol) as! RenderNode

--- a/Tests/SwiftDocCTests/Rendering/RenderBlockContent_ThematicBreakTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderBlockContent_ThematicBreakTests.swift
@@ -40,7 +40,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         
         let (bundle, context) = try testBundleAndContext()
         
-        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/TestThematicBreak", sourceLanguage: .swift))
+        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [
@@ -67,7 +67,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         
         let (bundle, context) = try testBundleAndContext()
         
-        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/TestThematicBreak", sourceLanguage: .swift))
+        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [
@@ -97,7 +97,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         
         let (bundle, context) = try testBundleAndContext()
         
-        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/TestThematicBreak", sourceLanguage: .swift))
+        var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [

--- a/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
@@ -16,7 +16,7 @@ import XCTest
 class RenderContentCompilerTests: XCTestCase {
     func testLinkOverrideTitle() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
         [Example](http://example.com)
@@ -134,7 +134,7 @@ class RenderContentCompilerTests: XCTestCase {
     
     func testLineBreak() throws {
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = #"""
         Backslash before new line\
@@ -199,7 +199,7 @@ class RenderContentCompilerTests: XCTestCase {
     
     func testThematicBreak() throws {
         let (bundle, context) = try testBundleAndContext()
-        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
 
         let source = #"""

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -100,7 +100,7 @@ class RenderMetadataTests: XCTestCase {
         }
 
         // Verify the symbol from bystanders graph is present in the documentation context.
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/MyKit/MyClass/myFunction1()", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction1()", sourceLanguage: .swift)
         let entity = try XCTUnwrap(try? context.entity(with: reference))
         let symbol = try XCTUnwrap(entity.semantic as? Symbol)
         
@@ -127,7 +127,7 @@ class RenderMetadataTests: XCTestCase {
         }
 
         // Verify the symbol from bystanders graph is present in the documentation context.
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/BaseKit/OtherStruct/someFunc()", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/BaseKit/OtherStruct/someFunc()", sourceLanguage: .swift)
         let entity = try XCTUnwrap(try? context.entity(with: reference))
         let symbol = try XCTUnwrap(entity.semantic as? Symbol)
 
@@ -149,7 +149,7 @@ class RenderMetadataTests: XCTestCase {
         }
 
         // Get a translated render node
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency/AmbiguousType", sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/BundleWithRelativePathAmbiguity/Dependency/AmbiguousType", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
         XCTAssertEqual(renderNode.metadata.modules?.first?.name, "BundleWithRelativePathAmbiguity")

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -35,7 +35,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     func testMultipleModules() throws {
         try assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
-                let moduleReference = ResolvedTopicReference(bundleIdentifier: resolvedTopicReference.bundleIdentifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+                let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Custom Module Title")
                 context.preResolveModuleNames()
             },
@@ -51,7 +51,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     func testMultipleModulesWithBystanderModule() throws {
         try assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
-                let moduleReference = ResolvedTopicReference(bundleIdentifier: resolvedTopicReference.bundleIdentifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+                let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Custom Module Title")
                 context.preResolveModuleNames()
             },
@@ -79,7 +79,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     func testMultipleModulesWithDifferentBystanderModule() throws {
         try assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
-                let moduleReference = ResolvedTopicReference(bundleIdentifier: resolvedTopicReference.bundleIdentifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+                let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Extended Module Title")
                 context.preResolveModuleNames()
             },
@@ -125,7 +125,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     func testPlatformsVariantsDefaultAvailability() throws {
         try assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
-                let moduleReference = ResolvedTopicReference(bundleIdentifier: resolvedTopicReference.bundleIdentifier, path: "/documentation/MyKit", sourceLanguage: .swift)
+                let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Custom Module Title")
                 context.preResolveModuleNames()
             },
@@ -665,7 +665,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 // Set up an Objective-C title for MyProtocol.
                 let myFunctionNode = try context.entity(
                     with: ResolvedTopicReference(
-                        bundleIdentifier: "org.swift.docc.example",
+                        bundleID: "org.swift.docc.example",
                         path: "/documentation/MyKit/MyProtocol",
                         fragment: nil,
                         sourceLanguage: .swift
@@ -716,7 +716,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 // Set up an Objective-C title for MyProtocol.
                 let myFunctionNode = try context.entity(
                     with: ResolvedTopicReference(
-                        bundleIdentifier: "org.swift.docc.example",
+                        bundleID: "org.swift.docc.example",
                         path: "/documentation/MyKit/MyProtocol",
                         fragment: nil,
                         sourceLanguage: .swift
@@ -755,7 +755,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             configureContext: { context, reference in
                 try makeSymbolAvailableInSwiftAndObjectiveC(
                     symbolPath: "/documentation/MyKit/MyProtocol",
-                    bundleIdentifier: reference.bundleIdentifier,
+                    id: reference.bundleID,
                     context: context
                 )
             },
@@ -887,7 +887,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                     Implementation(
                         reference: .successfullyResolved(
                             ResolvedTopicReference(
-                                bundleIdentifier: "org.swift.docc.example",
+                                bundleID: "org.swift.docc.example",
                                 path: path,
                                 fragment: nil,
                                 sourceLanguage: .swift
@@ -954,7 +954,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             configureContext: { context, reference in
                 try makeSymbolAvailableInSwiftAndObjectiveC(
                     symbolPath: "/documentation/MyKit/MyProtocol",
-                    bundleIdentifier: reference.bundleIdentifier,
+                    id: reference.bundleID,
                     context: context
                 )
             },
@@ -1146,7 +1146,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                 
                 let myFunctionNode = try context.entity(
                     with: ResolvedTopicReference(
-                        bundleIdentifier: "org.swift.docc.example",
+                        bundleID: "org.swift.docc.example",
                         path: "/documentation/MyKit/MyClass/myFunction()",
                         fragment: nil,
                         sourceLanguage: .swift
@@ -1188,7 +1188,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         let (_, bundle, context) = try testBundleAndContext(copying: bundleName)
         
         let identifier = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MyKit/MyClass",
             sourceLanguage: .swift
         )
@@ -1225,7 +1225,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle")
         
         let identifier = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/Test-Bundle/article",
             sourceLanguage: .swift
         )
@@ -1298,7 +1298,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
                     destinations: [
                         TopicReference.successfullyResolved(
                             ResolvedTopicReference(
-                                bundleIdentifier: "org.swift.docc.example",
+                                bundleID: "org.swift.docc.example",
                                 path: path,
                                 fragment: nil,
                                 sourceLanguage: .swift
@@ -1324,14 +1324,10 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     
     private func makeSymbolAvailableInSwiftAndObjectiveC(
         symbolPath: String,
-        bundleIdentifier: String,
+        id: DocumentationBundle.Identifier,
         context: DocumentationContext
     ) throws {
-        let reference = ResolvedTopicReference(
-            bundleIdentifier: bundleIdentifier,
-            path: symbolPath,
-            sourceLanguage: .swift
-        )
+        let reference = ResolvedTopicReference(bundleID: id, path: symbolPath, sourceLanguage: .swift)
         
         context.documentationCache[reference]?.availableSourceLanguages = [.swift, .objectiveC]
     }

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -19,7 +19,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     private func findDiscussion(forSymbolPath: String, configureBundle: ((URL) throws -> Void)? = nil) throws -> ContentRenderSection? {
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle", configureBundle: configureBundle)
         
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: forSymbolPath, sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: forSymbolPath, sourceLanguage: .swift))
         
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic as! Symbol) as! RenderNode
@@ -291,7 +291,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             """.write(to: url.appendingPathComponent("article.md"), atomically: true, encoding: .utf8)
         })
 
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
         let article = try XCTUnwrap(node.semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -341,7 +341,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         let article = try XCTUnwrap(
             Article(from: document.root, source: nil, for: bundle, in: context, problems: &problems)
         )
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/taskgroups", fragment: nil, sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/taskgroups", fragment: nil, sourceLanguage: .swift)
         context.documentationCache[reference] = try DocumentationNode(reference: reference, article: article)
         let topicGraphNode = TopicGraph.Node(reference: reference, kind: .article, source: .file(url: URL(fileURLWithPath: "/path/to/article.md")), title: "My Article")
         context.topicGraph.addNode(topicGraphNode)
@@ -375,7 +375,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             """.write(to: url.appendingPathComponent("sideclass.md"), atomically: true, encoding: .utf8)
         })
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(try? context.entity(with: reference))
         
@@ -406,7 +406,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Articles",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -440,7 +440,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Articles",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -451,7 +451,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Default Implementations",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -462,7 +462,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Another Task Group",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -502,7 +502,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             """.write(to: url.appendingPathComponent("article.md"), atomically: true, encoding: .utf8)
         })
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(try? context.entity(with: reference))
         
@@ -525,7 +525,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Articles",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -553,7 +553,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Articles",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -564,7 +564,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Default Implementations",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -575,7 +575,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                     title: "Another Task Group",
                     references: [
                         ResolvedTopicReference(
-                            bundleIdentifier: bundle.identifier,
+                            bundleID: bundle.id,
                             path: "/documentation/MyKit/MyProtocol",
                             sourceLanguage: .swift
                         ),
@@ -605,7 +605,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         // Verify "Default Implementations" group on the implementing type
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element", sourceLanguage: .swift)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let node = try XCTUnwrap(try? context.entity(with: reference))
             
@@ -624,7 +624,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         // Verify automatically generated api collection
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass/Element/Protocol-Implementations", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/Protocol-Implementations", sourceLanguage: .swift)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             let node = try XCTUnwrap(try? context.entity(with: reference))
             
@@ -653,7 +653,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             try? FileManager.default.copyItem(at: fancyProtocolSGFURL, to: url.appendingPathComponent("FancyProtocol.symbols.json"))
         }
 
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/FancyProtocol/SomeClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/FancyProtocol/SomeClass", sourceLanguage: .swift)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -856,7 +856,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func loadRenderNode(at path: String, in bundleURL: URL) throws -> RenderNode {
         let (_, bundle, context) = try loadBundle(from: bundleURL)
 
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try context.entity(with: reference)
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -865,7 +865,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     
     func testAutomaticTaskGroupTopicsAreSorted() throws {
         let (bundle, context) = try testBundleAndContext(named: "DefaultImplementations")
-        let structReference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/DefaultImplementations/Foo", sourceLanguage: .swift)
+        let structReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DefaultImplementations/Foo", sourceLanguage: .swift)
         let structNode = try context.entity(with: structReference)
         let symbol = try XCTUnwrap(structNode.semantic as? Symbol)
         
@@ -899,7 +899,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             """.write(to: url.appendingPathComponent("sideclass.md"), atomically: true, encoding: .utf8)
         })
 
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass", sourceLanguage: .swift)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let node = try XCTUnwrap(try? context.entity(with: reference))
         
@@ -927,7 +927,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             // First verify that `SideKit` page does not contain render reference to `SideKit/SideClass/Element`.
             let (bundle, context) = try testBundleAndContext(named: "TestBundle")
             
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -935,7 +935,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             
             // No render reference to `Element`
-            XCTAssertFalse(renderNode.references.keys.contains("doc://\(bundle.identifier)/documentation/SideKit/SideClass/Element"))
+            XCTAssertFalse(renderNode.references.keys.contains("doc://\(bundle.id)/documentation/SideKit/SideClass/Element"))
         }
         
         do {
@@ -947,7 +947,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                 """.write(to: url.appendingPathComponent("sideclass.md"), atomically: true, encoding: .utf8)
             })
 
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/SideKit", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -955,13 +955,13 @@ class RenderNodeTranslatorTests: XCTestCase {
             let renderNode = try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
             
             // There is a render reference to `Element`
-            XCTAssertTrue(renderNode.references.keys.contains("doc://\(bundle.identifier)/documentation/SideKit/SideClass/Element"))
+            XCTAssertTrue(renderNode.references.keys.contains("doc://\(bundle.id)/documentation/SideKit/SideClass/Element"))
         }
     }
 
     func testSnippetToCodeListing() throws {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
@@ -991,7 +991,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     
     func testSnippetSliceToCodeListing() throws {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
@@ -1015,7 +1015,7 @@ class RenderNodeTranslatorTests: XCTestCase {
 
     func testNestedSnippetSliceToCodeListing() throws {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
@@ -1046,7 +1046,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     
     func testSnippetSliceTrimsIndentation() throws {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/Snippets/SliceIndentation", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/SliceIndentation", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
         let renderNode = try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
@@ -1072,7 +1072,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func testRowAndColumn() throws {
         let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/BestBook/MyArticle",
             sourceLanguage: .swift
         )
@@ -1101,7 +1101,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func testSmall() throws {
         let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/BestBook/MyArticle",
             sourceLanguage: .swift
         )
@@ -1129,7 +1129,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func testTabNavigator() throws {
         let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/BestBook/TabNavigatorArticle",
             sourceLanguage: .swift
         )
@@ -1166,7 +1166,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func testRenderNodeMetadata() throws {
          let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
          let reference = ResolvedTopicReference(
-             bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
              path: "/documentation/BestBook/MyArticle",
              sourceLanguage: .swift
          )
@@ -1242,7 +1242,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func testPageColorMetadataInSymbolExtension() throws {
         let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/TestBed",
             sourceLanguage: .swift
         )
@@ -1258,7 +1258,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func testTitleHeadingMetadataInSymbolExtension() throws {
         let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/TestBed",
             sourceLanguage: .swift
         )
@@ -1340,7 +1340,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         func renderNodeArticleFromReferencePath(
             referencePath: String
         ) throws -> RenderNode {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: referencePath, sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: referencePath, sourceLanguage: .swift)
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             return try XCTUnwrap(translator.visitArticle(symbol) as? RenderNode)
@@ -1433,7 +1433,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         func renderNodeArticleFromReferencePath(
             referencePath: String
         ) throws -> RenderNode {
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: referencePath, sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: referencePath, sourceLanguage: .swift)
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
             var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
             return try XCTUnwrap(translator.visitArticle(symbol) as? RenderNode)

--- a/Tests/SwiftDocCTests/Rendering/RoleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RoleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -29,7 +29,7 @@ class RoleTests: XCTestCase {
 
         // Compile docs and verify contents
         for (path, expectedRole) in expectedRoles {
-            let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: path, fragment: nil, sourceLanguage: .swift)
+            let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: path, fragment: nil, sourceLanguage: .swift)
             do {
                 let node = try context.entity(with: identifier)
                 var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -45,7 +45,7 @@ class RoleTests: XCTestCase {
     func testDocumentationRenderReferenceRoles() throws {
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle")
 
-        let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
+        let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
         let node = try context.entity(with: identifier)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode
@@ -58,7 +58,7 @@ class RoleTests: XCTestCase {
     func testTutorialsRenderReferenceRoles() throws {
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle")
 
-        let identifier = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", fragment: nil, sourceLanguage: .swift)
+        let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", fragment: nil, sourceLanguage: .swift)
         let node = try context.entity(with: identifier)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let renderNode = translator.visit(node.semantic) as! RenderNode

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -128,7 +128,7 @@ class SampleDownloadTests: XCTestCase {
     private func renderNodeFromSampleBundle(at referencePath: String) throws -> RenderNode {
         let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: referencePath,
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
@@ -64,7 +64,7 @@ class SymbolAvailabilityTests: XCTestCase {
         )
         let (bundle, context) = try loadBundle(catalog: catalog)
         let reference = try XCTUnwrap(context.soleRootModuleReference).appendingPath(symbolName)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: reference.path, sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: reference.path, sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return try XCTUnwrap((translator.visit(node.semantic as! Symbol) as! RenderNode).metadata.platformsVariants.defaultValue)
     }

--- a/Tests/SwiftDocCTests/Rendering/TermListTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/TermListTests.swift
@@ -87,7 +87,7 @@ class TermListTests: XCTestCase {
         
         let (_, bundle, context) = try loadBundle(from: tempURL, externalResolvers: ["com.external.testbundle": resolver])
         
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
@@ -161,7 +161,7 @@ class TermListTests: XCTestCase {
         }
         
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
         - term First term : A paragraph that
@@ -204,7 +204,7 @@ class TermListTests: XCTestCase {
         }
         
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
-        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/path", fragment: nil, sourceLanguage: .swift))
+        var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
         - Not a term list, and

--- a/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
@@ -18,11 +18,11 @@ class ArticleSymbolMentionsTests: XCTestCase {
     /// Test that the recording abstraction for ``ArticleSymbolMentions`` works as expected.
     func testArticlesMentioningSymbol() throws {
         let article = ResolvedTopicReference(
-            bundleIdentifier: "org.swift.anything",
+            bundleID: "org.swift.anything",
             path: "/article",
             sourceLanguage: .swift
         )
-        let symbol = ResolvedTopicReference(bundleIdentifier: "org.swift.anything", path: "/Thing", sourceLanguage: .swift)
+        let symbol = ResolvedTopicReference(bundleID: "org.swift.anything", path: "/Thing", sourceLanguage: .swift)
         var mentions = ArticleSymbolMentions()
 
         XCTAssertTrue(mentions.articlesMentioning(symbol).isEmpty)
@@ -47,11 +47,11 @@ class ArticleSymbolMentionsTests: XCTestCase {
         XCTAssertEqual(1, context.articleSymbolMentions.mentions.count)
 
         let mentioningArticle = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MentionedIn/ArticleMentioningSymbol",
             sourceLanguage: .swift)
         let mentionedSymbol = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MentionedIn/MyClass",
             sourceLanguage: .swift)
         
@@ -68,7 +68,7 @@ class ArticleSymbolMentionsTests: XCTestCase {
         XCTAssertTrue(context.articleSymbolMentions.mentions.isEmpty)
 
         let mentionedSymbol = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "/documentation/MentionedIn/MyClass",
             sourceLanguage: .swift)
 

--- a/Tests/SwiftDocCTests/Semantics/ChoiceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ChoiceTests.swift
@@ -233,7 +233,7 @@ Choice @1:1-9:2 isCorrect: true
                 let expectedDump = """
 Choice @1:1-7:2 isCorrect: true
 ├─ MarkupContainer (empty)
-├─ ImageMedia @2:4-2:39 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "blah.png")' altText: 'blah'
+├─ ImageMedia @2:4-2:39 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "blah.png")' altText: 'blah'
 └─ Justification @4:4-6:5
    └─ MarkupContainer (1 element)
 """

--- a/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
@@ -89,7 +89,7 @@ class DoxygenTests: XCTestCase {
         ])
 
         let (_, bundle, context) = try loadBundle(from: tempURL)
-        let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/SomeClass", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SomeClass", sourceLanguage: .swift)
 
         // Verify the expected content in the in-memory model
         let node = try context.entity(with: reference)

--- a/Tests/SwiftDocCTests/Semantics/MultipleChoiceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MultipleChoiceTests.swift
@@ -117,7 +117,7 @@ class MultipleChoiceTests: XCTestCase {
                 let expectedDump = """
 MultipleChoice @1:1-24:2 title: 'SwiftDocC.MarkupContainer'
 ├─ MarkupContainer (2 elements)
-├─ ImageMedia @10:3-10:38 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "blah.png")' altText: 'blah'
+├─ ImageMedia @10:3-10:38 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "blah.png")' altText: 'blah'
 ├─ Choice @12:3-17:5 isCorrect: true
 │  ├─ MarkupContainer (1 element)
 │  └─ Justification @14:6-16:7

--- a/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
@@ -168,7 +168,7 @@ TutorialArticle @1:1-23:2
 TutorialArticle @1:1-23:2 title: 'Basic Augmented Reality App' time: '20'
 ├─ Intro @3:4-10:5 title: 'Basic Augmented Reality App'
 │  ├─ MarkupContainer (2 elements)
-│  └─ ImageMedia @9:7-9:46 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "myimage.png")' altText: 'image'
+│  └─ ImageMedia @9:7-9:46 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "myimage.png")' altText: 'image'
 └─ MarkupContainer (6 elements)
 """
                 XCTAssertEqual(expectedDump, article.dump())
@@ -282,29 +282,29 @@ TutorialArticle @1:1-23:2 title: 'Basic Augmented Reality App' time: '20'
 TutorialArticle @1:1-81:2
 ├─ ContentAndMedia @3:4-12:5 mediaPosition: 'leading'
 │  ├─ MarkupContainer (2 elements)
-│  └─ ImageMedia @4:7-4:58 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "customize-text-view.png")' altText: 'alt'
+│  └─ ImageMedia @4:7-4:58 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "customize-text-view.png")' altText: 'alt'
 ├─ ContentAndMedia @14:4-23:5 mediaPosition: 'trailing'
 │  ├─ MarkupContainer (2 elements)
-│  └─ ImageMedia @22:7-22:58 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "customize-text-view.png")' altText: 'alt'
+│  └─ ImageMedia @22:7-22:58 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "customize-text-view.png")' altText: 'alt'
 ├─ MarkupContainer (1 element)
 ├─ Stack @27:4-51:5
 │  ├─ ContentAndMedia @28:7-37:8 mediaPosition: 'trailing'
 │  │  ├─ MarkupContainer (2 elements)
-│  │  └─ ImageMedia @32:10-32:64 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "this-is-still-trailing.png")' altText: 'alt'
+│  │  └─ ImageMedia @32:10-32:64 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "this-is-still-trailing.png")' altText: 'alt'
 │  └─ ContentAndMedia @41:7-50:8 mediaPosition: 'trailing'
 │     ├─ MarkupContainer (2 elements)
-│     └─ ImageMedia @49:10-49:58 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "this-is-trailing.png")' altText: 'alt'
+│     └─ ImageMedia @49:10-49:58 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "this-is-trailing.png")' altText: 'alt'
 ├─ MarkupContainer (3 elements)
 └─ Stack @61:4-80:5
    ├─ ContentAndMedia @62:7-71:8 mediaPosition: 'trailing'
    │  ├─ MarkupContainer (2 elements)
-   │  └─ ImageMedia @66:10-66:64 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "this-is-still-trailing.png")' altText: 'alt'
+   │  └─ ImageMedia @66:10-66:64 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "this-is-still-trailing.png")' altText: 'alt'
    ├─ ContentAndMedia @73:7-75:8 mediaPosition: 'leading'
    │  ├─ MarkupContainer (empty)
-   │  └─ ImageMedia @74:10-74:57 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "this-is-leading.png")' altText: 'alt'
+   │  └─ ImageMedia @74:10-74:57 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "this-is-leading.png")' altText: 'alt'
    └─ ContentAndMedia @77:7-79:8 mediaPosition: 'leading'
       ├─ MarkupContainer (empty)
-      └─ ImageMedia @78:10-78:57 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "this-is-leading.png")' altText: 'alt'
+      └─ ImageMedia @78:10-78:57 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "this-is-leading.png")' altText: 'alt'
 """
                 XCTAssertEqual(expectedDump, article.dump())
             }
@@ -374,7 +374,7 @@ TutorialArticle @1:1-81:2
 TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
 ├─ Intro @2:4-7:5 title: 'Basic Augmented Reality App'
 │  ├─ MarkupContainer (1 element)
-│  └─ ImageMedia @6:7-6:46 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "myimage.png")' altText: 'image'
+│  └─ ImageMedia @6:7-6:46 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "myimage.png")' altText: 'image'
 ├─ MarkupContainer (6 elements)
 └─ Assessments @21:4-41:5
    └─ MultipleChoice @22:7-40:8 title: 'SwiftDocC.MarkupContainer'
@@ -395,7 +395,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
 
     func testAnalyzeNode() throws {
         let title = "unreferenced-tutorial"
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
@@ -414,7 +414,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
 
     func testAnalyzeExternalNode() throws {
         let title = "unreferenced-tutorial"
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .external, title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
@@ -433,7 +433,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
     func testAnalyzeFragmentNode() throws {
         let title = "unreferenced-tutorial"
         let url = URL(fileURLWithPath: "/path/to/\(title)")
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .range(range, url: url) , title: title)
 
@@ -454,7 +454,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
     func testAnalyzeForValidParent() throws {
         func node(withTitle title: String, ofKind kind: DocumentationNode.Kind) -> TopicGraph.Node {
             let url = URL(fileURLWithPath: "/path/to/\(title)")
-            let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TutorialArticleTests", path:  "/\(title)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TutorialArticleTests", path:  "/\(title)", sourceLanguage: .swift)
             let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
             return TopicGraph.Node(reference: reference, kind: kind, source: .range(range, url: url) , title: title)
         }

--- a/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
@@ -208,32 +208,32 @@ class TutorialTests: XCTestCase {
 Tutorial @1:1-150:2 projectFiles: nil
 ├─ Intro @3:4-6:5 title: 'Basic Augmented Reality App'
 │  ├─ MarkupContainer (empty)
-│  ├─ ImageMedia @5:7-5:46 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "myimage.png")' altText: 'image'
-│  └─ VideoMedia @4:7-4:51 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "test.mp4")' poster: 'Optional(SwiftDocC.ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "poster.png"))'
+│  ├─ ImageMedia @5:7-5:46 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "myimage.png")' altText: 'image'
+│  └─ VideoMedia @4:7-4:51 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "test.mp4")' poster: 'Optional(SwiftDocC.ResourceReference(bundleID: org.swift.docc.example, path: "poster.png"))'
 ├─ XcodeRequirement @2:4-2:97 title: 'Xcode X.Y Beta Z' destination: 'https://www.example.com/download'
 ├─ TutorialSection @8:4-48:5
 │  ├─ ContentAndMedia @9:7-19:8 mediaPosition: 'trailing'
 │  │  ├─ MarkupContainer (3 elements)
-│  │  └─ ImageMedia @14:10-14:51 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "figure1.png")' altText: 'figure1'
+│  │  └─ ImageMedia @14:10-14:51 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "figure1.png")' altText: 'figure1'
 │  └─ Steps @21:7-47:8
 │     ├─ MarkupContainer (1 element)
 │     ├─ Step @25:10-31:11
 │     │  ├─ MarkupContainer (1 element)
 │     │  ├─ MarkupContainer (empty)
-│     │  └─ Code @28:13-30:14 fileReference: ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "code1.swift") fileName: 'MyCode.swift' shouldResetDiff: false preview: Optional(SwiftDocC.ImageMedia)
+│     │  └─ Code @28:13-30:14 fileReference: ResourceReference(bundleID: org.swift.docc.example, path: "code1.swift") fileName: 'MyCode.swift' shouldResetDiff: false preview: Optional(SwiftDocC.ImageMedia)
 │     ├─ Step @32:10-38:11
 │     │  ├─ MarkupContainer (1 element)
 │     │  ├─ MarkupContainer (empty)
-│     │  └─ Code @35:13-37:14 fileReference: ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "code2.swift") fileName: 'MyCode.swift' shouldResetDiff: true preview: Optional(SwiftDocC.ImageMedia)
+│     │  └─ Code @35:13-37:14 fileReference: ResourceReference(bundleID: org.swift.docc.example, path: "code2.swift") fileName: 'MyCode.swift' shouldResetDiff: true preview: Optional(SwiftDocC.ImageMedia)
 │     ├─ MarkupContainer (1 element)
 │     └─ Step @42:10-46:11
 │        ├─ MarkupContainer (1 element)
 │        ├─ MarkupContainer (empty)
-│        └─ Code @45:13-45:65 fileReference: ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "othercode1.swift") fileName: 'OtherCode.swift' shouldResetDiff: false preview: nil
+│        └─ Code @45:13-45:65 fileReference: ResourceReference(bundleID: org.swift.docc.example, path: "othercode1.swift") fileName: 'OtherCode.swift' shouldResetDiff: false preview: nil
 ├─ TutorialSection @50:4-77:5
 │  ├─ ContentAndMedia @51:7-58:8 mediaPosition: 'trailing'
 │  │  ├─ MarkupContainer (2 elements)
-│  │  └─ ImageMedia @57:10-57:47 source: 'ResourceReference(bundleIdentifier: "org.swift.docc.example", path: "xcode.png")' altText: 'xcode'
+│  │  └─ ImageMedia @57:10-57:47 source: 'ResourceReference(bundleID: org.swift.docc.example, path: "xcode.png")' altText: 'xcode'
 │  └─ Steps @60:7-76:8
 │     ├─ MarkupContainer (1 element)
 │     ├─ Step @64:10-67:11
@@ -370,7 +370,7 @@ Tutorial @1:1-150:2 projectFiles: nil
 
     func testAnalyzeNode() throws {
         let title = "unreferenced-tutorial"
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
@@ -389,7 +389,7 @@ Tutorial @1:1-150:2 projectFiles: nil
 
     func testAnalyzeExternalNode() throws {
         let title = "unreferenced-tutorial"
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .external, title: title)
 
         let (_, context) = try testBundleAndContext(named: "TestBundle")
@@ -408,7 +408,7 @@ Tutorial @1:1-150:2 projectFiles: nil
     func testAnalyzeFragmentNode() throws {
         let title = "unreferenced-tutorial"
         let url = URL(fileURLWithPath: "/path/to/\(title)")
-        let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
+        let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .range(range, url: url) , title: title)
 
@@ -429,7 +429,7 @@ Tutorial @1:1-150:2 projectFiles: nil
     func testAnalyzeForValidParent() throws {
         func node(withTitle title: String, ofKind kind: DocumentationNode.Kind) -> TopicGraph.Node {
             let url = URL(fileURLWithPath: "/path/to/\(title)")
-            let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.TutorialArticleTests", path:  "/\(title)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TutorialArticleTests", path:  "/\(title)", sourceLanguage: .swift)
             let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
             return TopicGraph.Node(reference: reference, kind: kind, source: .range(range, url: url) , title: title)
         }

--- a/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -322,7 +322,7 @@ class VideoMediaTests: XCTestCase {
         var problems = [Problem]()
         let video = VideoMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
         let reference = ResolvedTopicReference(
-            bundleIdentifier: bundle.identifier,
+            bundleID: bundle.id,
             path: "",
             sourceLanguage: .swift
         )

--- a/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -102,7 +102,7 @@ class VolumeTests: XCTestCase {
 
         let node = try context.entity(
             with: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/tutorials/TestOverview",
                 sourceLanguage: .swift))
 

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -19,7 +19,7 @@ extension XCTestCase {
     /// Loads a documentation bundle from the given source URL and creates a documentation context.
     func loadBundle(
         from catalogURL: URL,
-        externalResolvers: [String: ExternalDocumentationSource] = [:],
+        externalResolvers: [DocumentationBundle.Identifier: ExternalDocumentationSource] = [:],
         externalSymbolResolver: GlobalExternalSymbolResolver? = nil,
         fallbackResolver: ConvertServiceFallbackResolver? = nil,
         diagnosticEngine: DiagnosticEngine = .init(filterLevel: .hint),
@@ -69,7 +69,7 @@ extension XCTestCase {
     func testBundleAndContext(
         copying name: String,
         excludingPaths excludedPaths: [String] = [],
-        externalResolvers: [BundleIdentifier : ExternalDocumentationSource] = [:],
+        externalResolvers: [DocumentationBundle.Identifier : ExternalDocumentationSource] = [:],
         externalSymbolResolver: GlobalExternalSymbolResolver? = nil,
         fallbackResolver: ConvertServiceFallbackResolver? = nil,
         diagnosticEngine: DiagnosticEngine = .init(filterLevel: .hint),
@@ -106,7 +106,7 @@ extension XCTestCase {
     
     func testBundleAndContext(
         named name: String,
-        externalResolvers: [String: ExternalDocumentationSource] = [:],
+        externalResolvers: [DocumentationBundle.Identifier: ExternalDocumentationSource] = [:],
         fallbackResolver: ConvertServiceFallbackResolver? = nil,
         configuration: DocumentationContext.Configuration = .init()
     ) throws -> (URL, DocumentationBundle, DocumentationContext) {
@@ -114,14 +114,14 @@ extension XCTestCase {
         return try loadBundle(from: catalogURL, externalResolvers: externalResolvers, fallbackResolver: fallbackResolver, configuration: configuration)
     }
     
-    func testBundleAndContext(named name: String, externalResolvers: [String: ExternalDocumentationSource] = [:]) throws -> (DocumentationBundle, DocumentationContext) {
+    func testBundleAndContext(named name: String, externalResolvers: [DocumentationBundle.Identifier: ExternalDocumentationSource] = [:]) throws -> (DocumentationBundle, DocumentationContext) {
         let (_, bundle, context) = try testBundleAndContext(named: name, externalResolvers: externalResolvers)
         return (bundle, context)
     }
     
     func renderNode(atPath path: String, fromTestBundleNamed testBundleName: String) throws -> RenderNode {
         let (bundle, context) = try testBundleAndContext(named: testBundleName)
-        let node = try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: path, sourceLanguage: .swift))
+        let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return try XCTUnwrap(translator.visit(node.semantic) as? RenderNode)
     }
@@ -142,7 +142,7 @@ extension XCTestCase {
         let bundle = DocumentationBundle(
             info: DocumentationBundle.Info(
                 displayName: "Test",
-                identifier: "com.example.test"
+                id: "com.example.test"
             ),
             baseURL: URL(string: "https://example.com/example")!,
             symbolGraphURLs: [],
@@ -273,7 +273,7 @@ extension XCTestCase {
             context: context,
             bundle: bundle,
             identifier: ResolvedTopicReference(
-                bundleIdentifier: bundle.identifier,
+                bundleID: bundle.id,
                 path: "/test-path-123",
                 sourceLanguage: .swift
             )

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionIndexerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionIndexerTests.swift
@@ -25,11 +25,11 @@ class ConvertActionIndexerTests: XCTestCase {
         
         // Add /documentation/MyKit to the index, verify the tree dump
         do {
-            let reference = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
             let renderNode = try converter.convert(context.entity(with: reference))
 
             let tempIndexURL = try createTemporaryDirectory(named: "index")
-            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, bundleIdentifier: bundle.identifier)
+            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, bundleID: bundle.id)
             indexer.index(renderNode)
             XCTAssertTrue(indexer.finalize(emitJSON: false, emitLMDB: false).isEmpty)
             let treeDump = try XCTUnwrap(indexer.dumpTree())
@@ -47,14 +47,14 @@ class ConvertActionIndexerTests: XCTestCase {
         // Add two nodes /documentation/MyKit and /documentation/Test-Bundle/Default-Code-Listing-Syntax to the index
         // and verify the tree.
         do {
-            let reference1 = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
+            let reference1 = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
             let renderNode1 = try converter.convert(context.entity(with: reference1))
 
-            let reference2 = ResolvedTopicReference(bundleIdentifier: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", sourceLanguage: .swift)
+            let reference2 = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", sourceLanguage: .swift)
             let renderNode2 = try converter.convert(context.entity(with: reference2))
 
             let tempIndexURL = try createTemporaryDirectory(named: "index")
-            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, bundleIdentifier: bundle.identifier)
+            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, bundleID: bundle.id)
             indexer.index(renderNode1)
             indexer.index(renderNode2)
             XCTAssertTrue(indexer.finalize(emitJSON: false, emitLMDB: false).isEmpty)

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1754,7 +1754,7 @@ class ConvertActionTests: XCTestCase {
 
         struct TestReferenceResolver: ExternalDocumentationSource {
             func resolve(_ reference: TopicReference) -> TopicReferenceResolutionResult {
-                return .success(ResolvedTopicReference(bundleIdentifier: "com.example.test", path: reference.url!.path, sourceLanguage: .swift))
+                return .success(ResolvedTopicReference(bundleID: "com.example.test", path: reference.url!.path, sourceLanguage: .swift))
             }
 
             func entity(with reference: ResolvedTopicReference) -> LinkResolver.ExternalEntity {
@@ -2443,7 +2443,7 @@ class ConvertActionTests: XCTestCase {
         let expectedOutput = Folder(name: ".docc-build", content: [
             JSONFile(
                 name: "metadata.json",
-                content: BuildMetadata(bundleDisplayName: "TestBundle", bundleIdentifier: "com.test.example")
+                content: BuildMetadata(bundleDisplayName: "TestBundle", bundleID: "com.test.example")
             ),
         ])
         
@@ -2855,7 +2855,7 @@ class ConvertActionTests: XCTestCase {
 
         let bundle = try XCTUnwrap(context.bundle, "Should have registered the generated test bundle.")
         XCTAssertEqual(bundle.displayName, "MyKit")
-        XCTAssertEqual(bundle.identifier, "MyKit")
+        XCTAssertEqual(bundle.id, "MyKit")
     }
     
     func testConvertWithoutBundleErrorsForMultipleModulesSymbolGraph() async throws {
@@ -2933,7 +2933,7 @@ class ConvertActionTests: XCTestCase {
 
         let bundle = try XCTUnwrap(context.bundle, "Should have registered the generated test bundle.")
         XCTAssertEqual(bundle.displayName, "Something")
-        XCTAssertEqual(bundle.identifier, "com.example.test")
+        XCTAssertEqual(bundle.id, "com.example.test")
     }
 
     private func uniformlyPrintDiagnosticMessages(_ problems: [Problem]) -> String {

--- a/Tests/SwiftDocCUtilitiesTests/JSONEncodingRenderNodeWriterTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/JSONEncodingRenderNodeWriterTests.swift
@@ -32,7 +32,7 @@ class JSONEncodingRenderNodeWriterTests: XCTestCase {
             transformForStaticHostingIndexHTML: indexHTML
         )
         
-        let renderNode = RenderNode(identifier: .init(bundleIdentifier: "com.test", path: "/documentation/test", sourceLanguage: .swift), kind: .article)
+        let renderNode = RenderNode(identifier: .init(bundleID: "com.test", path: "/documentation/test", sourceLanguage: .swift), kind: .article)
         
         // We take precautions in case we deadlock to stop the execution with a failing code.
         // In case the original issue is present and we deadlock, we fatalError from a bg thread.

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -1059,7 +1059,7 @@ class MergeActionTests: XCTestCase {
                 JSONFile(name: "index.json", content: RenderIndex(interfaceLanguages: [:], includedArchiveIdentifiers: [identifier]))
             ]),
             
-            JSONFile(name: "metadata.json", content: BuildMetadata(bundleDisplayName: name, bundleIdentifier: identifier))
+            JSONFile(name: "metadata.json", content: BuildMetadata(bundleDisplayName: name, bundleID: DocumentationBundle.Identifier(rawValue: identifier)))
         ]
         
         return Folder(name: "\(name).doccarchive", content: content)

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -47,7 +47,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         let resolver = try OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: { errorMessage in
             XCTFail("No error output is expected for this test executable. Got:\n\(errorMessage)")
         })
-        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle")
+        XCTAssertEqual(resolver.bundleID, "com.test.bundle")
         #endif
     }
     
@@ -88,7 +88,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         )
         
         let resolver = try makeResolver(testMetadata)
-        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle")
+        XCTAssertEqual(resolver.bundleID, "com.test.bundle")
         
         // Resolve the reference
         let unresolved = TopicReference.unresolved(
@@ -197,7 +197,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             })
 
             return try OutOfProcessReferenceResolver(
-                bundleIdentifier: "com.test.bundle",
+                bundleID: "com.test.bundle",
                 server: server,
                 convertRequestIdentifier: "convert-id"
             )
@@ -267,7 +267,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         
         let resolver = try makeResolver(testMetadata)
         
-        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle")
+        XCTAssertEqual(resolver.bundleID, "com.test.bundle")
         
         // Resolve the symbol
         let (_, entity) = try XCTUnwrap(resolver.symbolReferenceAndEntity(withPreciseIdentifier: "abc123"), "Unexpectedly failed to resolve symbol")
@@ -393,7 +393,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             })
 
             return try OutOfProcessReferenceResolver(
-                bundleIdentifier: "com.test.bundle",
+                bundleID: "com.test.bundle",
                 server: server,
                 convertRequestIdentifier: "convert-id"
             )
@@ -423,14 +423,14 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             XCTAssertEqual(errorMessage, "Some error output\n")
             didReadErrorOutputExpectation.fulfill()
         })
-        XCTAssertEqual(resolver?.bundleIdentifier, "com.test.bundle")
+        XCTAssertEqual(resolver?.bundleID, "com.test.bundle")
         
         wait(for: [didReadErrorOutputExpectation], timeout: 20.0)
         #endif
     }
     
     func assertForwardsResolverErrors(resolver: OutOfProcessReferenceResolver, file: StaticString = #file, line: UInt = #line) throws {
-        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle", file: file, line: line)
+        XCTAssertEqual(resolver.bundleID, "com.test.bundle", file: file, line: line)
         let resolverResult = resolver.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.test.bundle/something")!)))
         guard case .failure(_, let error) = resolverResult else {
             XCTFail("Encountered an unexpected type of error.", file: file, line: line)
@@ -495,7 +495,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         })
         
         let resolver = try OutOfProcessReferenceResolver(
-            bundleIdentifier: "com.test.bundle", server: server, convertRequestIdentifier: "convert-id")
+            bundleID: "com.test.bundle", server: server, convertRequestIdentifier: "convert-id")
         
         try assertForwardsResolverErrors(resolver: resolver)
     }
@@ -674,7 +674,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         XCTAssert(FileManager.default.isExecutableFile(atPath: executableLocation.path))
         
         let resolver = try OutOfProcessReferenceResolver(processLocation: executableLocation, errorOutputHandler: { _ in })
-        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle")
+        XCTAssertEqual(resolver.bundleID, "com.test.bundle")
         
         XCTAssertThrowsError(try resolver.resolveInformationForTopicURL(URL(string: "doc://com.test.bundle/something")!)) {
             guard case OutOfProcessReferenceResolver.Error.executableSentBundleIdentifierAgain = $0 else {
@@ -720,7 +720,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         )
                 
         let resolver = try makeResolver(testMetadata)
-        XCTAssertEqual(resolver.bundleIdentifier, "com.test.bundle", file: file, line: line)
+        XCTAssertEqual(resolver.bundleID, "com.test.bundle", file: file, line: line)
 
         // Resolve the reference
         let unresolved = TopicReference.unresolved(
@@ -826,7 +826,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
             })
 
             return try OutOfProcessReferenceResolver(
-                bundleIdentifier: "com.test.bundle",
+                bundleID: "com.test.bundle",
                 server: server,
                 convertRequestIdentifier: "convert-id"
             )

--- a/Tests/SwiftDocCUtilitiesTests/SemanticAnalyzerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/SemanticAnalyzerTests.swift
@@ -57,7 +57,7 @@ class SemanticAnalyzerTests: XCTestCase {
     func testDoNotCrashOnInvalidContent() throws {
         let (bundle, context) = try loadBundle(catalog: catalogHierarchy)
         
-        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/Oops", sourceLanguage: .swift)))
+        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/Oops", sourceLanguage: .swift)))
     }
     
     func testWarningsAboutDirectiveSupport() throws {

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
@@ -331,7 +331,7 @@ class TestFileSystemTests: XCTestCase {
             let (bundle, _) = try DocumentationContext.InputsProvider(fileManager: fs)
                 .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/"), options: .init())
             XCTAssertEqual(bundle.displayName, "DisplayName", "Display name is read from Info.plist")
-            XCTAssertEqual(bundle.identifier, "com.example", "Identifier is read from Info.plist")
+            XCTAssertEqual(bundle.id, "com.example", "Identifier is read from Info.plist")
         }
          
         do {


### PR DESCRIPTION
- **Explanation:** This fixes a crash for certain developer input (see scope). The fix updates a lot of API to use strong types. This API change is a major reason for cherry picking, since other code on "main" will have the updated API.
- **Scope:** Crash when the developer provided bundle identifier (either via Info.plist value, command line argument, or derived from catalog name) contains spaces or other characters that aren't valid URL host components. 
- **Issue:** rdar://135335645 
- **Risk:** Low. 
- **Testing:** New tests verify that developer provided input is transformed into valid URL host components.
- **Reviewer:** @sofiaromorales 
- **Original PR:** #1069 
