### PR TITLE
[6.1] Fix an incorrect equality implementation for ResolvedTopicReference

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ResolvedTopicReferenceTests.swift
@@ -83,4 +83,11 @@ class ResolvedTopicReferenceTests: XCTestCase {
             _ = topicReference.absoluteString
         }
     }
+    
+    func testDifferentReferencesAreNotEqual() {
+        XCTAssertNotEqual(
+            ResolvedTopicReference(bundleID: "com.example", path: "/OneTwo", fragment: nil,   sourceLanguage: .swift),
+            ResolvedTopicReference(bundleID: "com.example", path: "/One",    fragment: "Two", sourceLanguage: .swift)
+        )
+    }
 }


### PR DESCRIPTION
- **Explanation:** Fix a bug in ResolvedTopicReference equality where `SomePage#Fragment` and `SomePageFragment` would be "equal" and collide.
- **Scope:** Possible topic reference collisions
- **Issue:** rdar://130698358 
- **Risk:** Low. 
- **Testing:** New tests verify topic reference equality. Existing automated tests pass. 
- **Reviewer:** @sofiaromorales @anferbui    
- **Original PR:** #1140 