### PR TITLE
Fix occasional missing breadcrumbs for some multi-language symbols

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver+Breadcrumbs.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver+Breadcrumbs.swift
@@ -25,12 +25,7 @@ extension PathHierarchyBasedLinkResolver {
         var node = pathHierarchy.lookup[nodeID]! // Only the path hierarchy can create its IDs and a created ID always matches a node
         
         func matchesRequestedLanguage(_ node: PathHierarchy.Node) -> Bool {
-            guard let symbol = node.symbol,
-                  let language = SourceLanguage(knownLanguageIdentifier: symbol.identifier.interfaceLanguage)
-            else {
-                return false
-            }
-            return language == sourceLanguage
+             node.languages.contains(sourceLanguage)
         }
         
         if !matchesRequestedLanguage(node) {

--- a/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Navigation Tree/RenderHierarchyTranslator.swift
@@ -207,7 +207,9 @@ struct RenderHierarchyTranslator {
         )
         
         for language in symbolReference.sourceLanguages where language != symbolReference.sourceLanguage {
-            guard let variantPathReferences = context.linkResolver.localResolver.breadcrumbs(of: symbolReference, in: language) else {
+            guard let variantPathReferences = context.linkResolver.localResolver.breadcrumbs(of: symbolReference, in: language),
+                  variantPathReferences != mainPathReferences
+            else {
                 continue
             }
             hierarchyVariants.variants.append(.init(

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class SymbolBreadcrumbTests: XCTestCase {
     func testLanguageSpecificBreadcrumbs() throws {
-        let (_, context) = try testBundleAndContext(named: "GeometricalShapes")
+        let (bundle, context) = try testBundleAndContext(named: "GeometricalShapes")
         let resolver = try XCTUnwrap(context.linkResolver.localResolver)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
@@ -22,7 +22,8 @@ class SymbolBreadcrumbTests: XCTestCase {
         //     CGFloat radius;
         // } TLACircle NS_SWIFT_NAME(Circle);
         do {
-            let reference = moduleReference.appendingPath("Circle/center")
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/Circle/center" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 2, "Symbol has 2 language representations")
             
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), [
                 "/documentation/GeometricalShapes",
@@ -32,11 +33,14 @@ class SymbolBreadcrumbTests: XCTestCase {
                 "/documentation/GeometricalShapes",
                 "/documentation/GeometricalShapes/Circle", // named TLACircle in Objective-C
             ])
+            
+            assertNoVariantsForRenderHierarchy(reference, context, bundle) // Same breadcrumbs in both languages
         }
         
         // extern const TLACircle TLACircleZero NS_SWIFT_NAME(Circle.zero);
         do {
-            let reference = moduleReference.appendingPath("Circle/zero")
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/Circle/zero" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 2, "Symbol has 2 language representations")
             
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), [
                 "/documentation/GeometricalShapes",
@@ -45,11 +49,14 @@ class SymbolBreadcrumbTests: XCTestCase {
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .objectiveC)?.map(\.path), [
                 "/documentation/GeometricalShapes", // The Objective-C representation is a top-level function
             ])
+            
+            assertHasSomeVariantsForRenderHierarchy(reference, context, bundle) // Different breadcrumbs in different languages
         }
         
         // BOOL TLACircleIntersects(TLACircle circle, TLACircle otherCircle) NS_SWIFT_NAME(Circle.intersects(self:_:));
         do {
-            let reference = moduleReference.appendingPath("Circle/intersects(_:)")
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/Circle/intersects(_:)" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 2, "Symbol has 2 language representations")
             
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), [
                 "/documentation/GeometricalShapes",
@@ -58,26 +65,100 @@ class SymbolBreadcrumbTests: XCTestCase {
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .objectiveC)?.map(\.path), [
                 "/documentation/GeometricalShapes", // The Objective-C representation is a top-level function
             ])
+            
+            assertHasSomeVariantsForRenderHierarchy(reference, context, bundle) // Different breadcrumbs in different languages
         }
 
         // TLACircle TLACircleMake(CGPoint center, CGFloat radius) NS_SWIFT_UNAVAILABLE("Use 'Circle.init(center:radius:)' instead.");
         do {
-            let reference = moduleReference.appendingPath("TLACircleMake")
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/TLACircleMake" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 1, "Symbol only has one language representation")
             
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), nil) // There is no Swift representation
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .objectiveC)?.map(\.path), [
                 "/documentation/GeometricalShapes", // The Objective-C representation is a top-level function
             ])
+            
+            assertNoVariantsForRenderHierarchy(reference, context, bundle) // Only has one language representation
         }
         
         do {
-            let reference = moduleReference.appendingPath("Circle/init(center:radius:)")
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/Circle/init(center:radius:)" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 1, "Symbol only has one language representation")
             
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), [
                 "/documentation/GeometricalShapes",
                 "/documentation/GeometricalShapes/Circle", // The Swift representation is a member
             ])
             XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .objectiveC)?.map(\.path), nil) // There is no Objective-C representation
