### PR TITLE
Deprecate `FeatureFlag` initializer with unused parameter

### DIFF
--- a/Sources/SwiftDocC/Utility/FeatureFlags.swift
+++ b/Sources/SwiftDocC/Utility/FeatureFlags.swift
@@ -41,12 +41,17 @@ public struct FeatureFlags: Codable {
         set { isParametersAndReturnsValidationEnabled = newValue }
     }
     
+    /// Creates a set of feature flags with all default values.
+    public init() {}
+    
     /// Creates a set of feature flags with the given values.
     ///
     /// - Parameters:
     ///   - additionalFlags: Any additional flags to set.
     ///
     ///     This field allows clients to set feature flags without adding new API.
+    @available(*, deprecated, renamed: "init()", message: "Use 'init()' instead. This deprecated API will be removed after 6.2 is released")
+    @_disfavoredOverload
     public init(
         additionalFlags: [String : Bool] = [:]
     ) {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This deprecates the `init(additionalFlags:)` feature flag initializer because it doesn't use the argument and there's no corresponding property that would allow developers to access arbitrary string values on the `FeatureFlag` structure. 

Because the value is never used, this initializer doesn't behave as documented and doesn't "[allow] clients to set feature flags without adding new API."

## Dependencies

None 

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
