### PR TITLE
Remove unused `TestFileSystem.Errors` type

### DIFF
--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -317,15 +317,6 @@ package class TestFileSystem: FileManagerProtocol {
         URL(fileURLWithPath: "/tmp/\(ProcessInfo.processInfo.globallyUniqueString)", isDirectory: true)
     }
     
-    enum Errors: DescribedError {
-        case invalidPath(String)
-        var errorDescription: String {
-            switch self { 
-                case .invalidPath(let path): return "Invalid path '\(path)'"
-            }
-        }
-    }
-    
     /// Returns a stable string representation of the file system from a given subpath.
     ///
     /// - Parameter path: The path to the sub hierarchy to dump to a string representation.


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removed the unused `TestFileSystem.Errors` type.

## Dependencies

None 

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
