### PR TITLE
Deprecate the `context` initializer parameter for both `MarkupConvertible` and `DirectiveConvertible`

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -407,7 +407,7 @@ public class DocumentationContext {
     ///   - problems: A mutable collection of problems to update with any problem encountered during the semantic analysis.
     /// - Returns: The result of the semantic analysis.
     private func analyze(_ document: Document, at source: URL, in bundle: DocumentationBundle, engine: DiagnosticEngine) -> Semantic? {
-        var analyzer = SemanticAnalyzer(source: source, context: self, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: source, bundle: bundle)
         let result = analyzer.visit(document)
         engine.emit(analyzer.problems)
         return result
@@ -1074,8 +1074,7 @@ public class DocumentationContext {
         updatedNode.initializeSymbolContent(
             documentationExtension: foundDocumentationExtension?.value,
             engine: diagnosticEngine,
-            bundle: bundle,
-            context: self
+            bundle: bundle
         )
 
         // After merging the documentation extension into the symbol, warn about deprecation summary for non-deprecated symbols.
@@ -2010,7 +2009,7 @@ public class DocumentationContext {
             }
             let article = Article(
                 markup: articleResult.value.markup,
-                metadata: Metadata(from: metadataMarkup, for: bundle, in: self),
+                metadata: Metadata(from: metadataMarkup, for: bundle),
                 redirects: articleResult.value.redirects,
                 options: articleResult.value.options
             )
@@ -2043,7 +2042,7 @@ public class DocumentationContext {
                 Heading(level: 1, Text(title)),
                 metadataDirectiveMarkup
             )
-            let metadata = Metadata(from: metadataDirectiveMarkup, for: bundle, in: self)
+            let metadata = Metadata(from: metadataDirectiveMarkup, for: bundle)
             let article = Article(markup: markup, metadata: metadata, redirects: nil, options: [:])
             let documentationNode = DocumentationNode(
                 reference: reference,

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -332,8 +332,7 @@ public struct DocumentationNode {
     mutating func initializeSymbolContent(
         documentationExtension: Article?,
         engine: DiagnosticEngine,
-        bundle: DocumentationBundle,
-        context: DocumentationContext
+        bundle: DocumentationBundle
     ) {
         precondition(unifiedSymbol != nil && symbol != nil, "You can only call initializeSymbolContent() on a symbol node.")
         
@@ -341,7 +340,6 @@ public struct DocumentationNode {
             documentedSymbol: unifiedSymbol?.documentedSymbol,
             documentationExtension: documentationExtension,
             bundle: bundle,
-            context: context,
             engine: engine
         )
         
@@ -503,7 +501,6 @@ public struct DocumentationNode {
         documentedSymbol: SymbolGraph.Symbol?,
         documentationExtension: Article?,
         bundle: DocumentationBundle? = nil,
-        context: DocumentationContext? = nil,
         engine: DiagnosticEngine
     ) -> (
         markup: Markup,
@@ -543,7 +540,7 @@ public struct DocumentationNode {
 
             var problems = [Problem]()
             
-            if let bundle, let context {
+            if let bundle {
                 metadata = DirectiveParser()
                     .parseSingleDirective(
                         Metadata.self,
@@ -551,7 +548,6 @@ public struct DocumentationNode {
                         parentType: Symbol.self,
                         source: docCommentLocation?.url,
                         bundle: bundle,
-                        context: context,
                         problems: &problems
                     )
                 

--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -517,7 +517,7 @@ public class DocumentationContentRenderer {
             }
             
             let supportedLanguages = group.directives[SupportedLanguage.directiveName]?.compactMap {
-                SupportedLanguage(from: $0, source: nil, for: bundle, in: documentationContext)?.language
+                SupportedLanguage(from: $0, source: nil, for: bundle)?.language
             }
             
             return ReferenceGroup(

--- a/Sources/SwiftDocC/Model/Rendering/LinkTitleResolver.swift
+++ b/Sources/SwiftDocC/Model/Rendering/LinkTitleResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,11 +33,11 @@ struct LinkTitleResolver {
             var problems = [Problem]()
             switch directive.name {
             case Tutorial.directiveName:
-                if let tutorial = Tutorial(from: directive, source: source, for: bundle, in: context, problems: &problems) {
+                if let tutorial = Tutorial(from: directive, source: source, for: bundle, problems: &problems) {
                     return .init(defaultVariantValue: tutorial.intro.title)
                 }
             case TutorialTableOfContents.directiveName:
-                if let overview = TutorialTableOfContents(from: directive, source: source, for: bundle, in: context, problems: &problems) {
+                if let overview = TutorialTableOfContents(from: directive, source: source, for: bundle, problems: &problems) {
                     return .init(defaultVariantValue: overview.name)
                 }
             default: break

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentConvertible.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentConvertible.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -24,11 +24,7 @@ extension RenderableDirectiveConvertible {
         _ blockDirective: BlockDirective,
         with contentCompiler: inout RenderContentCompiler
     ) -> [RenderContent] {
-        guard let directive = Self.init(
-            from: blockDirective,
-            for: contentCompiler.bundle,
-            in: contentCompiler.context
-        ) else {
+        guard let directive = Self.init(from: blockDirective, for: contentCompiler.bundle) else {
             return []
         }
         

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1029,7 +1029,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
     ) -> [TaskGroupRenderSection] {
         return topics.taskGroups.compactMap { group in
             let supportedLanguages = group.directives[SupportedLanguage.directiveName]?.compactMap {
-                SupportedLanguage(from: $0, source: nil, for: bundle, in: context)?.language
+                SupportedLanguage(from: $0, source: nil, for: bundle)?.language
             }
             
             // If the task group has a set of supported languages, see if it should render for the allowed traits.

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -94,10 +94,9 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
     /// - Parameters:
     ///   - markup: The markup that makes up this article's content.
     ///   - source: The location of the file that this article's content comes from.
-    ///   - bundle: The documentation bundle that the article belongs to.
-    ///   - context: The documentation context that the article belongs to.
+    ///   - bundle: The documentation bundle that the source file belongs to.
     ///   - problems: A mutable collection of problems to update with any problem encountered while initializing the article.
-    public convenience init?(from markup: Markup, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from markup: Markup, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         guard let title = markup.child(at: 0) as? Heading, title.level == 1 else {
             let range = markup.child(at: 0)?.range ?? SourceLocation(line: 1, column: 1, source: nil)..<SourceLocation(line: 1, column: 1, source: nil)
             let diagnostic = Diagnostic(source: source, severity: .warning, range: range, identifier: "org.swift.docc.Article.Title.NotFound", summary: "An article is expected to start with a top-level heading title")
@@ -126,7 +125,7 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
             guard let childDirective = child as? BlockDirective, childDirective.name == Redirect.directiveName else {
                 return nil
             }
-            return Redirect(from: childDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Redirect(from: childDirective, source: source, for: bundle, problems: &problems)
         }
         
         var optionalMetadata = DirectiveParser()
@@ -136,7 +135,6 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
                 parentType: Article.self,
                 source: source,
                 bundle: bundle,
-                context: context,
                 problems: &problems
             )
 
@@ -155,7 +153,6 @@ public final class Article: Semantic, MarkupConvertible, Abstracted, Redirected,
                 from: childDirective,
                 source: source,
                 for: bundle,
-                in: context,
                 problems: &problems
             )
         }

--- a/Sources/SwiftDocC/Semantics/Article/MarkupConvertible.swift
+++ b/Sources/SwiftDocC/Semantics/Article/MarkupConvertible.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,13 +13,27 @@ import Markdown
 
 /// A type that can be initialized from markup.
 public protocol MarkupConvertible {
-    /// Initializes a new element with a given markup and source for a given documentation bundle and documentation context.
+    /// Initializes a new element with a given markup and source that's part of a given documentation bundle.
     ///
     /// - Parameters:
     ///   - markup: The markup that makes up this element's content.
     ///   - source: The location of the file that this element's content comes from.
-    ///   - bundle: The documentation bundle that the element belongs to.
-    ///   - context: The documentation context that the element belongs to.
+    ///   - bundle: The documentation bundle that the source file belongs to.
     ///   - problems: A mutable collection of problems to update with any problem encountered while initializing the element.
+    init?(from markup: Markup, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem])
+    
+    @available(*, deprecated, renamed: "init(from:source:for:problems:)", message: "Use 'init(from:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
     init?(from markup: Markup, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem])
+}
+
+public extension MarkupConvertible {
+    // Default implementation to avoid source breaking changes. Remove this after 6.2 is released.
+    init?(from markup: Markup, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
+        fatalError("Markup convertible type doesn't implement either 'init(from:source:for:problems:)' or 'init(from:source:for:in:problems:)'")
+    }
+    
+    // Default implementation to new types don't need to implement a deprecated initializer. Remove this after 6.2 is released.
+    init?(from markup: Markup, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+        self.init(from: markup, source: source, for: bundle, problems: &problems)
+    }
 }

--- a/Sources/SwiftDocC/Semantics/Comment.swift
+++ b/Sources/SwiftDocC/Semantics/Comment.swift
@@ -33,7 +33,7 @@ public final class Comment: Semantic, DirectiveConvertible {
         self.content = content
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for _: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for _: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == Comment.directiveName)
         self.init(originalMarkup: directive, content: MarkupContainer(directive.children))
     }

--- a/Sources/SwiftDocC/Semantics/ContentAndMedia.swift
+++ b/Sources/SwiftDocC/Semantics/ContentAndMedia.swift
@@ -75,7 +75,7 @@ public final class ContentAndMedia: Semantic, DirectiveConvertible {
         self.mediaPosition = mediaPosition
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         let arguments = Semantic.Analyses.HasOnlyKnownArguments<ContentAndMedia>(severityIfFound: .warning, allowedArguments: [Semantics.Title.argumentName, Semantics.Layout.argumentName, Semantics.Eyebrow.argumentName]).analyze(directive, children: directive.children, source: source, problems: &problems)
         
         Semantic.Analyses.HasOnlyKnownDirectives<ContentAndMedia>(severityIfFound: .warning, allowedDirectives: [ImageMedia.directiveName, VideoMedia.directiveName]).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -85,7 +85,7 @@ public final class ContentAndMedia: Semantic, DirectiveConvertible {
         
         let layout = Semantic.Analyses.DeprecatedArgument<ContentAndMedia, Semantics.Layout>.unused(severityIfFound: .warning).analyze(directive, arguments: arguments, problems: &problems)
         
-        let (media, remainder) = Semantic.Analyses.HasExactlyOneMedia<ContentAndMedia>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        let (media, remainder) = Semantic.Analyses.HasExactlyOneMedia<ContentAndMedia>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
         
         let mediaPosition: MediaPosition
         if let firstChildDirective = directive.child(at: 0) as? BlockDirective,

--- a/Sources/SwiftDocC/Semantics/DirectiveConvertable.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveConvertable.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -34,9 +34,11 @@ public protocol DirectiveConvertible {
     /// - Parameters:
     ///   -  directive: The parsed block directive to create a semantic object from.
     ///   -  source: The location of the source file that contains the markup for the parsed block directive.
-    ///   -  bundle: The documentation bundle that owns the directive.
-    ///   -  context: The documentation context in which the bundle resides.
+    ///   -  bundle: The documentation bundle that the source file belongs to.
     ///   -  problems: An inout array of ``Problem`` to be collected for later diagnostic reporting.
+    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem])
+    
+    @available(*, deprecated, renamed: "init(from:source:for:problems:)", message: "Use 'init(from:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
     init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem])
     
     /// Returns a Boolean value indicating whether the `DirectiveConvertible` recognizes the given directive.
@@ -51,6 +53,16 @@ public extension DirectiveConvertible {
     /// - Parameter directive: The directive to check for conversion compatibility.
     static func canConvertDirective(_ directive: BlockDirective) -> Bool {
         directiveName == directive.name
+    }
+    
+    // Default implementation to avoid source breaking changes. Remove this after 6.2 is released.
+    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
+        fatalError("Directive named \(directive.name) doesn't implement either 'init(from:source:for:problems:)' or 'init(from:source:for:in:problems:)'")
+    }
+    
+    // Default implementation to new types don't need to implement a deprecated initializer. Remove this after 6.2 is released.
+    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+        self.init(from: directive, source: source, for: bundle, problems: &problems)
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/AutomaticDirectiveConvertible.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/AutomaticDirectiveConvertible.swift
@@ -88,7 +88,7 @@ extension AutomaticDirectiveConvertible {
     /// Performs some semantic analyses to determine whether a valid directive can be created
     /// and returns nils upon failure.
     ///
-    /// > Tip: ``DirectiveConvertible/init(from:source:for:in:problems:)`` performs
+    /// > Tip: ``DirectiveConvertible/init(from:source:for:problems:)`` performs
     /// the same function but supports collecting an array of problems for diagnostics.
     ///
     /// - Parameters:
@@ -99,8 +99,7 @@ extension AutomaticDirectiveConvertible {
     public init?(
         from directive: BlockDirective,
         source: URL? = nil,
-        for bundle: DocumentationBundle,
-        in context: DocumentationContext
+        for bundle: DocumentationBundle
     ) {
         var problems = [Problem]()
         
@@ -108,16 +107,19 @@ extension AutomaticDirectiveConvertible {
             from: directive,
             source: source,
             for: bundle,
-            in: context,
             problems: &problems
         )
+    }
+    
+    @available(*, deprecated, renamed: "init(from:source:for:)", message: "Use 'init(from:source:for:)' instead. This deprecated API will be removed after 6.2 is released")
+    public init?(from directive: BlockDirective, source: URL? = nil, for bundle: DocumentationBundle, in _: DocumentationContext) {
+        self.init(from: directive, source: source, for: bundle)
     }
     
     public init?(
         from directive: BlockDirective,
         source: URL?,
         for bundle: DocumentationBundle,
-        in context: DocumentationContext,
         problems: inout [Problem]
     ) {
         precondition(directive.name == Self.directiveName)
@@ -181,7 +183,6 @@ extension AutomaticDirectiveConvertible {
             children: remainder,
             source: source,
             for: bundle,
-            in: context,
             problems: &problems
         )
         
@@ -195,7 +196,6 @@ extension AutomaticDirectiveConvertible {
                     children: remainder,
                     source: source,
                     for: bundle,
-                    in: context,
                     problems: &problems
                 )
                 
@@ -220,7 +220,6 @@ extension AutomaticDirectiveConvertible {
                     children: remainder,
                     source: source,
                     for: bundle,
-                    in: context,
                     problems: &problems
                 )
                 
@@ -244,7 +243,6 @@ extension AutomaticDirectiveConvertible {
                     children: remainder,
                     source: source,
                     for: bundle,
-                    in: context,
                     problems: &problems
                 )
                 
@@ -259,7 +257,6 @@ extension AutomaticDirectiveConvertible {
                     children: remainder,
                     source: source,
                     for: bundle,
-                    in: context,
                     problems: &problems
                 )
                 

--- a/Sources/SwiftDocC/Semantics/DirectiveParser.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveParser.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -11,7 +11,7 @@
 import Foundation
 import Markdown
 
-/// A utlity type for parsing directives from markup.
+/// A utility type for parsing directives from markup.
 struct DirectiveParser<Directive: AutomaticDirectiveConvertible> {
     
     /// Returns a directive of the given type if found in the given sequence of markup elements and the remaining markup.
@@ -24,7 +24,6 @@ struct DirectiveParser<Directive: AutomaticDirectiveConvertible> {
         parentType: Semantic.Type,
         source: URL?,
         bundle: DocumentationBundle,
-        context: DocumentationContext,
         problems: inout [Problem]
     ) -> Directive? {
         let (directiveElements, remainder) = markupElements.categorize { markup -> Directive? in
@@ -37,7 +36,6 @@ struct DirectiveParser<Directive: AutomaticDirectiveConvertible> {
                 from: childDirective,
                 source: source,
                 for: bundle,
-                in: context,
                 problems: &problems
             )
         }

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/Extract.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/Extract.swift
@@ -18,13 +18,17 @@ extension Semantic.Analyses {
     public struct ExtractAll<Child: Semantic & DirectiveConvertible> {
         public init() {}
         
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> ([Child], remainder: MarkupContainer) {
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> ([Child], remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> ([Child], remainder: MarkupContainer) {
             return Semantic.Analyses.extractAll(
                 childType: Child.self,
                 children: children,
                 source: source,
                 for: bundle,
-                in: context,
                 problems: &problems
             ) as! ([Child], MarkupContainer)
         }
@@ -35,7 +39,6 @@ extension Semantic.Analyses {
         children: some Sequence<Markup>,
         source: URL?,
         for bundle: DocumentationBundle,
-        in context: DocumentationContext,
         problems: inout [Problem]
     ) -> ([DirectiveConvertible], remainder: MarkupContainer) {
         let (candidates, remainder) = children.categorize { child -> BlockDirective? in
@@ -46,7 +49,7 @@ extension Semantic.Analyses {
             return childDirective
         }
         let converted = candidates.compactMap {
-            childType.init(from: $0, source: source, for: bundle, in: context, problems: &problems)
+            childType.init(from: $0, source: source, for: bundle, problems: &problems)
         }
         return (converted, remainder: MarkupContainer(remainder))
     }

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtLeastOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtLeastOne.swift
@@ -21,12 +21,16 @@ extension Semantic.Analyses {
             self.severityIfNotFound = severityIfNotFound
         }
         
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> ([Child], remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
         public func analyze(
             _ directive: BlockDirective,
             children: some Sequence<Markup>,
             source: URL?,
             for bundle: DocumentationBundle,
-            in context: DocumentationContext,
             problems: inout [Problem]
         ) -> ([Child], remainder: MarkupContainer) {
             Semantic.Analyses.extractAtLeastOne(
@@ -35,7 +39,6 @@ extension Semantic.Analyses {
                 children: children,
                 source: source,
                 for: bundle,
-                in: context,
                 severityIfNotFound: severityIfNotFound,
                 problems: &problems
             ) as! ([Child], MarkupContainer)
@@ -48,7 +51,6 @@ extension Semantic.Analyses {
         children: some Sequence<Markup>,
         source: URL?,
         for bundle: DocumentationBundle,
-        in context: DocumentationContext,
         severityIfNotFound: DiagnosticSeverity? = .warning,
         problems: inout [Problem]
     ) -> ([DirectiveConvertible], remainder: MarkupContainer) {
@@ -83,7 +85,6 @@ extension Semantic.Analyses {
                 from: childDirective,
                 source: source,
                 for: bundle,
-                in: context,
                 problems: &problems
             )
         }

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtMostOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtMostOne.swift
@@ -17,14 +17,18 @@ extension Semantic.Analyses {
      */
     public struct HasAtMostOne<Parent: Semantic & DirectiveConvertible, Child: Semantic & DirectiveConvertible> {
         
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> (Child?, remainder: MarkupContainer) {
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> (Child?, remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> (Child?, remainder: MarkupContainer) {
             return Semantic.Analyses.extractAtMostOne(
                 childType: Child.self,
                 parentDirective: directive,
                 children: children,
                 source: source,
                 for: bundle,
-                in: context,
                 problems: &problems
             ) as! (Child?, MarkupContainer)
         }
@@ -36,7 +40,6 @@ extension Semantic.Analyses {
         children: some Sequence<Markup>,
         source: URL?,
         for bundle: DocumentationBundle,
-        in context: DocumentationContext,
         severityIfNotFound: DiagnosticSeverity = .warning,
         problems: inout [Problem]
     ) -> (DirectiveConvertible?, remainder: MarkupContainer) {
@@ -70,7 +73,7 @@ extension Semantic.Analyses {
             problems.append(Problem(diagnostic: diagnostic, possibleSolutions: []))
         }
         
-        return (childType.init(from: match, source: source, for: bundle, in: context, problems: &problems), MarkupContainer(remainder))
+        return (childType.init(from: match, source: source, for: bundle, problems: &problems), MarkupContainer(remainder))
     }
 }
 

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasContent.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasContent.swift
@@ -38,7 +38,7 @@ extension Semantic.Analyses {
         }
         
         @available(*, deprecated, renamed: "analyze(_:children:source:problems:)", message: "Use 'analyze(_:children:source:problems:)' instead. This deprecated API will be removed after 6.2 is released")
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> MarkupContainer {
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for _: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> MarkupContainer {
             analyze(directive, children: children, source: source, problems: &problems)
         }
     }

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasExactlyOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasExactlyOne.swift
@@ -21,14 +21,18 @@ extension Semantic.Analyses {
             self.severityIfNotFound = severityIfNotFound
         }
         
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> (Child?, remainder: MarkupContainer) {
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> (Child?, remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> (Child?, remainder: MarkupContainer) {
             return Semantic.Analyses.extractExactlyOne(
                 childType: Child.self,
                 parentDirective: directive,
                 children: children,
                 source: source,
                 for: bundle,
-                in: context,
                 severityIfNotFound: severityIfNotFound,
                 problems: &problems
             ) as! (Child?, MarkupContainer)
@@ -41,7 +45,6 @@ extension Semantic.Analyses {
         children: some Sequence<Markup>,
         source: URL?,
         for bundle: DocumentationBundle,
-        in context: DocumentationContext,
         severityIfNotFound: DiagnosticSeverity? = .warning,
         problems: inout [Problem]
     ) -> (DirectiveConvertible?, remainder: MarkupContainer) {
@@ -91,7 +94,7 @@ extension Semantic.Analyses {
             }
         }
         
-        return (childType.init(from: candidate, source: source, for: bundle, in: context, problems: &problems), MarkupContainer(remainder))
+        return (childType.init(from: candidate, source: source, for: bundle, problems: &problems), MarkupContainer(remainder))
     }
     
     /// Checks a parent directive for the presence of exactly one of two child directives---but not both---to be converted to a type ``SemanticAnalysis/Result``. If so, return that child and the remainder.
@@ -101,7 +104,12 @@ extension Semantic.Analyses {
             self.severityIfNotFound = severityIfNotFound
         }
         
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> (Child1?, Child2?, remainder: MarkupContainer) {
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> (Child1?, Child2?, remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> (Child1?, Child2?, remainder: MarkupContainer) {
             let (candidates, remainder) = children.categorize { child -> BlockDirective? in
                 guard let childDirective = child as? BlockDirective else {
                     return nil
@@ -129,12 +137,12 @@ extension Semantic.Analyses {
             
             switch candidate.name {
             case Child1.directiveName:
-                guard let first = Child1(from: candidate, source: source, for: bundle, in: context, problems: &problems) else {
+                guard let first = Child1(from: candidate, source: source, for: bundle, problems: &problems) else {
                     return (nil, nil, remainder: MarkupContainer(remainder))
                 }
                 return (first, nil, remainder: MarkupContainer(remainder))
             case Child2.directiveName:
-                guard let second = Child2(from: candidate, source: source, for: bundle, in: context, problems: &problems) else {
+                guard let second = Child2(from: candidate, source: source, for: bundle, problems: &problems) else {
                     return (nil, nil, remainder: MarkupContainer(remainder))
                 }
                 return (nil, second, remainder: MarkupContainer(remainder))
@@ -150,9 +158,14 @@ extension Semantic.Analyses {
         public init(severityIfNotFound: DiagnosticSeverity?) {
             self.severityIfNotFound = severityIfNotFound
         }
-
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> (Media?, remainder: MarkupContainer) {
-            let (foundImage, foundVideo, remainder) = HasExactlyOneOf<Parent, ImageMedia, VideoMedia>(severityIfNotFound: severityIfNotFound).analyze(directive, children: children, source: source, for: bundle, in: context, problems: &problems)
+        
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> (Media?, remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> (Media?, remainder: MarkupContainer) {
+            let (foundImage, foundVideo, remainder) = HasExactlyOneOf<Parent, ImageMedia, VideoMedia>(severityIfNotFound: severityIfNotFound).analyze(directive, children: children, source: source, for: bundle, problems: &problems)
             return (foundImage ?? foundVideo, remainder)
         }
     }
@@ -164,7 +177,12 @@ extension Semantic.Analyses {
             self.severityIfNotFound = severityIfNotFound
         }
         
-        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> (Media?, remainder: MarkupContainer) {
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released")
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> (Media?, remainder: MarkupContainer) {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> (Media?, remainder: MarkupContainer) {
             let (mediaDirectives, remainder) = children.categorize { child -> BlockDirective? in
                 guard let childDirective = child as? BlockDirective else {
                     return nil
@@ -201,12 +219,12 @@ extension Semantic.Analyses {
             
             switch firstMedia.name {
             case ImageMedia.directiveName:
-                guard let image = ImageMedia(from: firstMedia, source: source, for: bundle, in: context, problems: &problems) else {
+                guard let image = ImageMedia(from: firstMedia, source: source, for: bundle, problems: &problems) else {
                     return (nil, remainder: MarkupContainer(remainder))
                 }
                 return (image, remainder: MarkupContainer(remainder))
             case VideoMedia.directiveName:
-                guard let video = VideoMedia(from: firstMedia, source: source, for: bundle, in: context, problems: &problems) else {
+                guard let video = VideoMedia(from: firstMedia, source: source, for: bundle, problems: &problems) else {
                     return (nil, remainder: MarkupContainer(remainder))
                 }
                 return (video, remainder: MarkupContainer(remainder))

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlySequentialHeadings.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlySequentialHeadings.swift
@@ -35,10 +35,13 @@ extension Semantic.Analyses {
             self.startingFromLevel = startingFromLevel
         }
         
-        /**
-         - returns: All valid headings.
-         */
-        @discardableResult public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for _: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> [Heading] {
+        @available(*, deprecated, renamed: "analyze(_:children:source:for:problems:)", message: "Use 'analyze(_:children:source:for:problems:)' instead. This deprecated API will be removed after 6.2 is released") 
+        @discardableResult public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) -> [Heading] {
+            analyze(directive, children: children, source: source, for: bundle, problems: &problems)
+        }
+        
+        /// Returns all valid headings.
+        @discardableResult public func analyze(_ directive: BlockDirective, children: some Sequence<Markup>, source: URL?, for _: DocumentationBundle, problems: inout [Problem]) -> [Heading] {
             var currentHeadingLevel = startingFromLevel
             var headings: [Heading] = []
             for case let child as Heading in children {

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -172,7 +172,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
         switch blockDirective.name {
         case Snippet.directiveName:
             var problems = [Problem]()
-            guard let snippet = Snippet(from: blockDirective, source: source, for: bundle, in: context, problems: &problems) else {
+            guard let snippet = Snippet(from: blockDirective, source: source, for: bundle, problems: &problems) else {
                 return blockDirective
             }
             
@@ -192,7 +192,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
                 return blockDirective
             }
         case ImageMedia.directiveName:
-            guard let imageMedia = ImageMedia(from: blockDirective, source: source, for: bundle, in: context) else {
+            guard let imageMedia = ImageMedia(from: blockDirective, source: source, for: bundle) else {
                 return blockDirective
             }
             
@@ -210,7 +210,7 @@ struct MarkupReferenceResolver: MarkupRewriter {
             
             return blockDirective
         case VideoMedia.directiveName:
-            guard let videoMedia = VideoMedia(from: blockDirective, source: source, for: bundle, in: context) else {
+            guard let videoMedia = VideoMedia(from: blockDirective, source: source, for: bundle) else {
                 return blockDirective
             }
             

--- a/Sources/SwiftDocC/Semantics/SemanticAnalyzer.swift
+++ b/Sources/SwiftDocC/Semantics/SemanticAnalyzer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,12 +14,10 @@ import Markdown
 struct SemanticAnalyzer: MarkupVisitor {
     var problems = [Problem]()
     let source: URL?
-    let context: DocumentationContext
     let bundle: DocumentationBundle
     
-    init(source: URL?, context: DocumentationContext, bundle: DocumentationBundle) {
+    init(source: URL?, bundle: DocumentationBundle) {
         self.source = source
-        self.context = context
         self.bundle = bundle
     }
 
@@ -79,7 +77,7 @@ struct SemanticAnalyzer: MarkupVisitor {
         }
         
         if topLevelChildren.isEmpty {
-            guard let article = Article(from: document, source: source, for: bundle, in: context, problems: &problems) else {
+            guard let article = Article(from: document, source: source, for: bundle, problems: &problems) else {
                 // We've already diagnosed the invalid article.
                 return nil
             }
@@ -102,58 +100,58 @@ struct SemanticAnalyzer: MarkupVisitor {
     mutating func visitBlockDirective(_ blockDirective: BlockDirective) -> Semantic? {
         switch blockDirective.name {
         case TutorialTableOfContents.directiveName:
-            return TutorialTableOfContents(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return TutorialTableOfContents(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Volume.directiveName:
-            return Volume(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Volume(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Chapter.directiveName:
-            return Chapter(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Chapter(from: blockDirective, source: source, for: bundle, problems: &problems)
         case TutorialReference.directiveName:
-            return TutorialReference(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return TutorialReference(from: blockDirective, source: source, for: bundle, problems: &problems)
         case ContentAndMedia.directiveName:
-            return ContentAndMedia(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return ContentAndMedia(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Intro.directiveName:
-            return Intro(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Intro(from: blockDirective, source: source, for: bundle, problems: &problems)
         case ImageMedia.directiveName:
-            return ImageMedia(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return ImageMedia(from: blockDirective, source: source, for: bundle, problems: &problems)
         case VideoMedia.directiveName:
-            return VideoMedia(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return VideoMedia(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Tutorial.directiveName:
-            return Tutorial(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Tutorial(from: blockDirective, source: source, for: bundle, problems: &problems)
         case TutorialArticle.directiveName:
-            return TutorialArticle(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return TutorialArticle(from: blockDirective, source: source, for: bundle, problems: &problems)
         case XcodeRequirement.directiveName:
-            return XcodeRequirement(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return XcodeRequirement(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Assessments.directiveName:
-            return Assessments(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Assessments(from: blockDirective, source: source, for: bundle, problems: &problems)
         case MultipleChoice.directiveName:
-            return MultipleChoice(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return MultipleChoice(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Choice.directiveName:
-            return Choice(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Choice(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Justification.directiveName:
-            return Justification(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Justification(from: blockDirective, source: source, for: bundle, problems: &problems)
         case TutorialSection.directiveName:
-            return TutorialSection(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return TutorialSection(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Step.directiveName:
-            return Step(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Step(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Resources.directiveName:
-            return Resources(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Resources(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Comment.directiveName:
-            return Comment(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Comment(from: blockDirective, source: source, for: bundle, problems: &problems)
         case DeprecationSummary.directiveName:
-            return DeprecationSummary(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return DeprecationSummary(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Metadata.directiveName:
-            return Metadata(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Metadata(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Redirect.directiveName:
-            return Redirect(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Redirect(from: blockDirective, source: source, for: bundle, problems: &problems)
         case DocumentationExtension.directiveName:
-            return DocumentationExtension(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            return DocumentationExtension(from: blockDirective, source: source, for: bundle, problems: &problems)
         case Snippet.directiveName:
             // A snippet directive does not need to stay around as a Semantic object.
             // we only need to check the path argument and that it doesn't
             // have any inner content as a convenience to the author.
             // The path will resolve as a symbol link later in the
             // MarkupReferenceResolver.
-            _ = Snippet(from: blockDirective, source: source, for: bundle, in: context, problems: &problems)
+            _ = Snippet(from: blockDirective, source: source, for: bundle, problems: &problems)
             return nil
         case Options.directiveName:
             return nil
@@ -169,7 +167,6 @@ struct SemanticAnalyzer: MarkupVisitor {
                 from: blockDirective,
                 source: source,
                 for: bundle,
-                in: context,
                 problems: &problems
             ) else {
                 return nil

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,7 +50,7 @@ public final class Snippet: Semantic, AutomaticDirectiveConvertible {
 
 extension Snippet: RenderableDirectiveConvertible {
     func render(with contentCompiler: inout RenderContentCompiler) -> [RenderContent] {
-        guard let snippet = Snippet(from: originalMarkup, for: contentCompiler.bundle, in: contentCompiler.context) else {
+        guard let snippet = Snippet(from: originalMarkup, for: contentCompiler.bundle) else {
                 return []
             }
             

--- a/Sources/SwiftDocC/Semantics/Technology/Resources/Resources.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Resources/Resources.swift
@@ -54,7 +54,7 @@ public final class Resources: Semantic, DirectiveConvertible, Abstracted, Redire
         self.redirects = redirects
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == Resources.directiveName)
         
         var remainder: [Markup]
@@ -76,7 +76,7 @@ public final class Resources: Semantic, DirectiveConvertible, Abstracted, Redire
             guard let childDirective = child as? BlockDirective, childDirective.name == Redirect.directiveName else {
                 return nil
             }
-            return Redirect(from: childDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Redirect(from: childDirective, source: source, for: bundle, problems: &problems)
         }
         
         let tiles: [Tile]
@@ -84,7 +84,7 @@ public final class Resources: Semantic, DirectiveConvertible, Abstracted, Redire
             guard let childDirective = child as? BlockDirective, Tile.DirectiveNames(rawValue: childDirective.name) != nil else {
                 return nil
             }
-            return Tile(from: childDirective, source: source, for: bundle, in: context, problems: &problems)
+            return Tile(from: childDirective, source: source, for: bundle, problems: &problems)
         }
         
         var seenTileDirectiveNames = Set<String>()

--- a/Sources/SwiftDocC/Semantics/Technology/Resources/Tile.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Resources/Tile.swift
@@ -166,7 +166,7 @@ public final class Tile: Semantic, DirectiveConvertible {
         self.init(originalMarkup: directive, identifier: tileIdentifier, title: title, destination: destination, content: MarkupContainer(directive.children))
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for _: DocumentationBundle, in _: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for _: DocumentationBundle, problems: inout [Problem]) {
         switch directive.name {
         case Tile.DirectiveNames.documentation.rawValue:
             self.init(genericTile: directive,

--- a/Sources/SwiftDocC/Semantics/Technology/TutorialTableOfContents.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/TutorialTableOfContents.swift
@@ -59,7 +59,7 @@ public final class TutorialTableOfContents: Semantic, DirectiveConvertible, Abst
         }
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == TutorialTableOfContents.directiveName)
         
         let arguments = Semantic.Analyses.HasOnlyKnownArguments<TutorialTableOfContents>(severityIfFound: .warning, allowedArguments: [Semantics.Name.argumentName]).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -67,15 +67,15 @@ public final class TutorialTableOfContents: Semantic, DirectiveConvertible, Abst
         Semantic.Analyses.HasOnlyKnownDirectives<TutorialTableOfContents>(severityIfFound: .warning, allowedDirectives: [Intro.directiveName, Volume.directiveName, Chapter.directiveName, Resources.directiveName, Redirect.directiveName]).analyze(directive, children: directive.children, source: source, problems: &problems)
     
         let requiredName = Semantic.Analyses.HasArgument<TutorialTableOfContents, Semantics.Name>(severityIfNotFound: .warning).analyze(directive, arguments: arguments, problems: &problems)
-        let requiredIntro = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, Intro>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems).0
+        let requiredIntro = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, Intro>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems).0
         
         var volumes: [Volume]
         var remainder: MarkupContainer
-        (volumes, remainder) = Semantic.Analyses.HasAtLeastOne<TutorialTableOfContents, Volume>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (volumes, remainder) = Semantic.Analyses.HasAtLeastOne<TutorialTableOfContents, Volume>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
 
         // Retrieve chapters outside volumes.
         let chapters: [Chapter]
-        (chapters, remainder) = Semantic.Analyses.HasAtLeastOne<TutorialTableOfContents, Chapter>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (chapters, remainder) = Semantic.Analyses.HasAtLeastOne<TutorialTableOfContents, Chapter>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
 
         if !chapters.isEmpty {
             if !volumes.isEmpty {
@@ -94,10 +94,10 @@ public final class TutorialTableOfContents: Semantic, DirectiveConvertible, Abst
         }
         
         let resources: Resources?
-        (resources, remainder) = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, Resources>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (resources, remainder) = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, Resources>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
 
         let redirects: [Redirect]
-            (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+            (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         guard let name = requiredName,
             let intro = requiredIntro else {

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
@@ -63,7 +63,7 @@ public final class Volume: Semantic, DirectiveConvertible, Abstracted, Redirecte
         }
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == Volume.directiveName)
         
         let arguments = Semantic.Analyses.HasOnlyKnownArguments<Volume>(severityIfFound: .warning, allowedArguments: [Semantics.Name.argumentName]).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -74,14 +74,14 @@ public final class Volume: Semantic, DirectiveConvertible, Abstracted, Redirecte
         
         let image: ImageMedia?
         var remainder: MarkupContainer
-        (image, remainder) = Semantic.Analyses.HasExactlyOne<Volume, ImageMedia>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (image, remainder) = Semantic.Analyses.HasExactlyOne<Volume, ImageMedia>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
         
         let chapters: [Chapter]
-        (chapters, remainder) = Semantic.Analyses.HasAtLeastOne<Volume, Chapter>(severityIfNotFound: .warning).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (chapters, remainder) = Semantic.Analyses.HasAtLeastOne<Volume, Chapter>(severityIfNotFound: .warning).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         _ = Semantic.Analyses.HasContent<Volume>(additionalContext: "A \(Volume.directiveName.singleQuoted) directive should at least have a sentence summarizing what the reader will learn").analyze(directive, children: remainder, source: source, problems: &problems)
         
         let redirects: [Redirect]
-        (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         guard let name = requiredName else {
             return nil

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/MultipleChoice.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/MultipleChoice.swift
@@ -51,7 +51,7 @@ public final class MultipleChoice: Semantic, DirectiveConvertible {
         self.choices = choices
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == MultipleChoice.directiveName)
         
         _ = Semantic.Analyses.HasOnlyKnownArguments<MultipleChoice>(severityIfFound: .warning, allowedArguments: []).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -70,7 +70,7 @@ public final class MultipleChoice: Semantic, DirectiveConvertible {
         }
         
         let choices: [Choice]
-        (choices, remainder) = Semantic.Analyses.ExtractAll<Choice>().analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (choices, remainder) = Semantic.Analyses.ExtractAll<Choice>().analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         if choices.count < 2 || choices.count > 4 {
             let diagnostic = Diagnostic(source: source, severity: .warning, range: directive.range, identifier: "org.swift.docc.\(MultipleChoice.self).CorrectNumberOfChoices", summary: "`\(MultipleChoice.directiveName)` should contain 2-4 `\(Choice.directiveName)` child directives")
@@ -115,7 +115,7 @@ public final class MultipleChoice: Semantic, DirectiveConvertible {
         }
         
         let images: [ImageMedia]
-        (images, remainder) = Semantic.Analyses.ExtractAll<ImageMedia>().analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (images, remainder) = Semantic.Analyses.ExtractAll<ImageMedia>().analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         if images.count > 1 {
             for extraneousImage in images.suffix(from: 1) {

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
@@ -59,7 +59,7 @@ public final class Code: Semantic, DirectiveConvertible {
         self.preview = preview
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == Code.directiveName)
         
         let arguments = Semantic.Analyses.HasOnlyKnownArguments<Code>(severityIfFound: .warning, allowedArguments: [Semantics.File.argumentName, Semantics.PreviousFile.argumentName, Semantics.Name.argumentName, Semantics.ResetDiff.argumentName]).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -80,7 +80,7 @@ public final class Code: Semantic, DirectiveConvertible {
             shouldResetDiff = false
         }
        
-        let (optionalPreview, _) = Semantic.Analyses.HasExactlyOneImageOrVideoMedia<Code>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        let (optionalPreview, _) = Semantic.Analyses.HasExactlyOneImageOrVideoMedia<Code>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
         
         let optionalPreviousFileReference = Semantic.Analyses.HasArgument<Code, Semantics.PreviousFile>(severityIfNotFound: nil).analyze(directive, arguments: arguments, problems: &problems).map { argument in
             ResourceReference(bundleID: bundle.id, path: argument)

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Step.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Step.swift
@@ -46,7 +46,7 @@ public final class Step: Semantic, DirectiveConvertible {
         self.caption = caption
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == Step.directiveName)
         
         _ = Semantic.Analyses.HasOnlyKnownArguments<Step>(severityIfFound: .warning, allowedArguments: []).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -55,10 +55,10 @@ public final class Step: Semantic, DirectiveConvertible {
         
         var remainder: MarkupContainer
         let optionalMedia: Media?
-        (optionalMedia, remainder) = Semantic.Analyses.HasExactlyOneMedia<Step>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (optionalMedia, remainder) = Semantic.Analyses.HasExactlyOneMedia<Step>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
         
         let optionalCode: Code?
-        (optionalCode, remainder) = Semantic.Analyses.HasExactlyOne<Step, Code>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (optionalCode, remainder) = Semantic.Analyses.HasExactlyOne<Step, Code>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         let paragraphs: [Paragraph]
         (paragraphs, remainder) = Semantic.Analyses.ExtractAllMarkup<Paragraph>().analyze(directive, children: remainder, source: source, problems: &problems)

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Steps.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Steps.swift
@@ -34,7 +34,7 @@ public final class Steps: Semantic, DirectiveConvertible {
         self.content = content
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == Steps.directiveName)
         
         _ = Semantic.Analyses.HasOnlyKnownArguments<Steps>(severityIfFound: .warning, allowedArguments: [])
@@ -46,7 +46,7 @@ public final class Steps: Semantic, DirectiveConvertible {
         let stepsContent: [Semantic] = directive.children.compactMap { child -> Semantic? in
             if let directive = child as? BlockDirective,
                 directive.name == Step.directiveName {
-                return Step(from: directive, source: source, for: bundle, in: context, problems: &problems)
+                return Step(from: directive, source: source, for: bundle, problems: &problems)
             } else {
                 return MarkupContainer(child)
             }

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/TutorialSection.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/TutorialSection.swift
@@ -77,7 +77,7 @@ public final class TutorialSection: Semantic, DirectiveConvertible, Abstracted, 
         }
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == TutorialSection.directiveName)
         
         let arguments = Semantic.Analyses.HasOnlyKnownArguments<TutorialSection>(severityIfFound: .warning, allowedArguments: [Semantics.Title.argumentName]).analyze(directive, children: directive.children, source: source, problems: &problems)
@@ -88,14 +88,14 @@ public final class TutorialSection: Semantic, DirectiveConvertible, Abstracted, 
         
         var remainder: MarkupContainer
         let optionalSteps: Steps?
-        (optionalSteps, remainder) = Semantic.Analyses.HasExactlyOne<TutorialSection, Steps>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (optionalSteps, remainder) = Semantic.Analyses.HasExactlyOne<TutorialSection, Steps>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
         
-        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         let redirects: [Redirect]
-            (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+            (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
-        let content = StackedContentParser.topLevelContent(from: remainder, source: source, for: bundle, in: context, problems: &problems)
+        let content = StackedContentParser.topLevelContent(from: remainder, source: source, for: bundle, problems: &problems)
         
         guard let title = requiredTitle else {
             return nil

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
@@ -102,7 +102,7 @@ public final class TutorialArticle: Semantic, DirectiveConvertible, Abstracted, 
         self.redirects = redirects
     }
     
-    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    public convenience init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(directive.name == TutorialArticle.directiveName)
         
         let arguments = Semantic.Analyses.HasOnlyKnownArguments<TutorialArticle>(severityIfFound: .warning, allowedArguments: [Semantics.Time.argumentName])
@@ -116,20 +116,20 @@ public final class TutorialArticle: Semantic, DirectiveConvertible, Abstracted, 
             
         var remainder: MarkupContainer
         let optionalIntro: Intro?
-        (optionalIntro, remainder) = Semantic.Analyses.HasExactlyOne<TutorialArticle, Intro>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, in: context, problems: &problems)
+        (optionalIntro, remainder) = Semantic.Analyses.HasExactlyOne<TutorialArticle, Intro>(severityIfNotFound: .warning).analyze(directive, children: directive.children, source: source, for: bundle, problems: &problems)
         
-        let headings = Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        let headings = Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
-        let content = StackedContentParser.topLevelContent(from: remainder, source: source, for: bundle, in: context, problems: &problems)
+        let content = StackedContentParser.topLevelContent(from: remainder, source: source, for: bundle, problems: &problems)
         
         let optionalAssessments: Assessments?
-        (optionalAssessments, remainder) = Semantic.Analyses.HasAtMostOne<Tutorial, Assessments>().analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (optionalAssessments, remainder) = Semantic.Analyses.HasAtMostOne<Tutorial, Assessments>().analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         let optionalCallToActionImage: ImageMedia?
-        (optionalCallToActionImage, remainder) = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, ImageMedia>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+        (optionalCallToActionImage, remainder) = Semantic.Analyses.HasExactlyOne<TutorialTableOfContents, ImageMedia>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         let redirects: [Redirect]
-            (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, in: context, problems: &problems)
+            (redirects, remainder) = Semantic.Analyses.HasAtLeastOne<Chapter, Redirect>(severityIfNotFound: nil).analyze(directive, children: remainder, source: source, for: bundle, problems: &problems)
         
         self.init(originalMarkup: directive, durationMinutes: optionalTime, intro: optionalIntro, content: content, assessments: optionalAssessments, callToActionImage: optionalCallToActionImage, landmarks: headings, redirects: redirects.isEmpty ? nil : redirects)
     }
@@ -152,14 +152,14 @@ public enum MarkupLayout {
 }
 
 struct StackedContentParser {
-    static func topLevelContent(from markup: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) -> [MarkupLayout] {
+    static func topLevelContent(from markup: some Sequence<Markup>, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) -> [MarkupLayout] {
         return markup.reduce(into: []) { (accumulation, nextBlock) in
             if let directive = nextBlock as? BlockDirective {
                 if directive.name == Stack.directiveName,
-                    let stack = Stack(from: directive, source: source, for: bundle, in: context, problems: &problems) {
+                    let stack = Stack(from: directive, source: source, for: bundle, problems: &problems) {
                     accumulation.append(.stack(stack))
                 } else if directive.name == ContentAndMedia.directiveName,
-                    let contentAndMedia = ContentAndMedia(from: directive, source: source, for: bundle, in: context, problems: &problems) {
+                    let contentAndMedia = ContentAndMedia(from: directive, source: source, for: bundle, problems: &problems) {
                     accumulation.append(.contentAndMedia(contentAndMedia))
                 }
             } else {

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -185,7 +185,7 @@ class RenderNodeCodableTests: XCTestCase {
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let article = try XCTUnwrap(
-            Article(from: document.root, source: nil, for: bundle, in: context, problems: &problems)
+            Article(from: document.root, source: nil, for: bundle, problems: &problems)
         )
         
         let reference = ResolvedTopicReference(

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -26,7 +26,7 @@ class ReferenceResolverTests: XCTestCase {
         let directive = document.child(at: 0)! as! BlockDirective
         let (bundle, context) = try testBundleAndContext()
         var problems = [Problem]()
-        let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)!
+        let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)!
         
         var resolver = ReferenceResolver(context: context, bundle: bundle)
         _ = resolver.visitIntro(intro)
@@ -45,7 +45,7 @@ class ReferenceResolverTests: XCTestCase {
         let directive = document.child(at: 0)! as! BlockDirective
         let (bundle, context) = try testBundleAndContext()
         var problems = [Problem]()
-        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)!
+        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)!
         
         var resolver = ReferenceResolver(context: context, bundle: bundle)
         _ = resolver.visit(contentAndMedia)
@@ -62,7 +62,7 @@ class ReferenceResolverTests: XCTestCase {
         let directive = document.child(at: 0)! as! BlockDirective
         let (bundle, context) = try testBundleAndContext()
         var problems = [Problem]()
-        let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)!
+        let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)!
         
         var resolver = ReferenceResolver(context: context, bundle: bundle)
         
@@ -563,7 +563,7 @@ class ReferenceResolverTests: XCTestCase {
         let (bundle, context) = try testBundleAndContext()
         var problems = [Problem]()
 
-        let chapter = try XCTUnwrap(Chapter(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+        let chapter = try XCTUnwrap(Chapter(from: directive, source: nil, for: bundle, problems: &problems))
         var resolver = ReferenceResolver(context: context, bundle: bundle)
         _ = resolver.visitChapter(chapter)
         XCTAssertFalse(resolver.problems.containsErrors)
@@ -786,7 +786,6 @@ class ReferenceResolverTests: XCTestCase {
             from: Document(parsing: documentationExtensionContent, source: documentationExtensionURL, options: [.parseSymbolLinks, .parseBlockDirectives]),
             source: documentationExtensionURL,
             for: bundle,
-            in: context,
             problems: &ignoredProblems
         )
         XCTAssert(ignoredProblems.isEmpty, "Unexpected problems creating article")

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -101,7 +101,7 @@ class RenderNodeSerializationTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -124,7 +124,7 @@ class RenderNodeSerializationTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let article = TutorialArticle(from: articleDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let article = TutorialArticle(from: articleDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create article from markup: \(problems)")
             return
         }
@@ -149,7 +149,7 @@ class RenderNodeSerializationTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -201,7 +201,7 @@ class RenderNodeSerializationTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let article = TutorialArticle(from: articleDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let article = TutorialArticle(from: articleDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create article from markup: \(problems)")
             return
         }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -25,7 +25,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -412,7 +412,7 @@ class SemaToRenderNodeTests: XCTestCase {
             }
             
             var problems = [Problem]()
-            guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+            guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, problems: &problems) else {
                 XCTFail("Couldn't create tutorial from markup: \(problems)")
                 return
             }
@@ -578,7 +578,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -815,7 +815,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -1596,7 +1596,7 @@ class SemaToRenderNodeTests: XCTestCase {
         }
         
         var problems = [Problem]()
-        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorial = Tutorial(from: tutorialDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -2508,7 +2508,7 @@ Document
         }
         
         var problems = [Problem]()
-        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: tutorialTableOfContentsDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -2528,7 +2528,7 @@ Document
                 return
             }
             
-            guard let tutorial = Tutorial(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+            guard let tutorial = Tutorial(from: technologyDirective, source: nil, for: bundle, problems: &problems) else {
                 XCTFail("Couldn't create tutorial from markup: \(problems)")
                 return
             }
@@ -2600,7 +2600,7 @@ Document
         }
         
         var problems = [Problem]()
-        guard let tutorial = Tutorial(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorial = Tutorial(from: technologyDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create tutorial from markup: \(problems)")
             return
         }
@@ -3245,7 +3245,7 @@ Document
             return
         }
         var problems = [Problem]()
-        guard let tutorialTableOfContents = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, in: context, problems: &problems) else {
+        guard let tutorialTableOfContents = TutorialTableOfContents(from: technologyDirective, source: nil, for: bundle, problems: &problems) else {
             XCTFail("Couldn't create technology from markup: \(problems)")
             return
         }

--- a/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -75,12 +75,12 @@ class PageKindTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+        let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Metadata.directiveName, directive.name)
-            let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(metadata)
             XCTAssertNotNil(metadata?.pageKind)
             XCTAssertEqual(metadata?.pageKind?.kind, .article)

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -223,7 +223,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
             
     func testArticleRoles() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         
         // Verify article's role
@@ -236,7 +236,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let article = try XCTUnwrap(
-                Article(from: document.root, source: nil, for: bundle, in: context, problems: &problems)
+                Article(from: document.root, source: nil, for: bundle, problems: &problems)
             )
             XCTAssertEqual(RenderMetadata.Role.article, DocumentationContentRenderer.roleForArticle(article, nodeKind: .article))
         }
@@ -256,7 +256,7 @@ class RenderNodeTranslatorTests: XCTestCase {
 
             // Verify a collection group
             let article1 = try XCTUnwrap(
-                Article(from: document.root, source: nil, for: bundle, in: context, problems: &problems)
+                Article(from: document.root, source: nil, for: bundle, problems: &problems)
             )
             XCTAssertEqual(RenderMetadata.Role.collectionGroup, DocumentationContentRenderer.roleForArticle(article1, nodeKind: .article))
             
@@ -272,7 +272,7 @@ class RenderNodeTranslatorTests: XCTestCase {
 
             // Verify a collection
             let article2 = try XCTUnwrap(
-                Article(from: metadataDocument.root, source: nil, for: bundle, in: context, problems: &problems)
+                Article(from: metadataDocument.root, source: nil, for: bundle, problems: &problems)
             )
             XCTAssertEqual(RenderMetadata.Role.collection, DocumentationContentRenderer.roleForArticle(article2, nodeKind: .article))
         }
@@ -339,7 +339,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let article = try XCTUnwrap(
-            Article(from: document.root, source: nil, for: bundle, in: context, problems: &problems)
+            Article(from: document.root, source: nil, for: bundle, problems: &problems)
         )
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/taskgroups", fragment: nil, sourceLanguage: .swift)
         context.documentationCache[reference] = try DocumentationNode(reference: reference, article: article)

--- a/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -22,9 +22,9 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
         XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
         
@@ -44,9 +44,9 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
         XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
         
@@ -73,9 +73,9 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
         XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
         
@@ -97,9 +97,9 @@ class ArticleTests: XCTestCase {
         # This is my article
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
         XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
         
@@ -115,9 +115,9 @@ class ArticleTests: XCTestCase {
         - This is not an abstract.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
         XCTAssert(problems.isEmpty, "Unexpectedly found problems: \(DiagnosticConsoleWriter.formattedDescription(for: problems))")
         
@@ -133,9 +133,9 @@ class ArticleTests: XCTestCase {
          This is my article
          """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
 
         XCTAssertNil(article)
         XCTAssertEqual(problems.count, 1)
@@ -153,9 +153,9 @@ class ArticleTests: XCTestCase {
          
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
 
         XCTAssertNil(article)
         XCTAssertEqual(problems.count, 1)
@@ -185,9 +185,9 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
         XCTAssertEqual(
             problems.map(\.diagnostic.identifier),
@@ -222,9 +222,9 @@ class ArticleTests: XCTestCase {
         Adding @DisplayName to an article will result in a warning.
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         
         XCTAssertEqual(problems.map(\.diagnostic.summary), [
             "A 'DisplayName' directive is only supported in documentation extension files. To customize the display name of an article, change the content of the level-1 heading."

--- a/Tests/SwiftDocCTests/Semantics/AssessmentsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/AssessmentsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class AssessmentsTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Assessments.directiveName, directive.name)
-            let assessments = Assessments(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let assessments = Assessments(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(assessments)
             XCTAssertEqual(1, problems.count)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })

--- a/Tests/SwiftDocCTests/Semantics/CallToActionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/CallToActionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -21,12 +21,12 @@ class CallToActionTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+        let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(CallToAction.directiveName, directive.name)
-            let callToAction = CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let callToAction = CallToAction(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(callToAction)
             XCTAssertEqual(2, problems.count)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
@@ -41,12 +41,12 @@ class CallToActionTests: XCTestCase {
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
 
-            let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
             directive.map { directive in
                 var problems = [Problem]()
                 XCTAssertEqual(CallToAction.directiveName, directive.name)
-                let callToAction = CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let callToAction = CallToAction(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNil(callToAction)
                 XCTAssertEqual(1, problems.count)
                 let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
@@ -63,12 +63,12 @@ class CallToActionTests: XCTestCase {
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
 
-            let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
             directive.map { directive in
                 var problems = [Problem]()
                 XCTAssertEqual(CallToAction.directiveName, directive.name)
-                let callToAction = CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let callToAction = CallToAction(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNil(callToAction)
                 XCTAssertEqual(1, problems.count)
                 let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
@@ -85,12 +85,12 @@ class CallToActionTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+        let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(CallToAction.directiveName, directive.name)
-            let callToAction = CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let callToAction = CallToAction(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(callToAction)
             XCTAssertEqual(1, problems.count)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
@@ -104,12 +104,12 @@ class CallToActionTests: XCTestCase {
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
 
-            let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
             directive.map { directive in
                 var problems = [Problem]()
                 XCTAssertEqual(CallToAction.directiveName, directive.name)
-                let callToAction = CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let callToAction = CallToAction(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(callToAction)
                 XCTAssert(problems.isEmpty)
             }
@@ -141,11 +141,11 @@ class CallToActionTests: XCTestCase {
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = try XCTUnwrap(document.child(at: 0) as? BlockDirective)
 
-            let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
 
             var problems = [Problem]()
             XCTAssertEqual(CallToAction.directiveName, directive.name)
-            let callToAction = try XCTUnwrap(CallToAction(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+            let callToAction = try XCTUnwrap(CallToAction(from: directive, source: nil, for: bundle, problems: &problems))
             XCTAssert(problems.isEmpty)
             
             XCTAssertEqual(callToAction.buttonLabel(for: nil), expectedDefaultLabel)

--- a/Tests/SwiftDocCTests/Semantics/ChapterTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ChapterTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class ChapterTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let chapter = Chapter(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let chapter = Chapter(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(chapter)
         XCTAssertEqual(3, problems.count)
         XCTAssertEqual("org.swift.docc.HasArgument.name", problems[0].diagnostic.identifier)
@@ -42,9 +42,9 @@ class ChapterTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let chapter = Chapter(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let chapter = Chapter(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertEqual(1, problems.count)
         problems.first.map { problem in
             XCTAssertEqual("org.swift.docc.HasExactlyOne<\(Chapter.self), \(ImageMedia.self)>.DuplicateChildren", problem.diagnostic.identifier)
@@ -71,9 +71,9 @@ class ChapterTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let chapter = Chapter(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let chapter = Chapter(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertNotNil(chapter)
         chapter.map { chapter in

--- a/Tests/SwiftDocCTests/Semantics/ChoiceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ChoiceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,12 +20,12 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(choice)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
             XCTAssertEqual(2, problems.count)
@@ -47,12 +47,12 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(choice)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
             XCTAssertEqual(1, problems.count)
@@ -70,12 +70,12 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(choice)
             XCTAssertEqual(1, problems.count)
             problems.first.map { problem in
@@ -96,12 +96,12 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(choice)
             XCTAssertEqual(1, problems.count)
             problems.first.map { problem in
@@ -122,12 +122,12 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(choice)
             XCTAssertEqual(1, problems.count)
             problems.first.map { problem in
@@ -152,12 +152,12 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(choice)
             XCTAssertTrue(problems.isEmpty)
             choice.map { choice in
@@ -188,12 +188,12 @@ Choice @1:1-6:2 isCorrect: true
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(choice)
             XCTAssertTrue(problems.isEmpty)
             choice.map { choice in
@@ -222,7 +222,7 @@ Choice @1:1-9:2 isCorrect: true
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+        let (bundle, _) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             InfoPlist(identifier: "org.swift.docc.example"),
             DataFile(name: "blah.png", data: Data()),
         ]))
@@ -230,7 +230,7 @@ Choice @1:1-9:2 isCorrect: true
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Choice.directiveName, directive.name)
-            let choice = Choice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let choice = Choice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(choice)
             XCTAssertTrue(problems.isEmpty)
             choice.map { choice in

--- a/Tests/SwiftDocCTests/Semantics/CodeTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/CodeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class CodeTests: XCTestCase {
         let source = "@Code"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let code = Code(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let code = Code(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(code)
         XCTAssertEqual(1, problems.count)
         XCTAssertEqual("org.swift.docc.HasArgument.file", problems.first?.diagnostic.identifier)

--- a/Tests/SwiftDocCTests/Semantics/ContentAndMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ContentAndMediaTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
         XCTAssertEqual(0, problems.count)
     }
@@ -37,9 +37,9 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
         XCTAssertTrue(problems.isEmpty)
         contentAndMedia.map { contentAndMedia in
@@ -58,9 +58,9 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
         XCTAssertTrue(problems.isEmpty)
         contentAndMedia.map { contentAndMedia in
@@ -81,9 +81,9 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
         XCTAssertTrue(problems.isEmpty)
         contentAndMedia.map { contentAndMedia in
@@ -102,9 +102,9 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
         XCTAssertEqual(problems.count, 3)
         XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Semantics/DisplayNameTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DisplayNameTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class DisplayNameTests: XCTestCase {
         let source = "@DisplayName"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(displayName)
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -32,9 +32,9 @@ class DisplayNameTests: XCTestCase {
         let source = "@DisplayName(\"Custom Symbol Name\")"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertEqual(displayName?.style, .conceptual)
@@ -44,9 +44,9 @@ class DisplayNameTests: XCTestCase {
         let source = "@DisplayName(\"Custom Symbol Name\", style: conceptual)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertEqual(displayName?.style, .conceptual)
@@ -56,9 +56,9 @@ class DisplayNameTests: XCTestCase {
         let source = "@DisplayName(\"Custom Symbol Name\", style: symbol)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertEqual(displayName?.style, .symbol)
@@ -68,9 +68,9 @@ class DisplayNameTests: XCTestCase {
         let source = "@DisplayName(\"Custom Symbol Name\", style: somethingUnknown)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -81,9 +81,9 @@ class DisplayNameTests: XCTestCase {
         let source = "@DisplayName(\"Custom Symbol Name\", argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName, "Even if there are warnings we can create a displayName value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -98,9 +98,9 @@ class DisplayNameTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName, "Even if there are warnings we can create a DisplayName value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(2, problems.count)
@@ -116,9 +116,9 @@ class DisplayNameTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let displayName = DisplayName(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName, "Even if there are warnings we can create a DisplayName value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)

--- a/Tests/SwiftDocCTests/Semantics/DocumentationExtensionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DocumentationExtensionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class DocumentationExtensionTests: XCTestCase {
         let source = "@DocumentationExtension"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(options)
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -32,9 +32,9 @@ class DocumentationExtensionTests: XCTestCase {
         let source = "@DocumentationExtension(mergeBehavior: append)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options)
         XCTAssertEqual(problems.count, 1)
         XCTAssertEqual("org.swift.docc.DocumentationExtension.NoConfiguration", problems.first?.diagnostic.identifier)
@@ -45,9 +45,9 @@ class DocumentationExtensionTests: XCTestCase {
         let source = "@DocumentationExtension(mergeBehavior: override)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertEqual(options?.behavior, .override)
@@ -57,9 +57,9 @@ class DocumentationExtensionTests: XCTestCase {
         let source = "@DocumentationExtension(mergeBehavior: somethingUnknown )"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(options)
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -70,9 +70,9 @@ class DocumentationExtensionTests: XCTestCase {
         let source = "@DocumentationExtension(mergeBehavior: override, argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options, "Even if there are warnings we can create an options value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -87,9 +87,9 @@ class DocumentationExtensionTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options, "Even if there are warnings we can create a DocumentationExtension value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(2, problems.count)
@@ -105,9 +105,9 @@ class DocumentationExtensionTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options, "Even if there are warnings we can create a DocumentationExtension value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -121,9 +121,9 @@ class DocumentationExtensionTests: XCTestCase {
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let options = DocumentationExtension(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(options)
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(2, problems.count)

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtLeastOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtLeastOneTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,7 +17,7 @@ final class TestParent: Semantic, DirectiveConvertible {
     static let introducedVersion = "1.2.3"
     let originalMarkup: BlockDirective
     let testChildren: [TestChild]
-    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(TestParent.canConvertDirective(directive))
         self.originalMarkup = directive
         self.testChildren = directive.children.compactMap { child -> TestChild? in
@@ -25,7 +25,7 @@ final class TestParent: Semantic, DirectiveConvertible {
                 childDirective.name == TestChild.directiveName else {
                     return nil
             }
-            return TestChild(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            return TestChild(from: directive, source: nil, for: bundle, problems: &problems)
         }
     }
     
@@ -38,7 +38,7 @@ final class TestChild: Semantic, DirectiveConvertible {
     static let directiveName = "Child"
     static let introducedVersion = "1.2.3"
     let originalMarkup: BlockDirective
-    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, in context: DocumentationContext, problems: inout [Problem]) {
+    init?(from directive: BlockDirective, source: URL?, for bundle: DocumentationBundle, problems: inout [Problem]) {
         precondition(TestChild.canConvertDirective(directive))
         self.originalMarkup = directive
     }
@@ -55,12 +55,12 @@ class HasAtLeastOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         do {
             var problems = [Problem]()
             directive.map { directive in
-                let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+                let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
                 XCTAssertTrue(matches.isEmpty)
                 XCTAssertTrue(remainder.elements.isEmpty)
             }
@@ -75,7 +75,7 @@ class HasAtLeastOneTests: XCTestCase {
         do {
             var problems = [Problem]()
             directive.map { directive in
-                let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+                let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: nil).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
                 XCTAssertTrue(matches.isEmpty)
                 XCTAssertTrue(remainder.elements.isEmpty)
             }
@@ -94,10 +94,10 @@ class HasAtLeastOneTests: XCTestCase {
         var problems = [Problem]()
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
-            let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertEqual(1, matches.count)
             XCTAssertTrue(remainder.elements.isEmpty)
         }
@@ -117,10 +117,10 @@ class HasAtLeastOneTests: XCTestCase {
         var problems = [Problem]()
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
-            let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertEqual(3, matches.count)
             XCTAssertTrue(remainder.elements.isEmpty)
         }
@@ -138,10 +138,10 @@ class HasAtLeastOneTests: XCTestCase {
         var problems = [Problem]()
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
-            let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertEqual(1, matches.count)
             XCTAssertTrue(remainder.elements.isEmpty)
         }

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtMostOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtMostOneTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,11 +19,11 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertTrue(problems.isEmpty)
@@ -40,11 +40,11 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertTrue(problems.isEmpty)
@@ -63,11 +63,11 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertEqual(2, problems.count)
@@ -90,11 +90,11 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasAtMostOne<TestParent, TestChild>().analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertTrue(problems.isEmpty)

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasContentTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasContentTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,11 +19,9 @@ class HasContentTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
-        
         directive.map { directive in
             var problems = [Problem]()
-            let hasContent = Semantic.Analyses.HasContent<Intro>().analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let hasContent = Semantic.Analyses.HasContent<Intro>().analyze(directive, children: directive.children, source: nil, problems: &problems)
             XCTAssertTrue(hasContent.isEmpty)
             XCTAssertEqual(1, problems.count)
             problems.first.map { problem in
@@ -42,11 +40,9 @@ class HasContentTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
-        
         directive.map { directive in
             var problems = [Problem]()
-            let hasContent = Semantic.Analyses.HasContent<Intro>().analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let hasContent = Semantic.Analyses.HasContent<Intro>().analyze(directive, children: directive.children, source: nil, problems: &problems)
             XCTAssertFalse(hasContent.isEmpty)
             XCTAssertTrue(problems.isEmpty)
         }

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasExactlyOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasExactlyOneTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,11 +19,11 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertEqual(1, problems.count)
@@ -50,11 +50,11 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertTrue(problems.isEmpty)
@@ -73,11 +73,11 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertEqual(2, problems.count)
@@ -102,11 +102,11 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
-            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+            let (match, remainder) = Semantic.Analyses.HasExactlyOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(match)
             XCTAssertTrue(remainder.isEmpty)
             XCTAssertTrue(problems.isEmpty)

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlyKnownArgumentsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlyKnownArgumentsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,10 +20,8 @@ class HasOnlyKnownArgumentsTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: ["foo", "bar"]).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: ["foo", "bar"]).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertTrue(problems.isEmpty)
     }
@@ -34,10 +32,8 @@ class HasOnlyKnownArgumentsTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: []).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: []).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 2)
     }
@@ -48,10 +44,8 @@ class HasOnlyKnownArgumentsTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: ["foo", "bar"]).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: ["foo", "bar"]).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 1)
     }
@@ -61,10 +55,8 @@ class HasOnlyKnownArgumentsTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: ["foo", "bar", "woof", "bark"]).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        _ = Semantic.Analyses.HasOnlyKnownArguments<Intro>(severityIfFound: .error, allowedArguments: ["foo", "bar", "woof", "bark"]).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 1)
         guard let first = problems.first else { return }

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlyKnownDirectivesTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlyKnownDirectivesTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -24,10 +24,8 @@ class HasOnlyKnownDirectivesTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid", "bar"]).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid", "bar"]).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertTrue(problems.isEmpty)
     }
@@ -44,10 +42,8 @@ class HasOnlyKnownDirectivesTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: []).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: []).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 2)
     }
@@ -64,10 +60,8 @@ class HasOnlyKnownDirectivesTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid"]).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid"]).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 1)
     }
@@ -86,17 +80,15 @@ class HasOnlyKnownDirectivesTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         // Does allow arbitrary markup
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid"], allowsMarkup: true).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid"], allowsMarkup: true).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 1)
         
         // Doesn't allow arbitrary markup
         problems = []
-        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid"], allowsMarkup: false).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["valid"], allowsMarkup: false).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 2)
     }
@@ -114,10 +106,8 @@ class HasOnlyKnownDirectivesTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
         
-        let (bundle, context) = try testBundleAndContext()
-        
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["foo", "bar", "woof", "bark"]).analyze(directive, children: directive.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlyKnownDirectives<Intro>(severityIfFound: .error, allowedDirectives: ["foo", "bar", "woof", "bark"]).analyze(directive, children: directive.children, source: nil, problems: &problems)
         
         XCTAssertEqual(problems.count, 1)
         guard let first = problems.first else { return }

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlySequentialHeadingsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlySequentialHeadingsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -27,10 +27,10 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
         
         XCTAssertTrue(problems.isEmpty)
     }
@@ -50,10 +50,10 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
         
         XCTAssertTrue(problems.isEmpty)
     }
@@ -65,10 +65,10 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
         
         XCTAssertEqual(problems.map { $0.diagnostic.summary },
                        [
@@ -86,10 +86,10 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         var problems: [Problem] = []
-        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, in: context, problems: &problems)
+        Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
         
         XCTAssertEqual(problems.map { $0.diagnostic.summary },
                        [

--- a/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class ImageMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let image = ImageMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(image)
         XCTAssertEqual(1, problems.count)
         XCTAssertFalse(problems.containsErrors)
@@ -38,9 +38,9 @@ class ImageMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let image = ImageMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(image)
         XCTAssertTrue(problems.isEmpty)
         image.map { image in
@@ -57,9 +57,9 @@ class ImageMediaTests: XCTestCase {
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, context) = try testBundleAndContext()
+            let (bundle, _) = try testBundleAndContext()
             var problems = [Problem]()
-            let image = ImageMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(image)
             XCTAssertTrue(problems.isEmpty)
             image.map { image in
@@ -75,9 +75,9 @@ class ImageMediaTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let image = ImageMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(image)
         XCTAssertEqual(3, problems.count)
         XCTAssertFalse(problems.containsErrors)

--- a/Tests/SwiftDocCTests/Semantics/IntroTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/IntroTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,9 +17,9 @@ class IntroTests: XCTestCase {
         let source = "@Intro"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(intro)
         XCTAssertEqual(1, problems.count)
         XCTAssertFalse(problems.containsErrors)
@@ -42,9 +42,9 @@ class IntroTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(intro)
         XCTAssertTrue(problems.isEmpty)
         intro.map { intro in
@@ -68,9 +68,9 @@ class IntroTests: XCTestCase {
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let intro = Intro(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(intro)
         XCTAssertEqual(2, problems.count)
         XCTAssertFalse(problems.containsErrors)

--- a/Tests/SwiftDocCTests/Semantics/JustificationTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/JustificationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class JustificationTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(directive.name, Justification.directiveName)
-            let justification = Justification(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let justification = Justification(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(justification)
             XCTAssertNil(justification?.reaction)
             XCTAssertTrue(problems.isEmpty)
@@ -44,12 +44,12 @@ class JustificationTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(directive.name, Justification.directiveName)
-            let justification = Justification(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let justification = Justification(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertTrue(problems.isEmpty)
             XCTAssertNotNil(justification)
             XCTAssertEqual(justification?.reaction, "Correct!")

--- a/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -158,12 +158,12 @@ class MetadataAvailabilityTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+        let (bundle, _) = try testBundleAndContext(named: "AvailabilityBundle")
 
         try directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Directive.directiveName, directive.name)
-            let converted = Directive(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let converted = Directive(from: directive, source: nil, for: bundle, problems: &problems)
             try assert(converted, problems)
         }
     }

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class MetadataTests: XCTestCase {
         let source = "@Metadata"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if a Metadata directive is empty we can create it")
         XCTAssertEqual(1, problems.count)
         XCTAssertEqual("org.swift.docc.Metadata.NoConfiguration", problems.first?.diagnostic.identifier)
@@ -33,9 +33,9 @@ class MetadataTests: XCTestCase {
         let source = "@Metadata(argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if there are warnings we can create a metadata value")
         XCTAssertEqual(2, problems.count)
         XCTAssertEqual("org.swift.docc.UnknownArgument", problems.first?.diagnostic.identifier)
@@ -50,9 +50,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if there are warnings we can create a Metadata value")
         XCTAssertEqual(3, problems.count)
         XCTAssertEqual("org.swift.docc.HasOnlyKnownDirectives", problems.first?.diagnostic.identifier)
@@ -69,9 +69,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if there are warnings we can create a Metadata value")
         XCTAssertEqual(2, problems.count)
         XCTAssertEqual("org.swift.docc.Metadata.UnexpectedContent", problems.first?.diagnostic.identifier)
@@ -88,9 +88,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
         XCTAssertEqual(0, problems.count)
         XCTAssertEqual(metadata?.documentationOptions?.behavior, .override)
@@ -105,9 +105,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
         XCTAssertEqual(2, problems.count)
         XCTAssertEqual(problems.map(\.diagnostic.identifier).sorted(), [
@@ -125,9 +125,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
@@ -142,9 +142,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
@@ -160,9 +160,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
         XCTAssertEqual(metadata?.customMetadata.count, 2)
         XCTAssertEqual(problems.count, 0)
@@ -176,9 +176,9 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let metadata = Metadata(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
         XCTAssertEqual(0, problems.count)
         XCTAssertEqual(metadata?.redirects?.first?.oldPath.relativePath, "some/other/path")
@@ -197,13 +197,13 @@ class MetadataTests: XCTestCase {
         The abstract of this article
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
@@ -219,15 +219,15 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a DisplayName child.")
         XCTAssertNotNil(article?.metadata?.displayName, "The Article has the parsed DisplayName metadata.")
         
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
@@ -243,9 +243,9 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a DisplayName child.")
         XCTAssertNotNil(article?.metadata, "The Article has the parsed Metadata")
         XCTAssertNil(article?.metadata?.displayName, "The Article doesn't have the DisplayName")
@@ -279,16 +279,16 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
         XCTAssertNotNil(article?.metadata?.titleHeading, "The Article has the parsed TitleHeading metadata.")
         XCTAssertEqual(article?.metadata?.titleHeading?.heading, "Custom Heading")
         
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
@@ -307,9 +307,9 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a DisplayName child.")
         XCTAssertNotNil(article?.metadata, "The Article has the parsed Metadata")
         XCTAssertNil(article?.metadata?.displayName, "The Article doesn't have the DisplayName")
@@ -418,10 +418,10 @@ class MetadataTests: XCTestCase {
         line: UInt = #line
     ) throws -> (problems: [String], metadata: Metadata) {
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         
         let problemIDs = problems.map { problem -> String in
             let line = problem.diagnostic.range?.lowerBound.line.description ?? "unknown-line"

--- a/Tests/SwiftDocCTests/Semantics/MultipleChoiceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MultipleChoiceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class MultipleChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(MultipleChoice.directiveName, directive.name)
-            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(multipleChoice)
             XCTAssertEqual(3, problems.count)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
@@ -53,12 +53,12 @@ class MultipleChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         try directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(MultipleChoice.directiveName, directive.name)
-            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(multipleChoice)
             XCTAssertEqual(1, problems.count)
             let problem = try XCTUnwrap(
@@ -101,12 +101,12 @@ class MultipleChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(MultipleChoice.directiveName, directive.name)
-            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(multipleChoice)
             XCTAssertFalse(problems.isEmpty)
             problems.first.map {
@@ -158,12 +158,12 @@ MultipleChoice @1:1-24:2 title: 'SwiftDocC.MarkupContainer'
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(MultipleChoice.directiveName, directive.name)
-            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(multipleChoice)
             XCTAssertTrue(problems.isEmpty)
             
@@ -214,12 +214,12 @@ MultipleChoice @1:1-18:2 title: 'SwiftDocC.MarkupContainer'
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(MultipleChoice.directiveName, directive.name)
-            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(multipleChoice)
             XCTAssertTrue(problems.isEmpty)
             
@@ -274,12 +274,12 @@ MultipleChoice @1:1-22:2 title: 'SwiftDocC.MarkupContainer'
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = try XCTUnwrap(document.child(at: 0) as? BlockDirective)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var problems = [Problem]()
         XCTAssertEqual(MultipleChoice.directiveName, directive.name)
         
-        let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let multipleChoice = MultipleChoice(from: directive, source: nil, for: bundle, problems: &problems)
         
         XCTAssertNotNil(multipleChoice)
         XCTAssertEqual(1, problems.count)

--- a/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class RedirectedTests: XCTestCase {
         let source = "@Redirected"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(redirected)
         XCTAssertEqual(1, problems.count)
         XCTAssertFalse(problems.containsErrors)
@@ -33,9 +33,9 @@ class RedirectedTests: XCTestCase {
         let source = "@Redirected(from: \(oldPath))"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertEqual(redirected?.oldPath.path, oldPath)
@@ -46,9 +46,9 @@ class RedirectedTests: XCTestCase {
         let source = "@Redirected(from: \(oldPath), argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected, "Even if there are warnings we can create a Redirected value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -64,9 +64,9 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected, "Even if there are warnings we can create a Redirected value")
         XCTAssertEqual(2, problems.count)
         XCTAssertFalse(problems.containsErrors)
@@ -83,9 +83,9 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected, "Even if there are warnings we can create a Redirected value")
         XCTAssertFalse(problems.containsErrors)
         XCTAssertEqual(1, problems.count)
@@ -107,13 +107,13 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let tutorialTableOfContents = TutorialTableOfContents(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let tutorialTableOfContents = TutorialTableOfContents(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(tutorialTableOfContents, "A tutorial table-of-contents value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
     }
@@ -139,9 +139,9 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let volume = Volume(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let volume = Volume(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(volume, "A Volume value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
     }
@@ -204,13 +204,13 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let tutorial = Tutorial(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let tutorial = Tutorial(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(tutorial, "A Tutorial value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
     }
@@ -232,13 +232,13 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "A TutorialArticle value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
         
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
     }
@@ -281,9 +281,9 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let article = Resources(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "A Resources value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
     }
@@ -302,13 +302,13 @@ class RedirectedTests: XCTestCase {
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
 
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
 
@@ -337,13 +337,13 @@ class RedirectedTests: XCTestCase {
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
 
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
 
@@ -374,13 +374,13 @@ class RedirectedTests: XCTestCase {
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+        let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
                 
-        var analyzer = SemanticAnalyzer(source: nil, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: nil, bundle: bundle)
         _ = analyzer.visit(document)
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
 
@@ -398,9 +398,9 @@ class RedirectedTests: XCTestCase {
         let source = "@Redirected(fromURL: /old/path)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let redirected = Redirect(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(redirected)
         XCTAssertEqual(2, problems.count)
         XCTAssertFalse(problems.containsErrors)

--- a/Tests/SwiftDocCTests/Semantics/ResourcesTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ResourcesTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,9 +17,9 @@ class ResourcesTests: XCTestCase {
         let source = "@\(Resources.directiveName)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let resources = Resources(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let resources = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(resources)
         XCTAssertEqual(1, problems.count)
       
@@ -67,9 +67,9 @@ class ResourcesTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let resources = Resources(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let resources = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(resources)
         XCTAssertTrue(problems.isEmpty, "Unexpected problems: \(problems)")
         
@@ -120,9 +120,9 @@ Resources @1:1-29:2
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let resources = Resources(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let resources = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(resources)
         XCTAssertFalse(problems.containsErrors)
         

--- a/Tests/SwiftDocCTests/Semantics/SectionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class TutorialSectionTests: XCTestCase {
         let source = "@Section"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let section = TutorialSection(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let section = TutorialSection(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(section)
         XCTAssertEqual(2, problems.count)
         XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,21 +16,21 @@ import Markdown
 
 class SnippetTests: XCTestCase {
     func testNoPath() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+        let (bundle, _) = try testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet()
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as! BlockDirective
         var problems = [Problem]()
-        XCTAssertNil(Snippet(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+        XCTAssertNil(Snippet(from: directive, source: nil, for: bundle, problems: &problems))
         XCTAssertEqual(1, problems.count)
         XCTAssertEqual(.warning, problems[0].diagnostic.severity)
         XCTAssertEqual("org.swift.docc.HasArgument.path", problems[0].diagnostic.identifier)
     }
 
     func testHasInnerContent() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+        let (bundle, _) = try testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "path/to/snippet") {
             This content shouldn't be here.
@@ -39,21 +39,21 @@ class SnippetTests: XCTestCase {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as! BlockDirective
         var problems = [Problem]()
-        XCTAssertNotNil(Snippet(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+        XCTAssertNotNil(Snippet(from: directive, source: nil, for: bundle, problems: &problems))
         XCTAssertEqual(1, problems.count)
         XCTAssertEqual(.warning, problems[0].diagnostic.severity)
         XCTAssertEqual("org.swift.docc.Snippet.NoInnerContentAllowed", problems[0].diagnostic.identifier)
     }
 
     func testLinkResolves() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+        let (bundle, _) = try testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as! BlockDirective
         var problems = [Problem]()
-        let snippet = try XCTUnwrap(Snippet(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+        let snippet = try XCTUnwrap(Snippet(from: directive, source: nil, for: bundle, problems: &problems))
         XCTAssertEqual("Test/Snippets/MySnippet", snippet.path)
         XCTAssertNotNil(snippet)
         XCTAssertTrue(problems.isEmpty)
@@ -74,14 +74,14 @@ class SnippetTests: XCTestCase {
     }
     
     func testSliceResolves() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+        let (bundle, _) = try testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet", slice: "foo")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as! BlockDirective
         var problems = [Problem]()
-        let snippet = try XCTUnwrap(Snippet(from: directive, source: nil, for: bundle, in: context, problems: &problems))
+        let snippet = try XCTUnwrap(Snippet(from: directive, source: nil, for: bundle, problems: &problems))
         XCTAssertEqual("Test/Snippets/MySnippet", snippet.path)
         XCTAssertEqual("foo", snippet.slice)
         XCTAssertNotNil(snippet)

--- a/Tests/SwiftDocCTests/Semantics/StackTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/StackTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class StackTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Stack.directiveName, directive.name)
-            let stack = Stack(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let stack = Stack(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(stack)
             XCTAssertEqual(1, problems.count)
             XCTAssertEqual(
@@ -48,12 +48,12 @@ class StackTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Stack.directiveName, directive.name)
-            let stack = Stack(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let stack = Stack(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(stack)
             XCTAssertEqual(0, problems.count)
         }
@@ -78,12 +78,12 @@ class StackTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Stack.directiveName, directive.name)
-            let stack = Stack(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let stack = Stack(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(stack)
             XCTAssertEqual(1, problems.count)
             XCTAssertEqual(

--- a/Tests/SwiftDocCTests/Semantics/StepTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/StepTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class StepTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let step = Step(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let step = Step(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertEqual([
             "org.swift.docc.HasContent",
         ], problems.map { $0.diagnostic.identifier })
@@ -46,9 +46,9 @@ class StepTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let step = Step(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let step = Step(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertTrue(problems.isEmpty)
         XCTAssertNotNil(step)
         
@@ -104,9 +104,9 @@ Step @1:1-9:2
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let step = Step(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let step = Step(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertEqual(2, problems.count)
         
         XCTAssertEqual([

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1395,7 +1395,7 @@ class SymbolTests: XCTestCase {
         let article: Article? = articleContent.flatMap {
             let document = Document(parsing: $0, options: .parseBlockDirectives)
             var problems = [Problem]()
-            let article = Article(from: document, source: nil, for: bundle, in: context, problems: &problems)
+            let article = Article(from: document, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(article, "The sidecar Article couldn't be created.", file: (file), line: line)
             return article
         }
@@ -1412,8 +1412,7 @@ class SymbolTests: XCTestCase {
         node.initializeSymbolContent(
             documentationExtension: article,
             engine: engine,
-            bundle: bundle,
-            context: context
+            bundle: bundle
         )
         
         return (node, engine.problems)

--- a/Tests/SwiftDocCTests/Semantics/TechnologyTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TechnologyTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class TechnologyTests: XCTestCase {
         let source = "@Tutorials"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let technology = TutorialTableOfContents(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let technology = TutorialTableOfContents(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(technology)
         XCTAssertEqual(
             problems.map { $0.diagnostic.identifier },

--- a/Tests/SwiftDocCTests/Semantics/TileTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TileTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -26,9 +26,9 @@ class TileTests: XCTestCase {
                 let source = "@\(directiveName)"
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
-                let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
                 XCTAssertEqual(2, problems.count)
                 XCTAssertEqual([
@@ -49,9 +49,9 @@ class TileTests: XCTestCase {
 """
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
-                let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
                 XCTAssertTrue(problems.isEmpty)
                 tile.map { tile in
@@ -75,9 +75,9 @@ class TileTests: XCTestCase {
                 let source = "@\(directiveName)"
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
-                let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
                 XCTAssertEqual(1, problems.count)
                 XCTAssertEqual([
@@ -97,9 +97,9 @@ class TileTests: XCTestCase {
 """
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
-                let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
                 XCTAssertTrue(problems.isEmpty)
                 tile.map { tile in
@@ -120,9 +120,9 @@ class TileTests: XCTestCase {
     """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+            let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             var problems = [Problem]()
-            let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
             // Destination is set.
             XCTAssertEqual(destination, tile?.destination)
         }
@@ -136,9 +136,9 @@ class TileTests: XCTestCase {
     """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+            let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             var problems = [Problem]()
-            let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
             // Destination is nil.
             XCTAssertNotNil(tile)
             XCTAssertEqual(nil, tile?.destination)
@@ -149,9 +149,9 @@ class TileTests: XCTestCase {
         let source = "@UnknownTile"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let tile = Tile(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(tile)
         XCTAssertEqual(1, problems.count)
         XCTAssertEqual(problems.first?.diagnostic.identifier, "org.swift.docc.Resources.UnknownTile")

--- a/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class TutorialArticleTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(TutorialArticle.directiveName, directive.name)
-            let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(article)
             XCTAssertEqual(2, problems.count)
             XCTAssertEqual([
@@ -56,12 +56,12 @@ class TutorialArticleTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(TutorialArticle.directiveName, directive.name)
-            let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(article)
             XCTAssertEqual(2, problems.count)
             article.map { article in
@@ -106,12 +106,12 @@ TutorialArticle @1:1-13:2
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(TutorialArticle.directiveName, directive.name)
-            let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(article)
             XCTAssertEqual(4, problems.count)
             article.map { article in
@@ -155,12 +155,12 @@ TutorialArticle @1:1-23:2
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(TutorialArticle.directiveName, directive.name)
-            let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(article)
             XCTAssertEqual(0, problems.count)
             article.map { article in
@@ -265,12 +265,12 @@ TutorialArticle @1:1-23:2 title: 'Basic Augmented Reality App' time: '20'
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(TutorialArticle.directiveName, directive.name)
-            let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(article)
             XCTAssertEqual(3, problems.count)
             let arbitraryMarkupProblem = problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.Stack.UnexpectedContent" })
@@ -361,12 +361,12 @@ TutorialArticle @1:1-81:2
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
             
-            let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             
             directive.map { directive in
                 var problems = [Problem]()
                 XCTAssertEqual(TutorialArticle.directiveName, directive.name)
-                let article = TutorialArticle(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+                let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(article)
                 XCTAssertEqual(0, problems.count)
                 article.map { article in

--- a/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,9 +19,9 @@ class TutorialReferenceTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(tutorialReference)
         XCTAssertEqual(1, problems.count)
         problems.first.map { problem in
@@ -37,9 +37,9 @@ class TutorialReferenceTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(tutorialReference)
         tutorialReference.map { tutorialReference in
             guard case let .unresolved(unresolved) = tutorialReference.topic else {
@@ -57,9 +57,9 @@ class TutorialReferenceTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
-        let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(tutorialReference)
         XCTAssertEqual(problems.count, 1)
         let problem = try XCTUnwrap(problems.first)

--- a/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class TutorialTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Tutorial.directiveName, directive.name)
-            let tutorial = Tutorial(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let tutorial = Tutorial(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(tutorial)
             XCTAssertEqual(
                 [
@@ -195,12 +195,12 @@ class TutorialTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Tutorial.directiveName, directive.name)
-            let tutorial = Tutorial(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let tutorial = Tutorial(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(tutorial)
             XCTAssertTrue(problems.isEmpty)
             tutorial.map { tutorial in
@@ -354,12 +354,12 @@ Tutorial @1:1-150:2 projectFiles: nil
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(Tutorial.directiveName, directive.name)
-            let tutorial = Tutorial(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let tutorial = Tutorial(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(tutorial)
             XCTAssertEqual(1, tutorial?.sections.count)
             XCTAssertEqual([

--- a/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,9 +20,9 @@ class VideoMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let video = VideoMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(video)
         XCTAssertEqual(1, problems.count)
         XCTAssertFalse(problems.containsErrors)
@@ -39,9 +39,9 @@ class VideoMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let video = VideoMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(video)
         XCTAssertTrue(problems.isEmpty)
         video.map { video in
@@ -58,9 +58,9 @@ class VideoMediaTests: XCTestCase {
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, context) = try testBundleAndContext()
+            let (bundle, _) = try testBundleAndContext()
             var problems = [Problem]()
-            let video = VideoMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(video)
             XCTAssertTrue(problems.isEmpty)
             video.map { video in
@@ -77,9 +77,9 @@ class VideoMediaTests: XCTestCase {
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let video = VideoMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(video)
         XCTAssertEqual(3, problems.count)
         XCTAssertFalse(problems.containsErrors)
@@ -332,7 +332,7 @@ class VideoMediaTests: XCTestCase {
             ])
         )
         var problems = [Problem]()
-        let video = VideoMedia(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "",

--- a/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -20,9 +20,9 @@ class VolumeTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let volume = Volume(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let volume = Volume(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(volume)
         XCTAssertEqual(4, problems.count)
         XCTAssertEqual([
@@ -51,9 +51,9 @@ class VolumeTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         var problems = [Problem]()
-        let volume = Volume(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+        let volume = Volume(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(volume)
         XCTAssertTrue(problems.isEmpty)
         volume.map { volume in

--- a/Tests/SwiftDocCTests/Semantics/XcodeRequirementTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/XcodeRequirementTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,12 @@ class XcodeRequirementTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(XcodeRequirement.directiveName, directive.name)
-            let requirement = XcodeRequirement(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let requirement = XcodeRequirement(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNil(requirement)
             XCTAssertEqual(2, problems.count)
             XCTAssertEqual(
@@ -48,12 +48,12 @@ class XcodeRequirementTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
             XCTAssertEqual(XcodeRequirement.directiveName, directive.name)
-            let requirement = XcodeRequirement(from: directive, source: nil, for: bundle, in: context, problems: &problems)
+            let requirement = XcodeRequirement(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(requirement)
             XCTAssertTrue(problems.isEmpty)
             requirement.map { requirement in

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -162,7 +162,7 @@ extension XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> (problemIdentifiers: [String], directive: Directive?) {
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, _) = try testBundleAndContext()
         
         let source = URL(fileURLWithPath: "/path/to/test-source-\(ProcessInfo.processInfo.globallyUniqueString)")
         let document = Document(parsing: content(), source: source, options: .parseBlockDirectives)
@@ -174,7 +174,6 @@ extension XCTestCase {
             from: blockDirectiveContainer,
             source: source,
             for: bundle,
-            in: context,
             problems: &problems
         )
         
@@ -265,7 +264,7 @@ extension XCTestCase {
         
         let blockDirectiveContainer = try XCTUnwrap(document.child(at: 0) as? BlockDirective, file: file, line: line)
         
-        var analyzer = SemanticAnalyzer(source: source, context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: source, bundle: bundle)
         let result = analyzer.visit(blockDirectiveContainer)
         context.diagnosticEngine.emit(analyzer.problems)
         

--- a/Tests/SwiftDocCUtilitiesTests/SemanticAnalyzerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/SemanticAnalyzerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -110,10 +110,10 @@ class SemanticAnalyzerTests: XCTestCase {
     }
     
     func testDoesNotWarnOnEmptyTutorials() throws {
-        let (bundle, context) = try loadBundle(catalog: catalogHierarchy)
+        let (bundle, _) = try loadBundle(catalog: catalogHierarchy)
         
         let document = Document(parsing: "", options: .parseBlockDirectives)
-        var analyzer = SemanticAnalyzer(source: URL(string: "/empty.tutorial"), context: context, bundle: bundle)
+        var analyzer = SemanticAnalyzer(source: URL(string: "/empty.tutorial"), bundle: bundle)
         let semantic = analyzer.visitDocument(document)
         XCTAssertNil(semantic)
         XCTAssert(analyzer.problems.isEmpty)


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This builds on #1168 to deprecate the `context` initializer parameter for both `MarkupConvertible` and `DirectiveConvertible`.

As you can see from the diff, the `context` was passed around quite a lot but not a single directive convertible or markup convertible type ever accessed the context other than to pass it to the initializer of other directives. 

Most of these types also don't use the `bundle` parameter but a few does access the bundle's `id`, so we can't remove the bundle parameter from these protocols.

---

The primary reason for removing the `context` parameter from these protocols is that it allows for them to be created without the context being created first which in the future would them to be created before or during the context's own initialization. 

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
