### PR TITLE
Parse Swift operators as link components for operators with symbol diacritics

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -588,6 +588,12 @@ private extension Unicode.Scalar {
             0x2041 ... 0x2053,
             // ⁕ ⁖ ⁗ ⁘ ⁙ ⁚ ⁛ ⁜ ⁝ ⁞
             0x2055 ... 0x205E,
+            // Arrows
+            0x2190 ... 0x21FF,
+            // Mathematical Operators
+            0x2200 ... 0x22FF,
+            // Miscellaneous Technical
+            0x2300 ... 0x23FF,
             // Box Drawing
             0x2500 ... 0x257F,
             // Block Elements

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3453,6 +3453,9 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("MyNumber//=(_:_:)", [("MyNumber", nil), ("/=(_:_:)", nil)])
         assertParsedPathComponents("MyNumber////=(_:_:)", [("MyNumber", nil), ("///=(_:_:)", nil)])
         assertParsedPathComponents("MyNumber/+/-(_:_:)", [("MyNumber", nil), ("+/-(_:_:)", nil)])
+        
+        // "☜⃩" is a symbol with a symbol diacritic mark.
+        assertParsedPathComponents("☜⃩/(_:_:)", [("☜⃩/(_:_:)", nil)])
 
         // Check parsing return values and parameter types
         assertParsedPathComponents("..<(_:_:)->Bool", [("..<(_:_:)", .typeSignature(parameterTypes: nil, returnTypes: ["Bool"]))])


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This fixes a very rare and unlikely bug where a Swift operator that contains both a symbol with a diacritic and a forward slash wouldn't parse as a symbol link correctly.

## Dependencies

None.

## Testing

Define a custom `☜⃩/` infix operator and link to it using `☜⃩/(_:_:)`. The link should resolve.

```swift
infix operator ☜⃩/ : DefaultPrecedence

/// This link should resolve ``☜⃩/(_:_:)``
public struct Something {
    public static func ☜⃩/ (lhs: Self, rhs: Self) -> Bool { 
        false
    }
}
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable.
