### PR TITLE
[6.1] Fix parsing bug for disambiguation with both parameter and return types

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -474,20 +474,14 @@ extension PathHierarchy.PathParser {
                 return PathComponent(full: String(original), name: name, disambiguation: .typeSignature(parameterTypes: parameterTypes, returnTypes: nil))
             } else if scanner.hasPrefix("->") {
                 _ = scanner.take(2)
-                let returnTypes = scanner.scanArguments() // The return types (tuple or not) can be parsed the same as the arguments
+                let returnTypes = scanner.scanReturnTypes()
                 return PathComponent(full: String(original), name: name, disambiguation: .typeSignature(parameterTypes: parameterTypes, returnTypes: returnTypes))
             }
         } else if let parameterStartRange = possibleDisambiguationText.range(of: "->") {
             let name = original[..<parameterStartRange.lowerBound]
             var scanner = StringScanner(original[parameterStartRange.upperBound...])
             
-            let returnTypes: [Substring]
-            if scanner.peek() == "(" {
-                _ = scanner.take() // the leading parenthesis
-                returnTypes = scanner.scanArguments() // The return types (tuple or not) can be parsed the same as the arguments
-            } else {
-                returnTypes = [scanner.takeAll()]
-            }
+            let returnTypes = scanner.scanReturnTypes()
             return PathComponent(full: String(original), name: name, disambiguation: .typeSignature(parameterTypes: nil, returnTypes: returnTypes))
         }
         
@@ -541,6 +535,15 @@ private struct StringScanner {
 
     // MARK: Parsing argument types by scanning
     
+    mutating func scanReturnTypes() -> [Substring] {
+        if peek() == "(" {
+            _ = take() // the leading parenthesis
+            return scanArguments() // The return types (tuple or not) can be parsed the same as the arguments
+        } else {
+            return [takeAll()]
+        }
+    }
+        
     mutating func scanArguments() -> [Substring] {
         guard peek() != ")" else {
             _ = take() // drop the ")"

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3627,6 +3627,10 @@ class PathHierarchyTests: XCTestCase {
         
         assertParsedPathComponents("something(first:second:third:)->(String,Int,Bool)", [("something(first:second:third:)", .typeSignature(parameterTypes: nil, returnTypes: ["String", "Int", "Bool"]))])
         
+        assertParsedPathComponents("something(first:second:third:)-(Int,_)->()", [("something(first:second:third:)", .typeSignature(parameterTypes: ["Int", "_"], returnTypes: []))])
+        assertParsedPathComponents("something(first:second:third:)-(Int,_)->Int", [("something(first:second:third:)", .typeSignature(parameterTypes: ["Int", "_"], returnTypes: ["Int"]))])
+        assertParsedPathComponents("something(first:second:third:)-(Int,_)->(String,Int,Bool)", [("something(first:second:third:)", .typeSignature(parameterTypes: ["Int", "_"], returnTypes: ["String", "Int", "Bool"]))])
+        
         // Check closure parameters
         assertParsedPathComponents("map(_:)-((Element)->T)", [("map(_:)", .typeSignature(parameterTypes: ["(Element)->T"], returnTypes: nil))])
         assertParsedPathComponents("map(_:)->[T]", [("map(_:)", .typeSignature(parameterTypes: nil, returnTypes: ["[T]"]))])


### PR DESCRIPTION
- **Explanation:** This fixes a parsing bug for symbol links where one path component has both parameter type disambiguation and return types disambiguation. If the return type disambiguation is a tuple, that information won't be parsed.
- **Scope:** Currently typed symbol links that require both parameter type and return type disambiguation won't resolve with nonsensical warnings about adding the disambiguation that's already written.
- **Issue:** rdar://143817712 
- **Risk:** Low. 
- **Testing:** New tests verify that these symbol links parse correctly.. Existing automated tests pass. 
- **Reviewer:** @sofiaromorales 
- **Original PR:** #1152 