### PR TITLE
Fix incorrect equality implementation for ResolvedTopicReference

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -83,4 +83,11 @@ class ResolvedTopicReferenceTests: XCTestCase {
             _ = topicReference.absoluteString
         }
     }
+    
+    func testDifferentReferencesAreNotEqual() {
+        XCTAssertNotEqual(
+            ResolvedTopicReference(bundleID: "com.example", path: "/OneTwo", fragment: nil,   sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: "com.example", path: "/One",    fragment: "Two", sourceLanguage: .swift)
+        )
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://130698358

## Summary

This fixes an incorrect equality (and hashing) implementation for `ResolvedTopicReference` which caused `/some/path#fragment` and `/some/pathfragment` to be considered "equal". This could for example result in reference collisions when a project contained both `SomethingViewController#Delegate` and `SomethingViewControllerDelegate`.

## Dependencies

None

## Testing

The user facing effects of this bug are a bit hard to test because you have to try and observe the secondary effect caused by the reference collision. It's very easy to verify in a [unit test](https://github.com/swiftlang/swift-docc/pull/1140/files#diff-31e03aa9b5cebdb6504d49b45638f5fe090cb2dd9a4d5b93b6fa7b6a87f41535R88-R91) though. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] ~Updated documentation if necessary~ Not applicable
