### PR TITLE
[6.1] Improve detection of inherited documentation comments for parameter and return validation

### DIFF
--- a/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
+++ b/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
@@ -278,13 +278,16 @@ struct ParametersAndReturnValidator {
     
     /// Checks if the symbol's documentation is inherited from another source location.
     private func hasInheritedDocumentationComment(symbol: UnifiedSymbolGraph.Symbol) -> Bool {
-        let symbolLocationURI = symbol.documentedSymbol?.mixins.getValueIfPresent(for: SymbolGraph.Symbol.Location.self)?.uri
-        for case .sourceCode(let location, _) in docChunkSources {
-            // Check if the symbol has documentation from another source location
-            return location?.uri != symbolLocationURI
+        guard let documentedSymbol = symbol.documentedSymbol else {
+            // If there's no doc comment, any documentation comes from an extension file and isn't inherited from another symbol.
+            return false
         }
-        // If the symbol didn't have any in-source documentation, check if there's a extension file override.
-        return docChunkSources.isEmpty
+        
+        // A symbol has inherited documentation if the doc comment doesn't come from the current module.
+        let moduleNames = symbol.modules.values.reduce(into: Set()) { $0.insert($1.name) }
+        return !moduleNames.contains(where: { moduleName in
+            documentedSymbol.isDocCommentFromSameModule(symbolModuleName: moduleName) == true
+        })
     }
     
     private typealias Signatures = [DocumentationDataVariantsTrait: SymbolGraph.Symbol.FunctionSignature]

--- a/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
@@ -47,6 +47,7 @@ extension XCTestCase {
     
     package func makeLineList(
         docComment: String,
+        moduleName: String?,
         startOffset: SymbolGraph.LineList.SourceRange.Position = defaultSymbolPosition,
         url: URL = defaultSymbolURL
     ) -> SymbolGraph.LineList {
@@ -64,7 +65,8 @@ extension XCTestCase {
                     )
                 },
             // We want to include the file:// scheme here
-            uri: url.absoluteString
+            uri: url.absoluteString,
+            moduleName: moduleName
         )
     }
     
@@ -83,6 +85,7 @@ extension XCTestCase {
         kind kindID: SymbolGraph.Symbol.KindIdentifier,
         pathComponents: [String],
         docComment: String? = nil,
+        moduleName: String? = nil,
         accessLevel: SymbolGraph.Symbol.AccessControl = .init(rawValue: "public"), // Defined internally in SwiftDocC
         location: (position: SymbolGraph.LineList.SourceRange.Position, url: URL)? = (defaultSymbolPosition, defaultSymbolURL),
         signature: SymbolGraph.Symbol.FunctionSignature? = nil,
@@ -109,6 +112,7 @@ extension XCTestCase {
             docComment: docComment.map {
                 makeLineList(
                     docComment: $0,
+                    moduleName: moduleName,
                     startOffset: location?.position ?? defaultSymbolPosition,
                     url: location?.url ?? defaultSymbolURL
                 )

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1368,6 +1368,7 @@ class SymbolTests: XCTestCase {
             
             let newDocComment = self.makeLineList(
                 docComment: docComment,
+                moduleName: nil,
                 startOffset: .init(
                     line: docCommentLineOffset,
                     character: 0


### PR DESCRIPTION
- **Explanation:** Improve detection of inherited documentation comments for parameter and return validation.
- **Scope:** Unactionable warnings when passing `--enable-inherited-docs` and inherited documentation comment contains warnings.
- **Issue:** rdar://134534169 
- **Risk:** Low. 
- **Testing:** New tests verify that warnings aren't emitted for inherited documentation comments. Manually tested with a small 2 target project and with the original project where that issue was reported for. Existing automated tests pass. 
- **Reviewer:** @patshaughnessy   
- **Original PR:** #1130 