### PR TITLE
[6.1] Remove beta tag from unavailable symbols. (#1121)

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -214,16 +214,12 @@ public class DocumentationContentRenderer {
         guard let symbol = node.semantic as? Symbol,
               let currentPlatforms = documentationContext.configuration.externalMetadata.currentPlatforms,
               !currentPlatforms.isEmpty,
-              let symbolAvailability = symbol.availability?.availability,
+              let symbolAvailability = symbol.availability?.availability.filter({ !$0.isUnconditionallyUnavailable }), // symbol that's unconditionally unavailable in all the platforms can't be in beta.
               !symbolAvailability.isEmpty // A symbol without availability items can't be in beta.
         else { return false }
 
         // Verify that if current platforms are in beta, they match the introduced version of the symbol
         for availability in symbolAvailability {
-            // If not available on this platform, skip to next platform.
-            guard !availability.isUnconditionallyUnavailable else {
-                continue
-            }
 
             // If the symbol doesn't have an introduced version for one of those platforms, we don't consider it "in beta".
             guard let introduced = availability.introducedVersion else {

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -2088,6 +2088,19 @@ Document
             // Verify task group link is not in beta because `iOS` does not have an introduced version
             XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass"] as? TopicRenderReference)?.isBeta, false)
         }
+        
+        // Set all platforms as unconditionally unavailable and test that the symbol is not marked as beta.
+        do {
+            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+                "iOS": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
+            ], referencePath: "/documentation/MyKit/MyClass")
+            let node = try context.entity(with: reference)
+            (node.semantic as? Symbol)?.availability = SymbolGraph.Symbol.Availability(availability: [.init(domain: SymbolGraph.Symbol.Availability.Domain(rawValue: "iOS"), introducedVersion: nil, deprecatedVersion: nil, obsoletedVersion: nil, message: nil, renamed: nil, isUnconditionallyDeprecated: false, isUnconditionallyUnavailable: true, willEventuallyBeDeprecated: false)])
+            let documentationContentRendered = DocumentationContentRenderer(documentationContext: context, bundle: bundle)
+            let isBeta = documentationContentRendered.isBeta(node)
+            // Verify that the symbol is not beta since it's unavailable in all the platforms.
+            XCTAssertFalse(isBeta)
+        }
     }
     
     func testRendersDeprecatedViolator() throws {


### PR DESCRIPTION
* **Explanation:**  Symbols that are unconditionally unavailable in all the platforms should not be tagged as beta. Before this fix the `isBeta` logic was returning true for symbols that were unavailable in all the platforms. Now is filtering out these platforms before assessing if it's beta or not.
* **Scope:** Symbol availability information.
* **Issue:** rdar://140415995
* **Risk:** Low
* **Testing:** New tests added to verify that a symbol is not marked in beta if all the platforms are unavailable.
* **Reviewer:** @d-ronnqvist 
* **Original PR:** https://github.com/swiftlang/swift-docc/pull/1121