+            
+            assertNoVariantsForRenderHierarchy(reference, context, bundle) // Only has one language representation
         }
+    }
+    
+    func testMixedLanguageSpecificBreadcrumbs() throws {
+        let (bundle, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+        let resolver = try XCTUnwrap(context.linkResolver.localResolver)
+        let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
+        
+        do {
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/MixedLanguageProtocol/mixedLanguageMethod()" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 2, "Symbol has 2 language representations")
+            
+            XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), [
+                "/documentation/MixedLanguageFramework",
+                "/documentation/MixedLanguageFramework/MixedLanguageProtocol",
+            ])
+            XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .objectiveC)?.map(\.path), [
+                "/documentation/MixedLanguageFramework",
+                "/documentation/MixedLanguageFramework/MixedLanguageProtocol",
+            ])
+            
+            assertNoVariantsForRenderHierarchy(reference, context, bundle) // Same breadcrumbs in both languages
+        }
+        do {
+//            let reference = moduleReference.appendingPath("MixedLanguageProtocol")
+            let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/MixedLanguageProtocol" }))
+            XCTAssertEqual(reference.sourceLanguages.count, 2, "Symbol has 2 language representations")
+            
+            XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .swift)?.map(\.path), [
+                "/documentation/MixedLanguageFramework",
+            ])
+            XCTAssertEqual(resolver.breadcrumbs(of: reference, in: .objectiveC)?.map(\.path), [
+                "/documentation/MixedLanguageFramework",
+            ])
+            
+            assertNoVariantsForRenderHierarchy(reference, context, bundle) // Same breadcrumbs in both languages
+        }
+    }
+    
+    // MARK: Test helpers
+    
+    private func assertNoVariantsForRenderHierarchy(
+        _ reference: ResolvedTopicReference,
+        _ context: DocumentationContext,
+        _ bundle: DocumentationBundle,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        var hierarchyTranslator = RenderHierarchyTranslator(context: context, bundle: bundle)
+        let hierarchyVariants = hierarchyTranslator.visitSymbol(reference)
+        
+        XCTAssertNotNil(hierarchyVariants.defaultValue, "Should always have default breadcrumbs", file: file, line: line)
+        XCTAssert(hierarchyVariants.variants.isEmpty, "No need for variants when value is same in Swift and Objective-C", file: file, line: line)
+    }
+    
+    private func assertHasSomeVariantsForRenderHierarchy(
+        _ reference: ResolvedTopicReference,
+        _ context: DocumentationContext,
+        _ bundle: DocumentationBundle,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        var hierarchyTranslator = RenderHierarchyTranslator(context: context, bundle: bundle)
+        let hierarchyVariants = hierarchyTranslator.visitSymbol(reference)
+        
+        XCTAssertNotNil(hierarchyVariants.defaultValue, "Should always have default breadcrumbs", file: file, line: line)
+        XCTAssertFalse(hierarchyVariants.variants.isEmpty, "Either language needs a variant when value is different in Swift and Objective-C", file: file, line: line)
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
@@ -117,7 +117,6 @@ class SymbolBreadcrumbTests: XCTestCase {
             assertNoVariantsForRenderHierarchy(reference, context, bundle) // Same breadcrumbs in both languages
         }
         do {
-//            let reference = moduleReference.appendingPath("MixedLanguageProtocol")
             let reference = try XCTUnwrap(context.knownPages.first(where: { $0.path == "\(moduleReference.path)/MixedLanguageProtocol" }))
             XCTAssertEqual(reference.sourceLanguages.count, 2, "Symbol has 2 language representations")
             

--- a/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
@@ -157,7 +157,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
             
             XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
             
-            let reference = ResolvedTopicReference(bundleIdentifier: bundle.identifier, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/functionName(...)", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             

--- a/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
@@ -179,10 +179,7 @@ class RenderHierarchyTranslatorTests: XCTestCase {
                 "doc://GeometricalShapes/documentation/GeometricalShapes",
                 "doc://GeometricalShapes/documentation/GeometricalShapes/Circle",
             ],
-            expectedObjectiveCPaths: [
-                "doc://GeometricalShapes/documentation/GeometricalShapes",
-                "doc://GeometricalShapes/documentation/GeometricalShapes/Circle", // named TLACircle in Objective-C
-            ]
+            expectedObjectiveCPaths: nil // Same in both languages. Only encoded once.
         )
 
         // extern const TLACircle TLACircleZero NS_SWIFT_NAME(Circle.zero);


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://141365081

## Summary

This fixes an issue where breadcrumbs would sometimes be missing in either language for some symbols with multiple language representations.

## Dependencies

None.

## Testing

This issue reproduces very inconsistently. You may need to repeat these steps tens of times (or more) to reproduce it.

For any project with a handful of symbols available in both Swift and ObjectiveC:
- Build and preview documentation 
- For a few different pages with multiple language representations:
  - Verify that the Swift representation has breadcrumbs on the rendered page.
  - Verify that the Objective-C representation has breadcrumbs on the rendered page.
- Repeat

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
