### PR TITLE
Revert "Resolve all current code warnings (#1143)"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "ba72f31e11275fc5bf060c966cf6c1f36842a291",
-        "version" : "2.79.0"
+        "revision" : "fc79798d5a150d61361a27ce0c51169b889e23de",
+        "version" : "2.68.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
+        "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
+        "version" : "1.3.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -129,7 +129,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.78.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
         .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-lmdb.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -479,11 +479,7 @@ extension NavigatorIndex {
         
         /// The data provider.
         @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
-        public var renderNodeProvider: RenderNodeProvider? {
-            _renderNodeProvider as! RenderNodeProvider?
-        }
-        // This property only exist to be able to assign `nil` to `renderNodeProvider` in the new initializer without causing a deprecation warning.
-        private let _renderNodeProvider: Any?
+        public let renderNodeProvider: RenderNodeProvider?
         
         /// The documentation archive to build an index from.
         public let archiveURL: URL?
@@ -579,7 +575,7 @@ extension NavigatorIndex {
         ///    - usePageTitle: Configure the builder to use the "page title" instead of the "navigator title" as the title for each entry.
         public init(archiveURL: URL? = nil, outputURL: URL, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
             self.archiveURL = archiveURL
-            self._renderNodeProvider = nil
+            self.renderNodeProvider = nil
             self.outputURL = outputURL
             self.bundleIdentifier = bundleIdentifier
             self.sortRootChildrenByName = sortRootChildrenByName
@@ -591,7 +587,7 @@ extension NavigatorIndex {
         @available(*, deprecated, renamed: "init(archiveURL:outputURL:bundleIdentifier:sortRootChildrenByName:groupByLanguage:writePathsOnDisk:usePageTitle:)", message: "Use 'init(archiveURL:outputURL:bundleIdentifier:sortRootChildrenByName:groupByLanguage:writePathsOnDisk:usePageTitle:)' instead. This deprecated API will be removed after 6.2 is released")
         @_disfavoredOverload
         public init(renderNodeProvider: RenderNodeProvider? = nil, outputURL: URL, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
-            self._renderNodeProvider = renderNodeProvider
+            self.renderNodeProvider = renderNodeProvider
             self.archiveURL = nil
             self.outputURL = outputURL
             self.bundleIdentifier = bundleIdentifier

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorTree.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorTree.swift
@@ -119,12 +119,7 @@ public class NavigatorTree {
         
         func __read() {
             let deadline = DispatchTime.now() + timeout
-#if swift(>=5.10)
-            // Access to this local variable is synchronized using the DispatchQueue `queue`, passed as an argument.
-            nonisolated(unsafe) var processedNodes = [NavigatorTree.Node]()
-#else
             var processedNodes = [NavigatorTree.Node]()
-#endif
             
             while readingCursor.cursor < readingCursor.data.count {
                 let length = MemoryLayout<UInt32>.stride

--- a/Sources/SwiftDocCTestUtilities/XCTestCase+TemporaryDirectory.swift
+++ b/Sources/SwiftDocCTestUtilities/XCTestCase+TemporaryDirectory.swift
@@ -36,8 +36,9 @@ public extension XCTestCase {
     ///
     /// - Parameters:
     ///   - pathComponents: The name of the temporary directory.
+    ///   - fileManager: The file manager that will create the directory.
     /// - Returns: The URL of the newly created directory.
-    func createTemporaryDirectory(named: String) throws -> URL {
+    func createTemporaryDirectory(named: String, fileManager: FileManager = .default) throws -> URL {
         try createTemporaryDirectory(pathComponents: named)
     }
         
@@ -47,8 +48,9 @@ public extension XCTestCase {
     ///
     /// - Parameters:
     ///   - pathComponents: Additional path components to add to the temporary URL.
+    ///   - fileManager: The file manager that will create the directory.
     /// - Returns: The URL of the newly created directory.
-    func createTemporaryDirectory(pathComponents: String...) throws -> URL {
+    func createTemporaryDirectory(pathComponents: String..., fileManager: FileManager = .default) throws -> URL {
         let bundleParentDir = Bundle(for: Self.self).bundleURL.deletingLastPathComponent()
         let baseURL = bundleParentDir.appendingPathComponent(name.replacingWhitespaceAndPunctuation(with: "-"))
         
@@ -60,20 +62,20 @@ public extension XCTestCase {
         
         addTeardownBlock {
             do {
-                if FileManager.default.fileExists(atPath: baseURL.path) {
-                    try FileManager.default.removeItem(at: baseURL)
+                if fileManager.fileExists(atPath: baseURL.path) {
+                    try fileManager.removeItem(at: baseURL)
                 }
             } catch {
                 XCTFail("Failed to remove temporary directory: '\(error)'")
             }
         }
         
-        if !FileManager.default.fileExists(atPath: bundleParentDir.path) {
+        if !fileManager.fileExists(atPath: bundleParentDir.path) {
             // Create the base URL directory without intermediate directories so that an error is raised if the parent directory doesn't exist.
-            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: false, attributes: nil)
+            try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: false, attributes: nil)
         }
          
-        try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true, attributes: nil)
+        try fileManager.createDirectory(at: tempURL, withIntermediateDirectories: true, attributes: nil)
         
         return tempURL
     }

--- a/Sources/SwiftDocCUtilities/PreviewServer/PreviewHTTPHandler.swift
+++ b/Sources/SwiftDocCUtilities/PreviewServer/PreviewHTTPHandler.swift
@@ -111,7 +111,7 @@ final class PreviewHTTPHandler: ChannelInboundHandler {
         
         // If we don't need to keep the connection alive, close `context` after flushing the response
         if !self.keepAlive {
-            promise.futureResult.assumeIsolated().whenComplete { _ in context.close(promise: nil) }
+            promise.futureResult.whenComplete { _ in context.close(promise: nil) }
         }
 
         context.writeAndFlush(self.wrapOutboundOut(.end(trailers)), promise: promise)

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/PreviewHTTPHandlerTests.swift
@@ -33,8 +33,10 @@ class PreviewHTTPHandlerTests: XCTestCase {
 
         let response = Response()
         
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(response).wait())
         XCTAssertNoThrow(try channel.pipeline.addHandler(channelHandler).wait())
+        XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPServerPipelineHandler()).wait())
 
         XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).wait())
 

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
@@ -92,8 +92,10 @@ func responseWithPipeline(request: HTTPRequestHead, handler factory: RequestHand
 
     let response = Response()
     
+    XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPResponseEncoder()).wait(), file: (file), line: line)
     XCTAssertNoThrow(try channel.pipeline.addHandler(response).wait(), file: (file), line: line)
     XCTAssertNoThrow(try channel.pipeline.addHandler(channelHandler).wait(), file: (file), line: line)
+    XCTAssertNoThrow(try channel.pipeline.addHandler(HTTPServerPipelineHandler()).wait(), file: (file), line: line)
 
     XCTAssertNoThrow(try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).wait(), file: (file), line: line)
 

--- a/bin/check-source
+++ b/bin/check-source
@@ -44,6 +44,7 @@ for language in swift-or-c bash md-or-tutorial html docker; do
   declare -a matching_files
   declare -a exceptions
   declare -a reader
+  expections=( )
   matching_files=( -name '*' )
   reader=head
   case "$language" in
@@ -135,7 +136,6 @@ EOF
     cd "$here/.."
     find . \
       \( \! -path './.build/*' -a \
-      \! -path './bin/benchmark/.build/*' -a \
       \! -name '.' -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do


### PR DESCRIPTION
The changes from https://github.com/swiftlang/swift-docc/pull/1143 are blocking PRs from being merged in the Swift compiler repo because the NIO dependency is not new enough ([example](https://ci.swift.org/job/swift-PR-Linux-smoke-test/16990/console)). Updating the version of NIO that this project depends on will need to be done in conjunction with an update to update-checkout.sh in the https://github.com/swiftlang/swift repo.