### PR TITLE
Fix FreeBSD build and test

### DIFF
--- a/Sources/SwiftDocC/Benchmark/Benchmark.swift
+++ b/Sources/SwiftDocC/Benchmark/Benchmark.swift
@@ -46,6 +46,8 @@ public class Benchmark: Encodable {
     public let platform = "Linux"
     #elseif os(Android)
     public let platform = "Android"
+    #elseif os(FreeBSD)
+    public let platform = "FreeBSD"
     #else
     public let platform = "unsupported"
     #endif

--- a/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/PeakMemory.swift
@@ -67,6 +67,15 @@ extension Benchmark {
             ) else { return nil }
             return Int64(pmcStats.PeakWorkingSetSize)
         }
+        #elseif os(FreeBSD)
+        private static func peakMemory() -> Int64? {
+            var usage = rusage()
+            if (getrusage(RUSAGE_SELF, &usage) == -1) {
+                return nil
+            } else {
+                return Int64(usage.ru_maxrss * 1024)
+            }
+        }
         #endif
         
         public var result: MetricValue? {

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -291,7 +291,7 @@ private class LongRunningService: ExternalLinkResolving {
 /// This private class is only used by the ``OutOfProcessReferenceResolver`` and shouldn't be used for general communication with other processes.
 private class LongRunningProcess: ExternalLinkResolving {
     
-    #if os(macOS) || os(Linux) || os(Android)
+    #if os(macOS) || os(Linux) || os(Android) || os(FreeBSD)
     private let process: Process
     
     init(location: URL, errorOutputHandler: @escaping (String) -> Void) throws {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContext.swift
@@ -61,7 +61,7 @@ public struct RenderContext {
             )
         }
         
-        #if os(macOS) || os(iOS) || os(Android) || os(Windows)
+        #if os(macOS) || os(iOS) || os(Android) || os(Windows) || os(FreeBSD)
         // Concurrently render content on macOS/iOS, Windows & Android
         let results: [(reference: ResolvedTopicReference, content: RenderReferenceStore.TopicContent)] = references.concurrentPerform { reference, results in
             results.append((reference, renderContentFor(reference)))

--- a/Sources/SwiftDocC/Utility/FoundationExtensions/AutoreleasepoolShim.swift
+++ b/Sources/SwiftDocC/Utility/FoundationExtensions/AutoreleasepoolShim.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(Linux) || os(Android) || os(Windows)
+#if os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
 /// A shim for non-ObjC targets that runs the given block of code.
 ///
 /// The existence of this shim allows you the use of auto-release pools to optimize memory footprint on Darwin platforms while maintaining

--- a/Sources/SwiftDocC/Utility/Synchronization.swift
+++ b/Sources/SwiftDocC/Utility/Synchronization.swift
@@ -35,6 +35,9 @@ public class Synchronized<Value> {
     #elseif os(Linux) || os(Android)
     /// A lock type appropriate for the current platform.
     var lock: UnsafeMutablePointer<pthread_mutex_t>
+    #elseif os(FreeBSD)
+    /// A lock type appropriate for the current platform.
+    var lock: UnsafeMutablePointer<pthread_mutex_t?>
     #elseif os(Windows)
     var lock: UnsafeMutablePointer<SRWLOCK>
     #else
@@ -52,6 +55,10 @@ public class Synchronized<Value> {
         #elseif os(Linux) || os(Android)
         lock = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
         lock.initialize(to: pthread_mutex_t())
+        pthread_mutex_init(lock, nil)
+        #elseif os(FreeBSD)
+        lock = UnsafeMutablePointer<pthread_mutex_t?>.allocate(capacity: 1)
+        lock.initialize(to: nil)
         pthread_mutex_init(lock, nil)
         #elseif os(Windows)
         lock = UnsafeMutablePointer<SRWLOCK>.allocate(capacity: 1)
@@ -75,6 +82,9 @@ public class Synchronized<Value> {
         os_unfair_lock_lock(lock)
         defer { os_unfair_lock_unlock(lock) }
         #elseif os(Linux) || os(Android)
+        pthread_mutex_lock(lock)
+        defer { pthread_mutex_unlock(lock) }
+        #elseif os(FreeBSD)
         pthread_mutex_lock(lock)
         defer { pthread_mutex_unlock(lock) }
         #elseif os(Windows)
@@ -111,6 +121,9 @@ extension Lock {
         os_unfair_lock_lock(lock)
         defer { os_unfair_lock_unlock(lock) }
         #elseif os(Linux) || os(Android)
+        pthread_mutex_lock(lock)
+        defer { pthread_mutex_unlock(lock) }
+        #elseif os(FreeBSD)
         pthread_mutex_lock(lock)
         defer { pthread_mutex_unlock(lock) }
         #elseif os(Windows)

--- a/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
+++ b/Sources/SwiftDocCUtilities/Utility/DirectoryMonitor.swift
@@ -11,7 +11,7 @@
 import Foundation
 import SwiftDocC
 
-#if !os(Linux) && !os(Android) && !os(Windows)
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
 import Darwin
 
 /// A throttle object to filter events that come too fast.

--- a/Sources/SwiftDocCUtilities/Utility/Signal.swift
+++ b/Sources/SwiftDocCUtilities/Utility/Signal.swift
@@ -25,6 +25,8 @@ public struct Signal {
         signalAction.__sigaction_handler = unsafeBitCast(callback, to: sigaction.__Unnamed_union___sigaction_handler.self)
         #elseif os(Android)
         signalAction.sa_handler = callback
+        #elseif os(FreeBSD)
+        signalAction.__sigaction_u.__sa_handler = callback
         #else
         signalAction.__sigaction_u = unsafeBitCast(callback, to: __sigaction_u.self)
         #endif

--- a/Sources/docc/main.swift
+++ b/Sources/docc/main.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(macOS) || os(Linux) || os(Android) || os(Windows)
+#if os(macOS) || os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
 import SwiftDocCUtilities
 
 await Task {

--- a/Tests/SwiftDocCTests/Servers/DocumentationSchemeHandlerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/DocumentationSchemeHandlerTests.swift
@@ -24,7 +24,7 @@ class DocumentationSchemeHandlerTests: XCTestCase {
         forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
     
     func testDocumentationSchemeHandler() {
-        #if !os(Linux) && !os(Android) && !os(Windows)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
         let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL)
         
         let request = URLRequest(url:  baseURL.appendingPathComponent("/images/figure1.jpg"))
@@ -50,7 +50,7 @@ class DocumentationSchemeHandlerTests: XCTestCase {
     }
     
     func testSetData() {
-        #if !os(Linux) && !os(Android) && !os(Windows)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
         let topicSchemeHandler = DocumentationSchemeHandler(withTemplateURL: templateURL)
         
         let data = "hello!".data(using: .utf8)!

--- a/Tests/SwiftDocCTests/Servers/FileServerTests.swift
+++ b/Tests/SwiftDocCTests/Servers/FileServerTests.swift
@@ -164,7 +164,7 @@ class FileServerTests: XCTestCase {
         (response, data) = fileServer.response(to: failingRequest)
         XCTAssertNil(data)
         // Initializing a URLResponse with `nil` as MIME type in Linux returns nil
-        #if os(Linux) || os(Android) || os(Windows)
+        #if os(Linux) || os(Android) || os(Windows) || os(FreeBSD)
         XCTAssertNil(response.mimeType)
         #else
         // Doing the same in macOS or iOS returns the default MIME type

--- a/Tests/SwiftDocCTests/Utility/LMDBTests.swift
+++ b/Tests/SwiftDocCTests/Utility/LMDBTests.swift
@@ -237,7 +237,7 @@ final class SwiftLMDBTests: XCTestCase {
     }
     
     func testArrayOfInt() throws {
-#if !os(Linux) && !os(Android) && !os(Windows)
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
         let database = try environment.openDatabase()
         
         var array: [UInt32] = []

--- a/Tests/SwiftDocCUtilitiesTests/C+Extensions.swift
+++ b/Tests/SwiftDocCUtilitiesTests/C+Extensions.swift
@@ -11,7 +11,7 @@
 import Foundation
 #if os(Windows)
 import ucrt
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(Android) || os(FreeBSD)
 import Glibc
 #else
 import Darwin

--- a/Tests/SwiftDocCUtilitiesTests/DirectoryMonitorTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/DirectoryMonitorTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwiftDocCUtilities
 
-#if !os(Linux) && !os(Android) && !os(Windows)
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
 fileprivate extension NSNotification.Name {
     static let testNodeUpdated = NSNotification.Name(rawValue: "testNodeUpdated")
     static let testDirectoryReloaded = NSNotification.Name(rawValue: "testDirectoryReloaded")
@@ -24,7 +24,7 @@ func fileURLsAreEqual(_ url1: URL, _ url2: URL) -> Bool {
 #endif
 
 class DirectoryMonitorTests: XCTestCase {
-    #if !os(Linux) && !os(Android) && !os(Windows)
+    #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
     // - MARK: Directory watching test infra
     
     /// Method that automates setting up a directory monitor, setting up the relevant expectations for a test,
@@ -118,7 +118,7 @@ class DirectoryMonitorTests: XCTestCase {
     /// Tests a succession of file system changes and verifies that they produce
     /// the expected monitor events.
     func testMonitorUpdates() throws {
-        #if !os(Linux) && !os(Android) && !os(Windows)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
 
         // Create temp folder & sub-folder.
         let tempSubfolderURL = try createTemporaryDirectory(named: "subfolder")
@@ -167,7 +167,7 @@ class DirectoryMonitorTests: XCTestCase {
     }
     
     func testMonitorDoesNotTriggerUpdates() throws {
-        #if !os(Linux) && !os(Android) && !os(Windows)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
         
         // Create temp folder & sub-folder.
         let tempSubfolderURL = try createTemporaryDirectory(named: "subfolder")
@@ -200,7 +200,7 @@ class DirectoryMonitorTests: XCTestCase {
     
     /// Tests a zero sum change aggregation triggers an event.
     func testMonitorZeroSumSizeChangesUpdates() throws {
-        #if !os(Linux) && !os(Android) && !os(Windows)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(FreeBSD)
 
         // Create temp folder & sub-folder.
         let tempSubfolderURL = try createTemporaryDirectory(named: "subfolder")


### PR DESCRIPTION
## Summary

This PR fixes building swift-docc on x86_64 FreeBSD

## Testing
All test passes! 

```
Build complete! (10.02s)
[1772/1772] Testing SwiftDocCTests.SwiftLMDBTests/testMultipleCustomObjects
➜  swift-docc git:(freebsd-wip) uname -msr
FreeBSD 14.1-RELEASE-p6 amd64
```
