### PR TITLE
Fix parsing bug for disambiguation with both parameter and return types

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -474,20 +474,14 @@ extension PathHierarchy.PathParser {
                 return PathComponent(full: String(original), name: name, disambiguation: .typeSignature(parameterTypes: parameterTypes, returnTypes: nil))
             } else if scanner.hasPrefix("->") {
                 _ = scanner.take(2)
-                let returnTypes = scanner.scanArguments() // The return types (tuple or not) can be parsed the same as the arguments
+                let returnTypes = scanner.scanReturnTypes()
                 return PathComponent(full: String(original), name: name, disambiguation: .typeSignature(parameterTypes: parameterTypes, returnTypes: returnTypes))
             }
         } else if let parameterStartRange = possibleDisambiguationText.range(of: "->") {
             let name = original[..<parameterStartRange.lowerBound]
             var scanner = StringScanner(original[parameterStartRange.upperBound...])
             
-            let returnTypes: [Substring]
-            if scanner.peek() == "(" {
-                _ = scanner.take() // the leading parenthesis
-                returnTypes = scanner.scanArguments() // The return types (tuple or not) can be parsed the same as the arguments
-            } else {
-                returnTypes = [scanner.takeAll()]
-            }
+            let returnTypes = scanner.scanReturnTypes()
             return PathComponent(full: String(original), name: name, disambiguation: .typeSignature(parameterTypes: nil, returnTypes: returnTypes))
         }
         
@@ -541,6 +535,15 @@ private struct StringScanner {
 
     // MARK: Parsing argument types by scanning
     
+    mutating func scanReturnTypes() -> [Substring] {
+        if peek() == "(" {
+            _ = take() // the leading parenthesis
+            return scanArguments() // The return types (tuple or not) can be parsed the same as the arguments
+        } else {
+            return [takeAll()]
+        }
+    }
+        
     mutating func scanArguments() -> [Substring] {
         guard peek() != ")" else {
             _ = take() // drop the ")"

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3623,6 +3623,10 @@ class PathHierarchyTests: XCTestCase {
         
         assertParsedPathComponents("something(first:second:third:)->(String,Int,Bool)", [("something(first:second:third:)", .typeSignature(parameterTypes: nil, returnTypes: ["String", "Int", "Bool"]))])
         
+        assertParsedPathComponents("something(first:second:third:)-(Int,_)->()", [("something(first:second:third:)", .typeSignature(parameterTypes: ["Int", "_"], returnTypes: []))])
+        assertParsedPathComponents("something(first:second:third:)-(Int,_)->Int", [("something(first:second:third:)", .typeSignature(parameterTypes: ["Int", "_"], returnTypes: ["Int"]))])
+        assertParsedPathComponents("something(first:second:third:)-(Int,_)->(String,Int,Bool)", [("something(first:second:third:)", .typeSignature(parameterTypes: ["Int", "_"], returnTypes: ["String", "Int", "Bool"]))])
+        
         // Check closure parameters
         assertParsedPathComponents("map(_:)-((Element)->T)", [("map(_:)", .typeSignature(parameterTypes: ["(Element)->T"], returnTypes: nil))])
         assertParsedPathComponents("map(_:)->[T]", [("map(_:)", .typeSignature(parameterTypes: nil, returnTypes: ["[T]"]))])


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://143817712

## Summary

This fixes a bug with parsing of link strings that contain _both_ parameter type disambiguation and return type disambiguation where the return type is a tuple.

## Dependencies

None.

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
