### PR TITLE
adds a base symbolgraph for Snippets test fixture

### DIFF
--- a/Tests/SwiftDocCTests/Test Bundles/Snippets.docc/Test.symbols.json
+++ b/Tests/SwiftDocCTests/Test Bundles/Snippets.docc/Test.symbols.json
@@ -1,0 +1,16 @@
+{
+    "metadata": {
+        "formatVersion": {
+            "major": 0,
+            "minor": 6,
+            "patch": 0
+        },
+        "generator": "SwiftPM"
+    },
+    "module": {
+        "name": "Snippets",
+        "platform": {}
+    },
+    "symbols": [],
+    "relationships": []
+}


### PR DESCRIPTION
## Summary

Supports fixing an issue confusing snippets as both "main" and "extension" symbolgraphs for a particular module. The fix in swift-docc-symbolkit fails this specific fixture since it doesn't currently have a "main" graph, even empty as this one, to extend from. With this in place, the tests fully pass for properly resolving snippets symbolgraphs reliably.

related to fix for [swift-docc-symbolkit#88](https://github.com/swiftlang/swift-docc-symbolkit/issues/88)

## Dependencies

none - this is a dependency for a fix in swift-docc-symbolkit

## Testing

Ran unit tests with existing main branch as well as branch for fix in symbol kit.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests (updated a test)
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
