### PR TITLE
Support `@Metadata` and `@DeprecationSummary` in documentation commen…

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
@@ -69,6 +69,12 @@ public extension Diagnostic {
     mutating func offsetWithRange(_ docRange: SymbolGraph.LineList.SourceRange) {
         // If there is no location information in the source diagnostic, the diagnostic might be removed for safety reasons.
         range?.offsetWithRange(docRange)
-        
+    }
+    
+    /// Returns the diagnostic with its range offset by the given documentation comment range.
+    func withRangeOffset(by docRange: SymbolGraph.LineList.SourceRange) -> Self {
+        var diagnostic = self
+        diagnostic.range?.offsetWithRange(docRange)
+        return diagnostic
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Problem.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Problem.swift
@@ -42,6 +42,13 @@ extension Problem {
             }
         }
     }
+    
+    /// Returns the diagnostic with its range offset by the given documentation comment range.
+    func withRangeOffset(by docRange: SymbolGraph.LineList.SourceRange) -> Self {
+        var problem = self
+        problem.offsetWithRange(docRange)
+        return problem
+    }
 }
 
 extension Sequence<Problem> {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1048,7 +1048,11 @@ public class DocumentationContext {
     /// A lookup of resolved references based on the reference's absolute string.
     private(set) var referenceIndex = [String: ResolvedTopicReference]()
     
-    private func nodeWithInitializedContent(reference: ResolvedTopicReference, match foundDocumentationExtension: DocumentationContext.SemanticResult<Article>?) -> DocumentationNode {
+    private func nodeWithInitializedContent(
+        reference: ResolvedTopicReference,
+        match foundDocumentationExtension: DocumentationContext.SemanticResult<Article>?,
+        bundle: DocumentationBundle
+    ) -> DocumentationNode {
         guard var updatedNode = documentationCache[reference] else {
             fatalError("A topic reference that has already been resolved should always exist in the cache.")
         }
@@ -1056,7 +1060,9 @@ public class DocumentationContext {
         // Pull a matched article out of the cache and attach content to the symbol
         updatedNode.initializeSymbolContent(
             documentationExtension: foundDocumentationExtension?.value,
-            engine: diagnosticEngine
+            engine: diagnosticEngine,
+            bundle: bundle,
+            context: self
         )
 
         // After merging the documentation extension into the symbol, warn about deprecation summary for non-deprecated symbols.
@@ -1399,7 +1405,11 @@ public class DocumentationContext {
                 Array(documentationCache.symbolReferences).concurrentMap { finalReference in
                     // Match the symbol's documentation extension and initialize the node content.
                     let match = uncuratedDocumentationExtensions[finalReference]
-                    let updatedNode = nodeWithInitializedContent(reference: finalReference, match: match)
+                    let updatedNode = nodeWithInitializedContent(
+                        reference: finalReference,
+                        match: match,
+                        bundle: bundle
+                    )
                     
                     return ((
                         node: updatedNode,

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -129,19 +129,16 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
             return Redirect(from: childDirective, source: source, for: bundle, in: context, problems: &problems)
         }
         
-        let metadata: [Metadata]
-        (metadata, remainder) = remainder.categorize { child -> Metadata? in
-            guard let childDirective = child as? BlockDirective, childDirective.name == Metadata.directiveName else {
-                return nil
-            }
-            return Metadata(from: childDirective, source: source, for: bundle, in: context)
-        }
-        
-        for extraMetadata in metadata.dropFirst() {
-            problems.append(Problem(diagnostic: Diagnostic(source: source, severity: .warning, range: extraMetadata.originalMarkup.range, identifier: "org.swift.docc.HasAtMostOne<\(Article.self), \(Metadata.self)>.DuplicateChildren", summary: "Duplicate \(Metadata.directiveName.singleQuoted) child directive", explanation: nil, notes: []), possibleSolutions: []))
-        }
-        
-        var optionalMetadata = metadata.first
+        var optionalMetadata = DirectiveParser()
+            .parseSingleDirective(
+                Metadata.self,
+                from: &remainder,
+                parentType: Article.self,
+                source: source,
+                bundle: bundle,
+                context: context,
+                problems: &problems
+            )
 
         // Append any redirects found in the metadata to the redirects
         // found in the main content.

--- a/Sources/SwiftDocC/Semantics/DirectiveParser.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveParser.swift
@@ -1,0 +1,68 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Markdown
+
+/// A utlity type for parsing directives from markup.
+struct DirectiveParser<Directive: AutomaticDirectiveConvertible> {
+    
+    /// Returns a directive of the given type if found in the given sequence of markup elements and the remaining markup.
+    ///
+    /// If there are multiple instances of the same directive type, this functions returns the first instance
+    /// and diagnoses subsequent instances.
+    func parseSingleDirective(
+        _ directiveType: Directive.Type,
+        from markupElements: inout [any Markup],
+        parentType: Semantic.Type,
+        source: URL?,
+        bundle: DocumentationBundle,
+        context: DocumentationContext,
+        problems: inout [Problem]
+    ) -> Directive? {
+        let (directiveElements, remainder) = markupElements.categorize { markup -> Directive? in
+            guard let childDirective = markup as? BlockDirective,
+                  childDirective.name == Directive.directiveName
+            else {
+                return nil
+            }
+            return Directive(
+                from: childDirective,
+                source: source,
+                for: bundle,
+                in: context,
+                problems: &problems
+            )
+        }
+        
+        let directive = directiveElements.first
+        
+        for extraDirective in directiveElements.dropFirst() {
+            problems.append(
+                Problem(
+                    diagnostic: Diagnostic(
+                        source: source,
+                        severity: .warning,
+                        range: extraDirective.originalMarkup.range,
+                        identifier: "org.swift.docc.HasAtMostOne<\(parentType), \(Directive.self)>.DuplicateChildren",
+                        summary: "Duplicate \(Metadata.directiveName.singleQuoted) child directive",
+                        explanation: nil,
+                        notes: []
+                    ),
+                    possibleSolutions: []
+                )
+            )
+        }
+        
+        markupElements = remainder
+        
+        return directive
+    }
+}

--- a/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
@@ -24,7 +24,9 @@ import Markdown
 /// }
 /// ```
 ///
-/// You can use the `@DeprecationSummary` directive top-level in both articles and documentation extension files.
+/// You can use the `@DeprecationSummary` directive top-level in articles, documentation extension files, or documentation comments.
+///
+/// > Earlier versions: Before Swift-DocC 6.1, `@DeprecationSummary` was not supported in documentation comments.
 ///
 /// > Tip:
 /// > If you are writing a custom deprecation summary message for an API or documentation page that isn't already deprecated,

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -2033,7 +2033,13 @@
             "text" : ""
           },
           {
-            "text" : "You can use the `@DeprecationSummary` directive top-level in both articles and documentation extension files."
+            "text" : "You can use the `@DeprecationSummary` directive top-level in articles, documentation extension files, or documentation comments."
+          },
+          {
+            "text" : ""
+          },
+          {
+            "text" : "> Earlier versions: Before Swift-DocC 6.1, `@DeprecationSummary` was not supported in documentation comments."
           },
           {
             "text" : ""

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -56,6 +56,17 @@ to add additional URLs for a page.
 > Note: Starting with version 6.0, @Redirected is supported as a child directive of @Metadata. In
 previous versions, @Redirected must be used as a top level directive.
 
+### Usage in documentation comments
+
+You can specify `@Metadata` configuration in documentation comments to specify ``Available`` directives. Other metadata directives are 
+not supported in documentation comments.  
+
+> Note: Don't specify an `@Metadata` directive in both the symbol's documentation comment and its documentation extension file.
+If you have one in each, DocC will pick the one in the documentation extension and discard the one in the documentation
+comment.
+
+> Earlier versions: Before Swift-DocC 6.1, `@Metadata` was not supported in documentation comments.
+
 ## Topics
 
 ### Extending or Overriding Source Documentation

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -314,9 +314,13 @@ class MetadataTests: XCTestCase {
         XCTAssertNotNil(article?.metadata, "The Article has the parsed Metadata")
         XCTAssertNil(article?.metadata?.displayName, "The Article doesn't have the DisplayName")
         
-        XCTAssertEqual(1, problems.count)
-        XCTAssertEqual("org.swift.docc.HasAtMostOne<Article, Metadata>.DuplicateChildren", problems.first?.diagnostic.identifier)
-        
+        XCTAssertEqual(
+            problems.map(\.diagnostic.identifier),
+            [
+                "org.swift.docc.DocumentationExtension.NoConfiguration",
+                "org.swift.docc.HasAtMostOne<Article, Metadata>.DuplicateChildren",
+            ]
+        )
     }
     
     func testPageImageSupport() throws {
@@ -416,10 +420,7 @@ class MetadataTests: XCTestCase {
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
         let (bundle, context) = try testBundleAndContext(named: "TestBundle")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
-        _ = analyzer.visit(document)
-        var problems = analyzer.problems
-        
+        var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
         
         let problemIDs = problems.map { problem -> String in

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1198,22 +1198,183 @@ class SymbolTests: XCTestCase {
         // Declaration fragments should remain unchanged
         XCTAssertEqual(1, withoutArticle.declarationVariants[trait]!.count)
     }
+    
+    func testParsesMetadataDirectiveFromDocComment() throws {
+        let (node, problems) = try makeDocumentationNodeForSymbol(
+            docComment: """
+                The symbol's abstract.
+
+                @Metadata {
+                  @Available(customOS, introduced: 1.2.3)
+                }
+                """,
+            articleContent: nil
+        )
+        
+        XCTAssert(problems.isEmpty)
+        
+        let availability = try XCTUnwrap(node.metadata?.availability.first)
+        XCTAssertEqual(availability.platform, .other("customOS"))
+        XCTAssertEqual(availability.introduced.description, "1.2.3")
+    }
+    
+    func testEmitsWarningsInMetadataDirectives() throws {
+        let (_, problems) = try makeDocumentationNodeForSymbol(
+            docComment: """
+                The symbol's abstract.
+
+                @Metadata
+                """,
+            docCommentLineOffset: 12,
+            articleContent: nil,
+            diagnosticEngineFilterLevel: .information
+        )
+        
+        XCTAssertEqual(problems.count, 1)
+        
+        let diagnostic = try XCTUnwrap(problems.first).diagnostic
+        XCTAssertEqual(diagnostic.identifier, "org.swift.docc.Metadata.NoConfiguration")
+        XCTAssertEqual(diagnostic.source?.absoluteString, "file:///tmp/File.swift")
+        XCTAssertEqual(diagnostic.range?.lowerBound.line, 15)
+        XCTAssertEqual(diagnostic.range?.lowerBound.column, 1)
+    }
+    
+    func testEmitsWarningForDuplicateMetadata() throws {
+        let (node, problems) = try makeDocumentationNodeForSymbol(
+            docComment: """
+                The symbol's abstract.
+
+                @Metadata {
+                  @Available("Platform from doc comment", introduced: 1.2.3)
+                }
+                """,
+            docCommentLineOffset: 12,
+            articleContent: """
+            # Title
+            
+            @Metadata {
+              @Available("Platform from documentation extension", introduced: 1.2.3)
+            }
+            """
+        )
+        
+        XCTAssertEqual(problems.count, 1)
+        
+        let diagnostic = try XCTUnwrap(problems.first).diagnostic
+        XCTAssertEqual(diagnostic.identifier, "org.swift.docc.DuplicateMetadata")
+        XCTAssertEqual(diagnostic.source?.absoluteString, "file:///tmp/File.swift")
+        XCTAssertEqual(diagnostic.range?.lowerBound.line, 15)
+        XCTAssertEqual(diagnostic.range?.lowerBound.column, 1)
+        
+        let availability = try XCTUnwrap(node.metadata?.availability.first)
+        XCTAssertEqual(availability.platform, .other("Platform from documentation extension"))
+    }
+    
+    func testEmitsWarningsForInvalidMetadataChildrenInDocumentationComments() throws {
+        let (_, problems) = try makeDocumentationNodeForSymbol(
+            docComment: """
+                The symbol's abstract.
+
+                @Metadata {
+                  @Available("Platform from doc comment", introduced: 1.2.3)
+                  @CustomMetadata(key: "key", value: "value")
+                  
+                  @Comment(The directives below this are invalid in documentation comments)
+                
+                  @DocumentationExtension(mergeBehavior: override)
+                  @TechnologyRoot
+                  @DisplayName(Title)
+                  @PageImage(source: test, purpose: icon)
+                  @CallToAction(url: "https://example.com/sample.zip", purpose: download)
+                  @PageKind(sampleCode)
+                  @SupportedLanguage(swift)
+                  @PageColor(orange)
+                  @TitleHeading("Release Notes")
+                  @Redirected(from: "old/path/to/this/page")
+                }
+                """,
+            articleContent: nil
+        )
+        
+        XCTAssertEqual(
+            Set(problems.map(\.diagnostic.identifier)),
+            [
+                "org.swift.docc.Metadata.InvalidDocumentationExtensionInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidTechnologyRootInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidDisplayNameInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidPageImageInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidCallToActionInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidPageKindInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidSupportedLanguageInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidPageColorInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidTitleHeadingInDocumentationComment",
+                "org.swift.docc.Metadata.InvalidRedirectedInDocumentationComment",
+            ]
+        )
+    }
+    
+    func testParsesDeprecationSummaryDirectiveFromDocComment() throws {
+        let (node, problems) = try makeDocumentationNodeForSymbol(
+            docComment: """
+                The symbol's abstract.
+
+                @DeprecationSummary {
+                  This is the deprecation summary.
+                }
+                """,
+            articleContent: nil
+        )
+        
+        XCTAssert(problems.isEmpty)
+        
+        XCTAssertEqual(
+            (node.semantic as? Symbol)?
+                .deprecatedSummary?
+                .content
+                .first?
+                .format()
+                .trimmingCharacters(in: .whitespaces)
+            ,
+            "This is the deprecation summary."
+        )
+    }
+    
+    func testAllowsCommentDirectiveInDocComment() throws {
+        let (_, problems) = try makeDocumentationNodeForSymbol(
+            docComment: """
+                The symbol's abstract.
+
+                @Comment(This is a comment)
+                """,
+            articleContent: nil
+        )
+        
+        XCTAssert(problems.isEmpty)
+    }
 
     // MARK: - Helpers
     
-    func makeDocumentationNodeSymbol(docComment: String, articleContent: String?, file: StaticString = #file, line: UInt = #line) throws -> (Symbol, [Problem]) {
+    func makeDocumentationNodeForSymbol(
+        docComment: String,
+        docCommentLineOffset: Int = 0,
+        articleContent: String?,
+        diagnosticEngineFilterLevel: DiagnosticSeverity = .warning,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> (DocumentationNode, [Problem]) {
         let myFunctionUSR = "s:5MyKit0A5ClassC10myFunctionyyF"
         let (_, bundle, context) = try testBundleAndContext(copying: "TestBundle") { url in
             var graph = try JSONDecoder().decode(SymbolGraph.self, from: Data(contentsOf: url.appendingPathComponent("mykit-iOS.symbols.json")))
             
-            let newDocComment = SymbolGraph.LineList(docComment.components(separatedBy: .newlines).enumerated().map { arg -> SymbolGraph.LineList.Line in
-                let (index, line) = arg
-                let range = SymbolGraph.LineList.SourceRange(
-                    start: .init(line: index, character: 0),
-                    end: .init(line: index, character: line.utf8.count)
-                )
-                return .init(text: line, range: range)
-            })
+            let newDocComment = self.makeLineList(
+                docComment: docComment,
+                startOffset: .init(
+                    line: docCommentLineOffset,
+                    character: 0
+                ),
+                url: URL(string: "file:///tmp/File.swift")!
+            )
+            
             // The `guard` statement` below will handle the `nil` case by failing the test and
             graph.symbols[myFunctionUSR]?.docComment = newDocComment
             
@@ -1221,7 +1382,10 @@ class SymbolTests: XCTestCase {
             try newGraphData.write(to: url.appendingPathComponent("mykit-iOS.symbols.json"))
         }
         
-        guard let original = context.documentationCache[myFunctionUSR], let symbol = original.symbol, let symbolSemantic = original.semantic as? Symbol else {
+        guard let original = context.documentationCache[myFunctionUSR],
+              let unifiedSymbol = original.unifiedSymbol,
+              let symbolSemantic = original.semantic as? Symbol
+        else {
             XCTFail("Couldn't find the expected symbol", file: (file), line: line)
             enum TestHelperError: Error { case missingExpectedMyFuctionSymbol }
             throw TestHelperError.missingExpectedMyFuctionSymbol
@@ -1232,14 +1396,43 @@ class SymbolTests: XCTestCase {
             var problems = [Problem]()
             let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
             XCTAssertNotNil(article, "The sidecar Article couldn't be created.", file: (file), line: line)
-            XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))", file: (file), line: line)
             return article
         }
         
-        let engine = DiagnosticEngine()
-        let node = DocumentationNode(reference: original.reference, symbol: symbol, platformName: symbolSemantic.platformName.map { $0.rawValue }, moduleReference: symbolSemantic.moduleReference, article: article, engine: engine)
+        let engine = DiagnosticEngine(filterLevel: diagnosticEngineFilterLevel)
+        
+        var node = DocumentationNode(
+            reference: original.reference,
+            unifiedSymbol: unifiedSymbol,
+            moduleData: unifiedSymbol.modules.first!.value,
+            moduleReference: symbolSemantic.moduleReference
+        )
+        
+        node.initializeSymbolContent(
+            documentationExtension: article,
+            engine: engine,
+            bundle: bundle,
+            context: context
+        )
+        
+        return (node, engine.problems)
+    }
+    
+    func makeDocumentationNodeSymbol(
+        docComment: String,
+        articleContent: String?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> (Symbol, [Problem]) {
+        let (node, problems) = try makeDocumentationNodeForSymbol(
+            docComment: docComment,
+            articleContent: articleContent,
+            file: file,
+            line: line
+        )
+        
         let semantic = try XCTUnwrap(node.semantic as? Symbol)
-        return (semantic, engine.problems)
+        return (semantic, problems)
     }
 }
 


### PR DESCRIPTION
* **Explanation:**  Adds support for `@Metadata`, `@DeprecationSummary`, and `@Comment` to be used in documentation comments.
* **Scope:** Documentation comment parsing.
* **Issue:** rdar://138395778
* **Risk:** Low
* **Testing:** Added new unit tests.
* **Reviewer:** @sofiaromorales @d-ronnqvist 
* **Original PR:** #1107 
