### PR TITLE
Display concrete examples of the different types of asides

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/other-formatting-options.md
+++ b/Sources/docc/DocCDocumentation.docc/other-formatting-options.md
@@ -14,13 +14,15 @@ configuration. For those situations, use an aside.
 
 DocC supports the following types of asides:
 
-| Type | Usage |
-| ----- | ------ |
-| Note | General information that applies to some users. |
-| Important | Important information, such as a requirement. |
-| Warning | Critical information, like potential data loss or an irrecoverable state. |
-| Tip | Helpful information, such as shortcuts, suggestions, or hints. |
-| Experiment | Instructional information to reinforce a learning objective, or to encourage developers to try out different parts of your framework. |
+> Note: General information that applies to some users.
+
+> Important: Important information, such as a requirement.
+
+> Warning: Critical information, like potential data loss or an irrecoverable state.
+
+> Tip: Helpful information, such as shortcuts, suggestions, or hints.
+
+> Experiment: Instructional information to reinforce a learning objective, or to encourage developers to try out different parts of your framework.
 
 To create an aside, begin a new line with a greater-than symbol (`>`), add a space, 
 the type of the aside, a colon (`:`), and the content of the aside.


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

## Summary

Make it easier to pick which aside to use by showing the types of asides inline in the doc page visually.

<img width="885" alt="Screenshot of the updated doc page" src="https://github.com/user-attachments/assets/9010dbbb-05cf-49a1-b7c2-e8af4a9d0945">


## Dependencies

None.

## Testing

Build the DocC documentation catalog and preview it.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- Added tests (N/A)
- Ran the `./bin/test` script and it succeeded (tests not working on my machine but this should be NFC)
- [x] Updated documentation if necessary
