### PR TITLE
Add "Musl" support for the `Signal` utility

### DIFF
--- a/Sources/SwiftDocCUtilities/Utility/Signal.swift
+++ b/Sources/SwiftDocCUtilities/Utility/Signal.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,8 +20,10 @@ public struct Signal {
     public static func on(_ signals: [Int32], callback: @convention(c) @escaping (Int32) -> Void) {
         var signalAction = sigaction()
         
-        #if os(Linux)
-        // This is where we get to use a triple underscore in a method name.
+        // Different libraries name the `sigaction` fields and handler type differently.
+        #if canImport(Musl)
+        signalAction.__sa_handler = unsafeBitCast(callback, to: sigaction.__Unnamed_union___sa_handler.self)
+        #elseif os(Linux)
         signalAction.__sigaction_handler = unsafeBitCast(callback, to: sigaction.__Unnamed_union___sigaction_handler.self)
         #elseif os(Android)
         signalAction.sa_handler = callback


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://145456460

## Summary

This adds a dedicated `#if canImport(Musl)` implementation to DocC's `Signal` utility to allow building DocC with the Swift Static Linux SDK.

## Dependencies

None.

## Testing

- Follow the [Getting Started with the Static Linux SDK instructions on Swift.org][1] to set up a toolchain with the Swift Static Linux SDK.
- Build `docc` with the static Linux SDK
  ```
  swift build --product docc --swift-sdk aarch64-swift-linux-musl
  ```
  - The build should succeed.

[1]:https://www.swift.org/documentation/articles/static-linux-getting-started.html

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
