### PR TITLE
Omit Swift tuple labels in type signature disambiguation

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -54,6 +54,9 @@ extension PathHierarchy {
         
         // Iterating over the declaration fragments to accumulate their spelling and to identify places that need to apply syntactic sugar.
         var markers = ContiguousArray<Int>()
+        // Track the current [], (), and <> scopes to identify when ":" is a part of the type name.
+        var swiftBracketsStack = SwiftBracketsStack()
+        
         for fragment in fragments {
             let preciseIdentifier = fragment.preciseIdentifier
             if isSwift {
@@ -84,17 +87,30 @@ extension PathHierarchy {
                     // Accumulate all of the identifier tokens' spelling.
                     accumulated.append(contentsOf: fragment.spelling.utf8)
                     
-                case .text: // In Swift, only `text` tokens contains whitespace so they're handled separately.
-                    // Text tokens like "[", "?", "<", "...", ",", "(", "->" etc. contribute to the type spellings like
+                case .text: // In Swift, we're only want some `text` tokens characters in the type disambiguation.
+                    // For example: "[", "?", "<", "...", ",", "(", "->" etc. contribute to the type spellings like
                     // `[Name]`, `Name?`, "Name<T>", "Name...", "()", "(Name, Name)", "(Name)->Name" and more.
-                    var spelling = fragment.spelling.utf8[...]
-                    // If the type spelling is a parameter, if often starts with a leading ":" that's not part of the type name.
-                    if accumulated.isEmpty, spelling.first == colon {
-                        _ = spelling.removeFirst()
-                    }
-                    
-                    // Ignore whitespace in text tokens. Here we use a loop instead of `filter` to avoid a potential temporary allocation.
-                    for char in spelling where char != space {
+                    for char in fragment.spelling.utf8 {
+                        switch char {
+                        case openAngle:
+                            swiftBracketsStack.push(.angle)
+                        case openParen:
+                            swiftBracketsStack.push(.paren)
+                        case openSquare:
+                            swiftBracketsStack.push(.square)
+                            
+                        case closeAngle, closeParen, closeSquare:
+                            swiftBracketsStack.pop()
+                            
+                        case colon where swiftBracketsStack.isCurrentScopeSquareBracket,
+                             comma, fullStop, question, hyphen:
+                            break // Include this character
+                            
+                        default:
+                            continue // Skip this character
+                        }
+                        
+                        // Unless the switch-statement (above) continued the next iteration, add this character to the accumulated type spelling.
                         accumulated.append(char)
                     }
                     
@@ -158,6 +174,33 @@ extension PathHierarchy {
             String(cString: pointer.baseAddress!)
         }
     }
+    
+    /// A small helper type that tracks the scope of nested brackets; `()`, `[]`, or `<>`.
+    private struct SwiftBracketsStack {
+        enum Bracket {
+            case angle  // <>
+            case square // []
+            case paren  // ()
+        }
+        private var stack: ContiguousArray<Bracket>
+        init() {
+            stack = []
+            stack.reserveCapacity(32) // Some temporary space to work with.
+        }
+        
+        /// Push a new bracket scope to the stack.
+        mutating func push(_ scope: Bracket) {
+            stack.append(scope)
+        }
+        /// Pop the current bracket scope from the stack.
+        mutating func pop() {
+            _ = stack.popLast()
+        }
+        /// A Boolean value that indicates whether the current scope is square brackets.
+        var isCurrentScopeSquareBracket: Bool {
+            stack.last == .square
+        }
+    }
 }
 
 // A collection of UInt8 raw values for various UTF-8 characters that this implementation frequently checks for
@@ -176,6 +219,7 @@ private let openParen   = UTF8.CodeUnit(ascii: "(")
 private let closeParen  = UTF8.CodeUnit(ascii: ")")
 
 private let comma       = UTF8.CodeUnit(ascii: ",")
+private let fullStop    = UTF8.CodeUnit(ascii: ".")
 private let question    = UTF8.CodeUnit(ascii: "?")
 private let colon       = UTF8.CodeUnit(ascii: ":")
 private let hyphen      = UTF8.CodeUnit(ascii: "-")

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -100,6 +100,7 @@ extension PathHierarchy {
                             swiftBracketsStack.push(.square)
                             
                         case closeAngle, closeParen, closeSquare:
+                            assert(!swiftBracketsStack.isEmpty, "Unexpectedly found more closing brackets than open brackets in \(String(cString: accumulated + [0]) + fragment.spelling)")
                             swiftBracketsStack.pop()
                             
                         case colon where swiftBracketsStack.isCurrentScopeSquareBracket,
@@ -199,6 +200,10 @@ extension PathHierarchy {
         /// A Boolean value that indicates whether the current scope is square brackets.
         var isCurrentScopeSquareBracket: Bool {
             stack.last == .square
+        }
+        
+        var isEmpty: Bool {
+            stack.isEmpty
         }
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://142822416

## Summary

This omits Swift tuple labels in DocC's type signature disambiguation so that a `(one: Int, two: Bool)` return value is disambiguated using `->(Int,Bool)` instead of `->(one:Int,two:Bool)`.

**Note:** Swift _does_ support overloading based on tuple labels, so there is an argument to be made for including it in the disambiguation. 
```swift
func something() -> (first: Int, second: Bool)
func something() -> (one:   Int, two:    Bool)
```

However, I believe that it's a much more common—but still fairly uncommon—to have overloads with different _types_ (including tuple element types) rather than different _tuple labels_ and that it's better to optimize the experience for that. For example; 
The Swift standard library has two `insert(_:)`overloads that return labeled tuples:
- [`mutating func insert(_ newMember: Element) -> (inserted: Bool, memberAfterInsert: Element)`](https://developer.apple.com/documentation/swift/set/insert(_:)-nads)
- [`mutating func insert<ConcreteElement>(_ newMember: ConcreteElement) -> (inserted: Bool, memberAfterInsert: ConcreteElement)`](https://developer.apple.com/documentation/swift/set/insert(_:)-yar4)

Without tuple labels in the disambiguation, these can be uniquely disambiguated with `->(_,Element)` and `->(_,ConcreteElement)` respectively. 

With tuple labels in the disambiguation these would need to be written `->(_,memberAfterInsert:Element)` and `->(_,memberAfterInsert:ConcreteElement)` instead.

The user experience tradeoff with _excluding_ tuple labels is tuples parameters or return type with the same element types but different labels can't be disambiguated using their type signatures and instead need to use hash disambiguation. However, in all the frameworks I've looked I've yet to find a case that disambiguates overloads based on only tuple labels. Also, because it's ambiguous to call such overloads, I believe that they are very rare in practice.

It would be _significantly_ more complex—and require that data is stored differently than it is today—to support tuple labels only when necessary. Because it would only be relevant to distinguish between overloads with different tuple labels, which I believe to be very rare, I don't think it would be worth that complexity.

## Dependencies

None

## Testing

- Define overloads for Swift functions with different types where some of those types are tuples with labels. For example:
  ```
  func something() -> (first: Int, second: Bool)
  func something() -> (one:   Int, two:    String)
  func something() -> Int
  ```

- Link to the overloaded symbol name without disambiguation. 
  - DocC suggested disambiguation for the ambiguous link shouldn't include the tuple labels. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ 
