### PR TITLE
Update Metadata article to include AlternateRepresentation

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
@@ -12,7 +12,7 @@ import Foundation
 import Markdown
 
 
-/// A directive that configures an alternate language representations of a symbol.
+/// A directive that configures an alternate language representation of a symbol.
 ///
 /// An API that can be called from more than one source language has more than one language representation.
 ///

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -75,7 +75,7 @@
       "docComment" : {
         "lines" : [
           {
-            "text" : "A directive that configures an alternate language representations of a symbol."
+            "text" : "A directive that configures an alternate language representation of a symbol."
           },
           {
             "text" : ""

--- a/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
+++ b/Sources/docc/DocCDocumentation.docc/Reference Syntax/API Reference Syntax/Metadata.md
@@ -89,6 +89,7 @@ comment.
 ### Customizing the Languages of an Article
 
 - ``SupportedLanguage``
+- ``AlternateRepresentation``
 
 ### Customizing the Availability Information of a Page
 


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

The `Metadata` article curates a list of its child directives, with relevant topic titles.

This adds `AlternateRepresentation` to that list, in the same section as `SupportedLanguage` as they both deal with language representations.

## Dependencies

N/A

## Testing

Tested by previewing the `DocCDocumentation.docc` catalog locally.

Steps:
1. `docc preview Sources/docc/DocCDocumentation.docc`
2. Verify http://localhost:8080/documentation/docc/metadata shows `AlternateRepresentation` in the topic list as expected.

<img width="1688" alt="Screenshot 2024-12-13 at 10 55 14" src="https://github.com/user-attachments/assets/887a4919-8ba5-413a-9f81-9eaba0f98250" />

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~~[ ] Added tests~~ -> Not applicable
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
