### PR TITLE
Added warning for multiple root pages #1170

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
-        "version" : "1.3.0"
+        "revision" : "ae33e5941bb88d88538d0a6b19ca0b01e6c76dcf",
+        "version" : "1.3.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -13,14 +13,18 @@ import Markdown
 import SymbolKit
 
 /// A type that provides information about documentation bundles and their content.
-@available(*, deprecated, message: "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released")
+@available(
+    *, deprecated,
+    message:
+        "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released"
+)
 public protocol DocumentationContextDataProvider {
     /// An object to notify when bundles are added or removed.
     var delegate: DocumentationContextDataProviderDelegate? { get set }
-    
+
     /// The documentation bundles that this data provider provides.
     var bundles: [BundleIdentifier: DocumentationBundle] { get }
-    
+
     /// Returns the data for the specified `url` in the provided `bundle`.
     ///
     /// - Parameters:
@@ -32,9 +36,13 @@ public protocol DocumentationContextDataProvider {
 }
 
 /// An object that responds to changes in available documentation bundles for a specific provider.
-@available(*, deprecated, message: "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released")
+@available(
+    *, deprecated,
+    message:
+        "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released"
+)
 public protocol DocumentationContextDataProviderDelegate: AnyObject {
-    
+
     /// Called when the `dataProvider` has added a new documentation bundle to its list of `bundles`.
     ///
     /// - Parameters:
@@ -42,8 +50,10 @@ public protocol DocumentationContextDataProviderDelegate: AnyObject {
     ///   - bundle: The bundle that was added.
     ///
     /// - Note: This method is called after the `dataProvider` has been added the bundle to its `bundles` property.
-    func dataProvider(_ dataProvider: DocumentationContextDataProvider, didAddBundle bundle:  DocumentationBundle) throws
-    
+    func dataProvider(
+        _ dataProvider: DocumentationContextDataProvider, didAddBundle bundle: DocumentationBundle)
+        throws
+
     /// Called when the `dataProvider` has removed a documentation bundle from its list of `bundles`.
     ///
     /// - Parameters:
@@ -51,7 +61,9 @@ public protocol DocumentationContextDataProviderDelegate: AnyObject {
     ///   - bundle: The bundle that was removed.
     ///
     /// - Note: This method is called after the `dataProvider` has been removed the bundle from its `bundles` property.
-    func dataProvider(_ dataProvider: DocumentationContextDataProvider, didRemoveBundle bundle:  DocumentationBundle) throws
+    func dataProvider(
+        _ dataProvider: DocumentationContextDataProvider,
+        didRemoveBundle bundle: DocumentationBundle) throws
 }
 
 /// Documentation bundles use a string value as a unique identifier.
@@ -59,7 +71,11 @@ public protocol DocumentationContextDataProviderDelegate: AnyObject {
 /// This value is typically a reverse host name, for example: `com.<organization-name>.<product-name>`.
 ///
 /// Documentation links may include the bundle identifier---as a host component of the URL---to reference content in a specific documentation bundle.
-@available(*, deprecated, renamed: "DocumentationBundle.Identifier", message: "Use 'DocumentationBundle.Identifier' instead. This deprecated API will be removed after 6.2 is released")
+@available(
+    *, deprecated, renamed: "DocumentationBundle.Identifier",
+    message:
+        "Use 'DocumentationBundle.Identifier' instead. This deprecated API will be removed after 6.2 is released"
+)
 public typealias BundleIdentifier = String
 
 /// The documentation context manages the in-memory model for the built documentation.
@@ -89,43 +105,52 @@ public class DocumentationContext {
     public enum ContextError: DescribedError {
         /// The node couldn't be found in the documentation context.
         case notFound(URL)
-        
+
         /// The file wasn't UTF-8 encoded.
         case utf8StringDecodingFailed(url: URL)
-        
+
         /// We allow a symbol declaration with no OS (for REST & Plist symbols)
         /// but if such a declaration is found the symbol can have only one declaration.
         case unexpectedEmptyPlatformName(String)
-        
+
         /// The bundle registration operation is cancelled externally.
         case registrationDisabled
-        
+
         public var errorDescription: String {
             switch self {
-                case .notFound(let url):
-                    return "Couldn't find the requested node '\(url)' in the documentation context."
-                case .utf8StringDecodingFailed(let url):
-                    return "The file at '\(url)' could not be read because it was not valid UTF-8."
-                case .unexpectedEmptyPlatformName(let symbolIdentifier):
-                    return "Declaration without operating system name for symbol \(symbolIdentifier) cannot be merged with more declarations with operating system name for the same symbol"
-                case .registrationDisabled:
-                    return "The bundle registration operation is cancelled externally."
+            case .notFound(let url):
+                return "Couldn't find the requested node '\(url)' in the documentation context."
+            case .utf8StringDecodingFailed(let url):
+                return "The file at '\(url)' could not be read because it was not valid UTF-8."
+            case .unexpectedEmptyPlatformName(let symbolIdentifier):
+                return
+                    "Declaration without operating system name for symbol \(symbolIdentifier) cannot be merged with more declarations with operating system name for the same symbol"
+            case .registrationDisabled:
+                return "The bundle registration operation is cancelled externally."
             }
         }
     }
-    
+
     /// A class that resolves documentation links by orchestrating calls to other link resolver implementations.
     public var linkResolver: LinkResolver
-    
+
     private enum _Provider {
-        @available(*, deprecated, message: "Use 'DataProvider' instead. This deprecated API will be removed after 6.2 is released")
+        @available(
+            *, deprecated,
+            message:
+                "Use 'DataProvider' instead. This deprecated API will be removed after 6.2 is released"
+        )
         case legacy(DocumentationContextDataProvider)
         case new(DataProvider)
     }
     private var dataProvider: _Provider
 
     /// The provider of documentation bundles for this context.
-    @available(*, deprecated, message: "Use 'DataProvider' instead. This deprecated API will be removed after 6.2 is released")
+    @available(
+        *, deprecated,
+        message:
+            "Use 'DataProvider' instead. This deprecated API will be removed after 6.2 is released"
+    )
     private var _legacyDataProvider: DocumentationContextDataProvider! {
         get {
             switch dataProvider {
@@ -139,13 +164,16 @@ public class DocumentationContext {
             dataProvider = .legacy(newValue)
         }
     }
-    
+
     func contentsOfURL(_ url: URL, in bundle: DocumentationBundle) throws -> Data {
         switch dataProvider {
         case .legacy(let legacyDataProvider):
             return try legacyDataProvider.contentsOfURL(url, in: bundle)
         case .new(let dataProvider):
-            assert(self.bundle?.id == bundle.id, "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'.")
+            assert(
+                self.bundle?.id == bundle.id,
+                "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'."
+            )
             return try dataProvider.contents(of: url)
         }
     }
@@ -156,24 +184,32 @@ public class DocumentationContext {
     /// A collection of configuration for this context.
     public package(set) var configuration: Configuration {
         get { _configuration }
-        @available(*, deprecated, message: "Pass a configuration at initialization. This property will become read-only after Swift 6.2 is released.")
+        @available(
+            *, deprecated,
+            message:
+                "Pass a configuration at initialization. This property will become read-only after Swift 6.2 is released."
+        )
         set { _configuration = newValue }
     }
     // Having a deprecated setter above requires a computed property.
     private var _configuration: Configuration
-    
+
     /// The graph of all the documentation content and their relationships to each other.
     ///
     /// > Important: The topic graph has no awareness of source language specific edges.
     var topicGraph = TopicGraph()
-    
+
     /// User-provided global options for this documentation conversion.
     var options: Options?
-    
+
     /// The set of all manually curated references if `shouldStoreManuallyCuratedReferences` was true at the time of processing and has remained `true` since.. Nil if curation has not been processed yet.
     public private(set) var manuallyCuratedReferences: Set<ResolvedTopicReference>?
 
-    @available(*, deprecated, renamed: "tutorialTableOfContentsReferences", message: "Use 'tutorialTableOfContentsReferences' This deprecated API will be removed after 6.2 is released")
+    @available(
+        *, deprecated, renamed: "tutorialTableOfContentsReferences",
+        message:
+            "Use 'tutorialTableOfContentsReferences' This deprecated API will be removed after 6.2 is released"
+    )
     public var rootTechnologies: [ResolvedTopicReference] {
         tutorialTableOfContentsReferences
     }
@@ -181,18 +217,19 @@ public class DocumentationContext {
     /// The tutorial table-of-contents nodes in the topic graph.
     public var tutorialTableOfContentsReferences: [ResolvedTopicReference] {
         return topicGraph.nodes.values.compactMap { node in
-            guard node.kind == .tutorialTableOfContents && parents(of: node.reference).isEmpty else {
+            guard node.kind == .tutorialTableOfContents && parents(of: node.reference).isEmpty
+            else {
                 return nil
             }
             return node.reference
         }
     }
-    
+
     /// The root module nodes of the Topic Graph.
     ///
     /// This property is initialized during the registration of a documentation bundle.
     public private(set) var rootModules: [ResolvedTopicReference]!
-        
+
     /// The topic reference of the root module, if it's the only registered module.
     var soleRootModuleReference: ResolvedTopicReference? {
         guard rootModules.count > 1 else {
@@ -205,15 +242,15 @@ public class DocumentationContext {
         }
         return nonVirtualModules.count == 1 ? nonVirtualModules.first : nil
     }
-       
+
     typealias LocalCache = ContentCache<DocumentationNode>
     typealias ExternalCache = ContentCache<LinkResolver.ExternalEntity>
-    
+
     /// Map of document URLs to topic references.
     var documentLocationMap = BidirectionalMap<URL, ResolvedTopicReference>()
     /// A storage of already created documentation nodes for the local documentation content.
     ///
-    /// The documentation cache is built up incrementally as local content is registered with the documentation context. 
+    /// The documentation cache is built up incrementally as local content is registered with the documentation context.
     ///
     /// First, the context adds all symbols, with both their references and symbol IDs for lookup. The ``SymbolGraphRelationshipsBuilder`` looks up documentation
     /// nodes by their symbol's ID when it builds up in-memory relationships between symbols. Later, the context adds articles and other conceptual content with only their
@@ -223,7 +260,7 @@ public class DocumentationContext {
     var assetManagers = [DocumentationBundle.Identifier: DataAssetManager]()
     /// A list of non-topic links that can be resolved.
     var nodeAnchorSections = [ResolvedTopicReference: AnchorSection]()
-    
+
     /// A storage of externally resolved content.
     ///
     /// The external cache is built up in two steps;
@@ -235,9 +272,10 @@ public class DocumentationContext {
 
     /// Returns the local or external reference for a known symbol ID.
     func localOrExternalReference(symbolID: String) -> ResolvedTopicReference? {
-        documentationCache.reference(symbolID: symbolID) ?? externalCache.reference(symbolID: symbolID)
+        documentationCache.reference(symbolID: symbolID)
+            ?? externalCache.reference(symbolID: symbolID)
     }
-    
+
     /// A list of all the problems that was encountered while registering and processing the documentation bundles in this context.
     public var problems: [Problem] {
         return diagnosticEngine.problems
@@ -245,12 +283,12 @@ public class DocumentationContext {
 
     /// The engine that collects problems encountered while registering and processing the documentation bundles in this context.
     public var diagnosticEngine: DiagnosticEngine
-    
+
     /// All the link references that have been resolved from external sources, either successfully or not.
     ///
     /// The unsuccessful links are tracked so that the context doesn't attempt to re-resolve the unsuccessful links during rendering which runs concurrently for each page.
     var externallyResolvedLinks = [ValidatedURL: TopicReferenceResolutionResult]()
-    
+
     /// A temporary structure to hold a semantic value that hasn't yet had its links resolved.
     ///
     /// These temporary values are only expected to exist while the documentation is being built. Once the documentation bundles have been fully registered and the topic graph
@@ -258,14 +296,14 @@ public class DocumentationContext {
     struct SemanticResult<S: Semantic> {
         /// The ``Semantic`` value with unresolved links.
         var value: S
-        
+
         /// The source of the document that produces the ``value``.
         var source: URL
-        
+
         /// The Topic Graph node for this value.
         var topicGraphNode: TopicGraph.Node
     }
-    
+
     /// Temporary storage for articles before they are curated and moved to the documentation cache.
     ///
     /// This storage is only used while the documentation context is being built. Once the documentation bundles have been fully registered and the topic graph
@@ -273,7 +311,7 @@ public class DocumentationContext {
     ///
     /// The key to lookup an article is the reference to the article itself.
     var uncuratedArticles = [ResolvedTopicReference: SemanticResult<Article>]()
-    
+
     /// Temporary storage for documentation extension files before they are curated and moved to the documentation cache.
     ///
     /// This storage is only used while the documentation context is being built. Once the documentation bundles have been fully registered and the topic graph
@@ -292,7 +330,11 @@ public class DocumentationContext {
     ///   - diagnosticEngine: The pre-configured engine that will collect problems encountered during compilation.
     ///   - configuration: A collection of configuration for the created context.
     /// - Throws: If an error is encountered while registering a documentation bundle.
-    @available(*, deprecated, message: "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released")
+    @available(
+        *, deprecated,
+        message:
+            "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released"
+    )
     public init(
         dataProvider: DocumentationContextDataProvider,
         diagnosticEngine: DiagnosticEngine = .init(),
@@ -302,9 +344,9 @@ public class DocumentationContext {
         self.diagnosticEngine = diagnosticEngine
         self._configuration = configuration
         self.linkResolver = LinkResolver(dataProvider: FileManager.default)
-        
+
         _legacyDataProvider.delegate = self
-        
+
         for bundle in dataProvider.bundles.values {
             try register(bundle)
         }
@@ -339,44 +381,63 @@ public class DocumentationContext {
     /// - Parameters:
     ///   - dataProvider: The provider that added this bundle.
     ///   - bundle: The bundle that was added.
-    @available(*, deprecated, message: "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released")
-    public func dataProvider(_ dataProvider: DocumentationContextDataProvider, didAddBundle bundle: DocumentationBundle) throws {
+    @available(
+        *, deprecated,
+        message:
+            "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released"
+    )
+    public func dataProvider(
+        _ dataProvider: DocumentationContextDataProvider, didAddBundle bundle: DocumentationBundle
+    ) throws {
         try benchmark(wrap: Benchmark.Duration(id: "bundle-registration")) {
             // Enable reference caching for this documentation bundle.
             ResolvedTopicReference.enableReferenceCaching(for: bundle.id)
-            
+
             try self.register(bundle)
         }
     }
-    
+
     /// Respond to a new `bundle` being removed from the `dataProvider` by unregistering it.
     ///
     /// - Parameters:
     ///   - dataProvider: The provider that removed this bundle.
     ///   - bundle: The bundle that was removed.
-    @available(*, deprecated, message: "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released")
-    public func dataProvider(_ dataProvider: DocumentationContextDataProvider, didRemoveBundle bundle: DocumentationBundle) throws {
+    @available(
+        *, deprecated,
+        message:
+            "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released"
+    )
+    public func dataProvider(
+        _ dataProvider: DocumentationContextDataProvider,
+        didRemoveBundle bundle: DocumentationBundle
+    ) throws {
         linkResolver.localResolver?.unregisterBundle(identifier: bundle.id)
-        
+
         // Purge the reference cache for this bundle and disable reference caching for
         // this bundle moving forward.
         ResolvedTopicReference.purgePool(for: bundle.id)
-        
+
         unregister(bundle)
     }
-    
+
     /// The documentation bundles that are currently registered with the context.
-    @available(*, deprecated, message: "Use 'bundle' instead. This deprecated API will be removed after 6.2 is released")
+    @available(
+        *, deprecated,
+        message: "Use 'bundle' instead. This deprecated API will be removed after 6.2 is released"
+    )
     public var registeredBundles: some Collection<DocumentationBundle> {
         _registeredBundles
     }
-    
+
     /// Returns the `DocumentationBundle` with the given `identifier` if it's registered with the context, otherwise `nil`.
-    @available(*, deprecated, message: "Use 'bundle' instead. This deprecated API will be removed after 6.2 is released")
+    @available(
+        *, deprecated,
+        message: "Use 'bundle' instead. This deprecated API will be removed after 6.2 is released"
+    )
     public func bundle(identifier: String) -> DocumentationBundle? {
         _bundle(identifier: identifier)
     }
-    
+
     // Remove these  when removing `registeredBundles` and `bundle(identifier:)`.
     // These exist so that internal code that need to be compatible with legacy data providers can access the bundles without deprecation warnings.
     var _registeredBundles: [DocumentationBundle] {
@@ -387,17 +448,20 @@ public class DocumentationContext {
             bundle.map { [$0] } ?? []
         }
     }
-    
+
     func _bundle(identifier: String) -> DocumentationBundle? {
         switch dataProvider {
         case .legacy(let legacyDataProvider):
             return legacyDataProvider.bundles[identifier]
         case .new:
-            assert(bundle?.id.rawValue == identifier, "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'.")
+            assert(
+                bundle?.id.rawValue == identifier,
+                "New code shouldn't pass unknown bundle identifiers to 'DocumentationContext.bundle(identifier:)'."
+            )
             return bundle?.id.rawValue == identifier ? bundle : nil
         }
     }
-        
+
     /// Perform semantic analysis on a given `document` at a given `source` location and append any problems found to `problems`.
     ///
     /// - Parameters:
@@ -406,13 +470,16 @@ public class DocumentationContext {
     ///   - bundle: The bundle that the document belongs to.
     ///   - problems: A mutable collection of problems to update with any problem encountered during the semantic analysis.
     /// - Returns: The result of the semantic analysis.
-    private func analyze(_ document: Document, at source: URL, in bundle: DocumentationBundle, engine: DiagnosticEngine) -> Semantic? {
+    private func analyze(
+        _ document: Document, at source: URL, in bundle: DocumentationBundle,
+        engine: DiagnosticEngine
+    ) -> Semantic? {
         var analyzer = SemanticAnalyzer(source: source, context: self, bundle: bundle)
         let result = analyzer.visit(document)
         engine.emit(analyzer.problems)
         return result
     }
-    
+
     /// Perform global analysis of compiled Markup
     ///
     /// Global analysis differs from semantic analysis in that no transformation is expected to occur. The
@@ -442,28 +509,34 @@ public class DocumentationContext {
         checker.visit(document)
         diagnosticEngine.emit(checker.problems)
     }
-    
+
     /// A cache of plain string module names, keyed by the module node reference.
-    private var moduleNameCache: [ResolvedTopicReference: (displayName: String, symbolName: String)] = [:]
-    
+    private var moduleNameCache:
+        [ResolvedTopicReference: (displayName: String, symbolName: String)] = [:]
+
     /// Find the known plain string module name for a given module reference.
     ///
     /// - Note: Looking up module names requires that the module names have been pre-resolved. This happens automatically at the end of bundle registration.
     ///
     /// - Parameter moduleReference: The module reference to find the module name for.
     /// - Returns: The plain string name for the referenced module.
-    func moduleName(forModuleReference moduleReference: ResolvedTopicReference) -> (displayName: String, symbolName: String) {
+    func moduleName(forModuleReference moduleReference: ResolvedTopicReference) -> (
+        displayName: String, symbolName: String
+    ) {
         if let name = moduleNameCache[moduleReference] {
             return name
         }
         // If no name is found it's considered a programmer error; either that the names haven't been resolved yet
         // or that the passed argument isn't a reference to a known module.
         if moduleNameCache.isEmpty {
-            fatalError("Incorrect use of API: '\(#function)' requires that bundles have finished registering.")
+            fatalError(
+                "Incorrect use of API: '\(#function)' requires that bundles have finished registering."
+            )
         }
-        fatalError("Incorrect use of API: '\(#function)' can only be used with known module references")
+        fatalError(
+            "Incorrect use of API: '\(#function)' can only be used with known module references")
     }
-    
+
     /// Attempts to resolve the module names of all root modules.
     ///
     /// This allows the module names to quickly be looked up using ``moduleName(forModuleReference:)``
@@ -472,7 +545,9 @@ public class DocumentationContext {
             if let node = try? entity(with: reference) {
                 // A module node should always have a symbol.
                 // Remove the fallback value and force unwrap `node.symbol` on the main branch: https://github.com/swiftlang/swift-docc/issues/249
-                moduleNameCache[reference] = (node.name.plainText, node.symbol?.names.title ?? reference.lastPathComponent)
+                moduleNameCache[reference] = (
+                    node.name.plainText, node.symbol?.names.title ?? reference.lastPathComponent
+                )
             }
         }
     }
@@ -484,21 +559,30 @@ public class DocumentationContext {
     /// - Parameters:
     ///   - references: A list of references to local nodes to visit to collect links.
     ///   - localBundleID: The local bundle ID, used to identify and skip absolute fully qualified local links.
-    private func preResolveExternalLinks(references: [ResolvedTopicReference], localBundleID: DocumentationBundle.Identifier) {
-        preResolveExternalLinks(semanticObjects: references.compactMap({ reference -> ReferencedSemanticObject? in
-            guard let node = try? entity(with: reference), let semantic = node.semantic else { return nil }
-            return (reference: reference, semantic: semantic)
-        }), localBundleID: localBundleID)
+    private func preResolveExternalLinks(
+        references: [ResolvedTopicReference], localBundleID: DocumentationBundle.Identifier
+    ) {
+        preResolveExternalLinks(
+            semanticObjects: references.compactMap({ reference -> ReferencedSemanticObject? in
+                guard let node = try? entity(with: reference), let semantic = node.semantic else {
+                    return nil
+                }
+                return (reference: reference, semantic: semantic)
+            }), localBundleID: localBundleID)
     }
-    
+
     /// A tuple of a semantic object and its reference in the topic graph.
-    private typealias ReferencedSemanticObject = (reference: ResolvedTopicReference, semantic: Semantic)
-    
+    private typealias ReferencedSemanticObject = (
+        reference: ResolvedTopicReference, semantic: Semantic
+    )
+
     /// Converts a semantic result to a referenced semantic object by removing the generic constraint.
-    private func referencedSemanticObject(from: SemanticResult<some Semantic>) -> ReferencedSemanticObject {
+    private func referencedSemanticObject(from: SemanticResult<some Semantic>)
+        -> ReferencedSemanticObject
+    {
         return (reference: from.topicGraphNode.reference, semantic: from.value)
     }
-    
+
     /// Attempts to resolve links external to the given bundle by visiting the given list of semantic objects.
     ///
     /// The resolved references are collected in ``externallyResolvedLinks``.
@@ -506,11 +590,14 @@ public class DocumentationContext {
     /// - Parameters:
     ///   - semanticObjects: A list of semantic objects to visit to collect links.
     ///   - localBundleID: The local bundle ID, used to identify and skip absolute fully qualified local links.
-    private func preResolveExternalLinks(semanticObjects: [ReferencedSemanticObject], localBundleID: DocumentationBundle.Identifier) {
+    private func preResolveExternalLinks(
+        semanticObjects: [ReferencedSemanticObject], localBundleID: DocumentationBundle.Identifier
+    ) {
         // If there are no external resolvers added we will not resolve any links.
         guard !configuration.externalDocumentationConfiguration.sources.isEmpty else { return }
-        
-        let collectedExternalLinks = Synchronized([DocumentationBundle.Identifier: Set<UnresolvedTopicReference>]())
+
+        let collectedExternalLinks = Synchronized(
+            [DocumentationBundle.Identifier: Set<UnresolvedTopicReference>]())
         semanticObjects.concurrentPerform { _, semantic in
             autoreleasepool {
                 // Walk the node and extract external link references.
@@ -519,32 +606,38 @@ public class DocumentationContext {
 
                 // Avoid any synchronization overhead if there are no references to add.
                 guard !externalLinksCollector.collectedExternalReferences.isEmpty else { return }
-                
+
                 // Add the link pairs to `collectedExternalLinks`.
                 collectedExternalLinks.sync {
-                    for (bundleID, collectedLinks) in externalLinksCollector.collectedExternalReferences {
+                    for (bundleID, collectedLinks) in externalLinksCollector
+                        .collectedExternalReferences
+                    {
                         $0[bundleID, default: []].formUnion(collectedLinks)
                     }
                 }
             }
         }
-        
+
         for (bundleID, collectedLinks) in collectedExternalLinks.sync({ $0 }) {
-            guard let externalResolver = configuration.externalDocumentationConfiguration.sources[bundleID] else {
+            guard
+                let externalResolver = configuration.externalDocumentationConfiguration.sources[
+                    bundleID]
+            else {
                 continue
             }
             for externalLink in collectedLinks {
                 let unresolvedURL = externalLink.topicURL
                 let result = externalResolver.resolve(.unresolved(externalLink))
                 externallyResolvedLinks[unresolvedURL] = result
-                
+
                 if case .success(let resolvedReference) = result {
                     // Add the resolved entity to the documentation cache.
                     if let externallyResolvedNode = externalEntity(with: resolvedReference) {
                         externalCache[resolvedReference] = externallyResolvedNode
                     }
                     if unresolvedURL.absoluteString != resolvedReference.absoluteString,
-                       let resolvedURL = ValidatedURL(resolvedReference.url) {
+                        let resolvedURL = ValidatedURL(resolvedReference.url)
+                    {
                         // If the resolved reference has a different URL than the authored link, cache both URLs so we can resolve both unresolved and resolved references.
                         //
                         // The two main examples when this would happen are:
@@ -556,68 +649,81 @@ public class DocumentationContext {
             }
         }
     }
-    
+
     /// A resolved documentation node along with any relevant problems.
-    private typealias LinkResolveResult = (reference: ResolvedTopicReference, node: DocumentationNode, problems: [Problem])
+    private typealias LinkResolveResult = (
+        reference: ResolvedTopicReference, node: DocumentationNode, problems: [Problem]
+    )
 
     /**
      Attempt to resolve links in curation-only documentation, converting any ``TopicReferences`` from `.unresolved` to `.resolved` where possible.
      */
-    private func resolveLinks(curatedReferences: Set<ResolvedTopicReference>, bundle: DocumentationBundle) {
-        let signpostHandle = signposter.beginInterval("Resolve links", id: signposter.makeSignpostID())
+    private func resolveLinks(
+        curatedReferences: Set<ResolvedTopicReference>, bundle: DocumentationBundle
+    ) {
+        let signpostHandle = signposter.beginInterval(
+            "Resolve links", id: signposter.makeSignpostID())
         defer {
             signposter.endInterval("Resolve links", signpostHandle)
         }
-        
+
         let references = Array(curatedReferences)
         let results = Synchronized<[LinkResolveResult]>([])
         results.sync({ $0.reserveCapacity(references.count) })
 
-        func inheritsDocumentationFromOtherModule(_ documentationNode: DocumentationNode, symbolOriginReference: ResolvedTopicReference) -> Bool {
+        func inheritsDocumentationFromOtherModule(
+            _ documentationNode: DocumentationNode, symbolOriginReference: ResolvedTopicReference
+        ) -> Bool {
             // Check that this symbol only has documentation from an in-source documentation comment
             guard documentationNode.docChunks.count == 1,
-                  case .sourceCode = documentationNode.docChunks.first?.source
+                case .sourceCode = documentationNode.docChunks.first?.source
             else {
                 return false
             }
-            
+
             // Check that that documentation comment is inherited from a symbol belonging to another module
             guard let symbolSemantic = documentationNode.semantic as? Symbol,
-                  let originSymbolSemantic = documentationCache[symbolOriginReference]?.semantic as? Symbol
+                let originSymbolSemantic = documentationCache[symbolOriginReference]?.semantic
+                    as? Symbol
             else {
                 return false
             }
             return symbolSemantic.moduleReference != originSymbolSemantic.moduleReference
         }
-        
-        let resolveNodeWithReference: (ResolvedTopicReference) -> Void = { [unowned self] reference in
+
+        let resolveNodeWithReference: (ResolvedTopicReference) -> Void = {
+            [unowned self] reference in
             guard var documentationNode = try? entity(with: reference),
-                  documentationNode.semantic is Article || documentationNode.semantic is Symbol
+                documentationNode.semantic is Article || documentationNode.semantic is Symbol
             else {
                 return
             }
-                    
-            let symbolOriginReference = (documentationNode.semantic as? Symbol)?.origin.flatMap { origin in
+
+            let symbolOriginReference = (documentationNode.semantic as? Symbol)?.origin.flatMap {
+                origin in
                 documentationCache.reference(symbolID: origin.identifier)
             }
             // Check if we should skip resolving links for inherited documentation from other modules.
             if !configuration.externalMetadata.inheritDocs,
                 let symbolOriginReference,
-                inheritsDocumentationFromOtherModule(documentationNode, symbolOriginReference: symbolOriginReference)
+                inheritsDocumentationFromOtherModule(
+                    documentationNode, symbolOriginReference: symbolOriginReference)
             {
                 // Don't resolve any links for this symbol.
                 return
             }
-            
-            var resolver = ReferenceResolver(context: self, bundle: bundle, rootReference: reference, inheritanceParentReference: symbolOriginReference)
-            
+
+            var resolver = ReferenceResolver(
+                context: self, bundle: bundle, rootReference: reference,
+                inheritanceParentReference: symbolOriginReference)
+
             // Update the node with the markup that contains resolved references instead of authored links.
-            documentationNode.semantic = autoreleasepool { 
+            documentationNode.semantic = autoreleasepool {
                 // We use an autorelease pool to release used memory as soon as possible, since the resolver will copy each semantic value
                 // to rewrite it and replace the authored links with resolved reference strings instead.
                 resolver.visit(documentationNode.semantic)
             }
-            
+
             // Also resolve the node's alternate representations. This isn't part of the node's 'semantic' value (resolved above).
             if let alternateRepresentations = documentationNode.metadata?.alternateRepresentations {
                 for alternateRepresentation in alternateRepresentations {
@@ -637,39 +743,45 @@ public class DocumentationContext {
                 problems = resolver.problems
             } else {
                 // Diagnostics for in-source documentation comments need to be offset based on the start location of the comment in the source file.
-                
+
                 // Get the source location
                 let inSourceDocumentationCommentInfo = documentationNode.inSourceDocumentationChunk
-                
+
                 // Post-process and filter out unwanted diagnostics (for example from inherited documentation comments)
                 problems = resolver.problems.compactMap { problem in
                     guard let source = problem.diagnostic.source else {
                         // Ignore any diagnostic without a source location. These can't be meaningfully presented to the user.
                         return nil
                     }
-                    
-                    if source == inSourceDocumentationCommentInfo?.url, let offset = inSourceDocumentationCommentInfo?.offset {
+
+                    if source == inSourceDocumentationCommentInfo?.url,
+                        let offset = inSourceDocumentationCommentInfo?.offset
+                    {
                         // Diagnostics from an in-source documentation comment need to be offset based on the location of that documentation comment.
                         var modifiedProblem = problem
                         modifiedProblem.offsetWithRange(offset)
                         return modifiedProblem
-                    } 
-                    
+                    }
+
                     // Diagnostics from documentation extension files have correct source ranges and don't need to be modified.
                     return problem
                 }
             }
-            
+
             // Also resolve the node's page images. This isn't part of the node's 'semantic' value (resolved above).
-            let pageImageProblems = documentationNode.metadata?.pageImages.compactMap { pageImage in
-                return resolver.resolve(
-                    resource: pageImage.source,
-                    range: pageImage.originalMarkup.range,
-                    severity: .warning
-                )
-            } ?? []
-            
-            let result: LinkResolveResult = (reference: reference, node: documentationNode, problems: problems + pageImageProblems)
+            let pageImageProblems =
+                documentationNode.metadata?.pageImages.compactMap { pageImage in
+                    return resolver.resolve(
+                        resource: pageImage.source,
+                        range: pageImage.originalMarkup.range,
+                        severity: .warning
+                    )
+                } ?? []
+
+            let result: LinkResolveResult = (
+                reference: reference, node: documentationNode,
+                problems: problems + pageImageProblems
+            )
             results.sync({ $0.append(result) })
         }
 
@@ -685,14 +797,17 @@ public class DocumentationContext {
                 // Record symbol links as symbol "mentions" for automatic cross references
                 // on rendered symbol documentation.
                 if let article = result.node.semantic as? Article,
-                   case .article = DocumentationContentRenderer.roleForArticle(article, nodeKind: result.node.kind) 
+                    case .article = DocumentationContentRenderer.roleForArticle(
+                        article, nodeKind: result.node.kind)
                 {
                     for markup in article.abstractSection?.content ?? [] {
-                        var mentions = SymbolLinkCollector(context: self, article: result.node.reference, baseWeight: 2)
+                        var mentions = SymbolLinkCollector(
+                            context: self, article: result.node.reference, baseWeight: 2)
                         mentions.visit(markup)
                     }
                     for markup in article.discussion?.content ?? [] {
-                        var mentions = SymbolLinkCollector(context: self, article: result.node.reference, baseWeight: 1)
+                        var mentions = SymbolLinkCollector(
+                            context: self, article: result.node.reference, baseWeight: 1)
                         mentions.visit(markup)
                     }
                 }
@@ -700,16 +815,19 @@ public class DocumentationContext {
 
             assert(
                 // If this is a symbol, verify that the reference exist in the in the symbolIndex
-                result.node.symbol.map { documentationCache.reference(symbolID: $0.identifier.precise) == result.reference }
-                ?? true, // Nothing to check for non-symbols
+                result.node.symbol.map {
+                    documentationCache.reference(symbolID: $0.identifier.precise)
+                        == result.reference
+                }
+                    ?? true,  // Nothing to check for non-symbols
                 "Previous versions stored symbolIndex and documentationCache separately and updated both. This assert verifies that that's no longer necessary."
             )
             diagnosticEngine.emit(result.problems)
         }
-        
+
         mergeFallbackLinkResolutionResults()
     }
-    
+
     /// Attempt to resolve links in imported documentation, converting any ``TopicReferences`` from `.unresolved` to `.resolved` where possible.
     ///
     /// This function is passed pages that haven't been added to the topic graph yet. Calling this function will load the documentation entity for each of these pages
@@ -722,17 +840,21 @@ public class DocumentationContext {
     ///   - tutorialArticles: The list of temporary 'tutorialArticle' pages.
     ///   - bundle: The bundle to resolve links against.
     private func resolveLinks(
-        tutorialTableOfContents tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
+        tutorialTableOfContents tutorialTableOfContentsResults: [SemanticResult<
+            TutorialTableOfContents
+        >],
         tutorials: [SemanticResult<Tutorial>],
         tutorialArticles: [SemanticResult<TutorialArticle>],
         bundle: DocumentationBundle
     ) {
-        let signpostHandle = signposter.beginInterval("Resolve links", id: signposter.makeSignpostID())
+        let signpostHandle = signposter.beginInterval(
+            "Resolve links", id: signposter.makeSignpostID())
         defer {
             signposter.endInterval("Resolve links", signpostHandle)
         }
-        
-        let sourceLanguages = soleRootModuleReference.map { self.sourceLanguages(for: $0) } ?? [.swift]
+
+        let sourceLanguages =
+            soleRootModuleReference.map { self.sourceLanguages(for: $0) } ?? [.swift]
 
         // Tutorial table-of-contents
 
@@ -740,13 +862,15 @@ public class DocumentationContext {
             autoreleasepool {
                 let url = tableOfContentsResult.source
                 var resolver = ReferenceResolver(context: self, bundle: bundle)
-                let tableOfContents = resolver.visit(tableOfContentsResult.value) as! TutorialTableOfContents
+                let tableOfContents =
+                    resolver.visit(tableOfContentsResult.value) as! TutorialTableOfContents
                 diagnosticEngine.emit(resolver.problems)
-                
+
                 // Add to document map
                 documentLocationMap[url] = tableOfContentsResult.topicGraphNode.reference
-                
-                let tableOfContentsReference = tableOfContentsResult.topicGraphNode.reference.withSourceLanguages(sourceLanguages)
+
+                let tableOfContentsReference = tableOfContentsResult.topicGraphNode.reference
+                    .withSourceLanguages(sourceLanguages)
 
                 let tutorialTableOfContentsNode = DocumentationNode(
                     reference: tableOfContentsReference,
@@ -758,7 +882,7 @@ public class DocumentationContext {
                     semantic: tableOfContents
                 )
                 documentationCache[tableOfContentsReference] = tutorialTableOfContentsNode
-                
+
                 // Update the reference in the topic graph with the table-of-contents page's available languages.
                 topicGraph.updateReference(
                     tableOfContentsResult.topicGraphNode.reference,
@@ -766,16 +890,19 @@ public class DocumentationContext {
                 )
 
                 let anonymousVolumeName = "$volume"
-                
+
                 for volume in tableOfContents.volumes {
                     // Graph node: Volume
-                    let volumeReference = tutorialTableOfContentsNode.reference.appendingPath(volume.name ?? anonymousVolumeName)
-                    let volumeNode = TopicGraph.Node(reference: volumeReference, kind: .volume, source: .file(url: url), title: volume.name ?? anonymousVolumeName)
+                    let volumeReference = tutorialTableOfContentsNode.reference.appendingPath(
+                        volume.name ?? anonymousVolumeName)
+                    let volumeNode = TopicGraph.Node(
+                        reference: volumeReference, kind: .volume, source: .file(url: url),
+                        title: volume.name ?? anonymousVolumeName)
                     topicGraph.addNode(volumeNode)
-                    
+
                     // Graph edge: Tutorial table-of-contents -> Volume
                     topicGraph.addEdge(from: tableOfContentsResult.topicGraphNode, to: volumeNode)
-                    
+
                     for chapter in volume.chapters {
                         // Graph node: Module
                         let baseNodeReference: ResolvedTopicReference
@@ -786,16 +913,21 @@ public class DocumentationContext {
                         }
 
                         let chapterReference = baseNodeReference.appendingPath(chapter.name)
-                        let chapterNode = TopicGraph.Node(reference: chapterReference, kind: .chapter, source: .file(url: url), title: chapter.name)
+                        let chapterNode = TopicGraph.Node(
+                            reference: chapterReference, kind: .chapter, source: .file(url: url),
+                            title: chapter.name)
                         topicGraph.addNode(chapterNode)
-                        
+
                         // Graph edge: Volume -> Chapter
                         topicGraph.addEdge(from: volumeNode, to: chapterNode)
-                        
+
                         for tutorialReference in chapter.topicReferences {
-                            guard case let .resolved(.success(tutorialReference)) = tutorialReference.topic,
-                                let tutorialNode = topicGraph.nodeWithReference(tutorialReference) else {
-                                    continue
+                            guard
+                                case let .resolved(.success(tutorialReference)) = tutorialReference
+                                    .topic,
+                                let tutorialNode = topicGraph.nodeWithReference(tutorialReference)
+                            else {
+                                continue
                             }
                             // Graph edge: Chapter -> Tutorial | TutorialArticle
                             topicGraph.addEdge(from: chapterNode, to: tutorialNode)
@@ -804,9 +936,9 @@ public class DocumentationContext {
                 }
             }
         }
-        
+
         // Tutorials
-        
+
         for tutorialResult in tutorials {
             autoreleasepool {
                 let url = tutorialResult.source
@@ -814,12 +946,13 @@ public class DocumentationContext {
                 var resolver = ReferenceResolver(context: self, bundle: bundle)
                 let tutorial = resolver.visit(unresolvedTutorial) as! Tutorial
                 diagnosticEngine.emit(resolver.problems)
-                
+
                 // Add to document map
                 documentLocationMap[url] = tutorialResult.topicGraphNode.reference
-                
-                let tutorialReference = tutorialResult.topicGraphNode.reference.withSourceLanguages(sourceLanguages)
-                
+
+                let tutorialReference = tutorialResult.topicGraphNode.reference.withSourceLanguages(
+                    sourceLanguages)
+
                 let tutorialNode = DocumentationNode(
                     reference: tutorialReference,
                     kind: .tutorial,
@@ -830,7 +963,7 @@ public class DocumentationContext {
                     semantic: tutorial
                 )
                 documentationCache[tutorialReference] = tutorialNode
-                
+
                 // Update the reference in the topic graph with the tutorial's available languages.
                 topicGraph.updateReference(
                     tutorialResult.topicGraphNode.reference,
@@ -838,9 +971,9 @@ public class DocumentationContext {
                 )
             }
         }
-        
+
         // Tutorial Articles
-        
+
         for articleResult in tutorialArticles {
             autoreleasepool {
                 let url = articleResult.source
@@ -848,12 +981,13 @@ public class DocumentationContext {
                 var resolver = ReferenceResolver(context: self, bundle: bundle)
                 let article = resolver.visit(unresolvedTutorialArticle) as! TutorialArticle
                 diagnosticEngine.emit(resolver.problems)
-                            
+
                 // Add to document map
                 documentLocationMap[url] = articleResult.topicGraphNode.reference
 
-                let articleReference = articleResult.topicGraphNode.reference.withSourceLanguages(sourceLanguages)
-                
+                let articleReference = articleResult.topicGraphNode.reference.withSourceLanguages(
+                    sourceLanguages)
+
                 let articleNode = DocumentationNode(
                     reference: articleReference,
                     kind: .tutorialArticle,
@@ -864,7 +998,7 @@ public class DocumentationContext {
                     semantic: article
                 )
                 documentationCache[articleReference] = articleNode
-                
+
                 // Update the reference in the topic graph with the article's available languages.
                 topicGraph.updateReference(
                     articleResult.topicGraphNode.reference,
@@ -872,10 +1006,10 @@ public class DocumentationContext {
                 )
             }
         }
-        
+
         // Articles are resolved in a separate pass
     }
-    
+
     private func registerDocuments(from bundle: DocumentationBundle) throws -> (
         tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
         tutorials: [SemanticResult<Tutorial>],
@@ -890,47 +1024,54 @@ public class DocumentationContext {
         var tutorialArticles = [SemanticResult<TutorialArticle>]()
         var articles = [SemanticResult<Article>]()
         var documentationExtensions = [SemanticResult<Article>]()
-        
+
         var references: [ResolvedTopicReference: URL] = [:]
 
         let decodeError = Synchronized<Error?>(nil)
-        
+
         // Load and analyze documents concurrently
-        let analyzedDocuments: [(URL, Semantic)] = bundle.markupURLs.concurrentPerform { url, results in
+        let analyzedDocuments: [(URL, Semantic)] = bundle.markupURLs.concurrentPerform {
+            url, results in
             guard decodeError.sync({ $0 == nil }) else { return }
-            
+
             do {
                 let data = try contentsOfURL(url, in: bundle)
                 let source = String(decoding: data, as: UTF8.self)
-                let document = Document(parsing: source, source: url, options: [.parseBlockDirectives, .parseSymbolLinks])
-                
+                let document = Document(
+                    parsing: source, source: url,
+                    options: [.parseBlockDirectives, .parseSymbolLinks])
+
                 // Check for non-inclusive language in all types of docs if that diagnostic severity is required.
-                if configuration.externalMetadata.diagnosticLevel >= NonInclusiveLanguageChecker.severity {
+                if configuration.externalMetadata.diagnosticLevel
+                    >= NonInclusiveLanguageChecker.severity
+                {
                     var langChecker = NonInclusiveLanguageChecker(sourceFile: url)
                     langChecker.visit(document)
                     diagnosticEngine.emit(langChecker.problems)
                 }
 
-                guard let analyzed = analyze(document, at: url, in: bundle, engine: diagnosticEngine) else {
+                guard
+                    let analyzed = analyze(document, at: url, in: bundle, engine: diagnosticEngine)
+                else {
                     return
                 }
-                
+
                 // Only check non-tutorial documents from markup.
                 if analyzed is Article {
                     check(document, at: url)
                 }
-                
+
                 results.append((url, analyzed))
             } catch {
                 decodeError.sync({ $0 = error })
             }
         }
-        
+
         // Rethrow the decoding error if decoding failed.
         if let error = decodeError.sync({ $0 }) {
             throw error
         }
-        
+
         // to preserve the order of documents by url
         let analyzedDocumentsSorted = analyzedDocuments.sorted(by: \.0.absoluteString)
 
@@ -939,12 +1080,13 @@ public class DocumentationContext {
             let (url, analyzed) = analyzedDocument
 
             let path = NodeURLGenerator.pathForSemantic(analyzed, source: url, bundle: bundle)
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: path, sourceLanguage: .swift)
+
             // Since documentation extensions' filenames have no impact on the URL of pages, there is no need to enforce unique filenames for them.
             // At this point we consider all articles with an H1 containing link a "documentation extension."
             let isDocumentationExtension = (analyzed as? Article)?.title?.child(at: 0) is AnyLink
-            
+
             if let firstFoundAtURL = references[reference], !isDocumentationExtension {
                 let problem = Problem(
                     diagnostic: Diagnostic(
@@ -953,72 +1095,93 @@ public class DocumentationContext {
                         range: nil,
                         identifier: "org.swift.docc.DuplicateReference",
                         summary: """
-                        Redeclaration of '\(firstFoundAtURL.lastPathComponent)'; this file will be skipped
-                        """,
+                            Redeclaration of '\(firstFoundAtURL.lastPathComponent)'; this file will be skipped
+                            """,
                         explanation: """
-                        This content was already declared at '\(firstFoundAtURL)'
-                        """
+                            This content was already declared at '\(firstFoundAtURL)'
+                            """
                     ),
                     possibleSolutions: []
                 )
                 diagnosticEngine.emit(problem)
                 continue
             }
-            
+
             if !isDocumentationExtension {
                 references[reference] = url
             }
-            
+
             /*
              Add all topic graph nodes up front before resolution starts, because
              there may be circular linking.
              */
             if let tableOfContents = analyzed as? TutorialTableOfContents {
-                let topicGraphNode = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: url), title: tableOfContents.intro.title)
+                let topicGraphNode = TopicGraph.Node(
+                    reference: reference, kind: .tutorialTableOfContents, source: .file(url: url),
+                    title: tableOfContents.intro.title)
                 topicGraph.addNode(topicGraphNode)
-                let result = SemanticResult(value: tableOfContents, source: url, topicGraphNode: topicGraphNode)
+                let result = SemanticResult(
+                    value: tableOfContents, source: url, topicGraphNode: topicGraphNode)
                 tutorialTableOfContentsResults.append(result)
             } else if let tutorial = analyzed as? Tutorial {
-                let topicGraphNode = TopicGraph.Node(reference: reference, kind: .tutorial, source: .file(url: url), title: tutorial.title ?? "")
+                let topicGraphNode = TopicGraph.Node(
+                    reference: reference, kind: .tutorial, source: .file(url: url),
+                    title: tutorial.title ?? "")
                 topicGraph.addNode(topicGraphNode)
-                let result = SemanticResult(value: tutorial, source: url, topicGraphNode: topicGraphNode)
+                let result = SemanticResult(
+                    value: tutorial, source: url, topicGraphNode: topicGraphNode)
                 tutorials.append(result)
-                
+
                 insertLandmarks(tutorial.landmarks, from: topicGraphNode, source: url)
             } else if let tutorialArticle = analyzed as? TutorialArticle {
-                let topicGraphNode = TopicGraph.Node(reference: reference, kind: .tutorialArticle, source: .file(url: url), title: tutorialArticle.title ?? "")
+                let topicGraphNode = TopicGraph.Node(
+                    reference: reference, kind: .tutorialArticle, source: .file(url: url),
+                    title: tutorialArticle.title ?? "")
                 topicGraph.addNode(topicGraphNode)
-                let result = SemanticResult(value: tutorialArticle, source: url, topicGraphNode: topicGraphNode)
+                let result = SemanticResult(
+                    value: tutorialArticle, source: url, topicGraphNode: topicGraphNode)
                 tutorialArticles.append(result)
-                
+
                 insertLandmarks(tutorialArticle.landmarks, from: topicGraphNode, source: url)
             } else if let article = analyzed as? Article {
-                                
+
                 // Here we create a topic graph node with the prepared data but we don't add it to the topic graph just yet
                 // because we don't know where in the hierarchy the article belongs, we will add it later when crawling the manual curation via Topics task groups.
-                let topicGraphNode = TopicGraph.Node(reference: reference, kind: .article, source: .file(url: url), title: article.title!.plainText)
-                let result = SemanticResult(value: article, source: url, topicGraphNode: topicGraphNode)
-                
+                let topicGraphNode = TopicGraph.Node(
+                    reference: reference, kind: .article, source: .file(url: url),
+                    title: article.title!.plainText)
+                let result = SemanticResult(
+                    value: article, source: url, topicGraphNode: topicGraphNode)
+
                 // Separate articles that look like documentation extension files from other articles, so that the documentation extension files can be matched up with a symbol.
                 // Some links might not resolve in the final documentation hierarchy and we will emit warnings for those later on when we finalize the bundle discovery phase.
                 if isDocumentationExtension {
                     documentationExtensions.append(result)
-                    
+
                     // Warn for an incorrect root page metadata directive.
                     if let technologyRoot = result.value.metadata?.technologyRoot {
-                        let diagnostic = Diagnostic(source: url, severity: .warning, range: article.metadata?.technologyRoot?.originalMarkup.range, identifier: "org.swift.docc.UnexpectedTechnologyRoot", summary: "Documentation extension files can't become technology roots.")
+                        let diagnostic = Diagnostic(
+                            source: url, severity: .warning,
+                            range: article.metadata?.technologyRoot?.originalMarkup.range,
+                            identifier: "org.swift.docc.UnexpectedTechnologyRoot",
+                            summary: "Documentation extension files can't become technology roots.")
                         let solutions: [Solution]
                         if let range = technologyRoot.originalMarkup.range {
                             solutions = [
-                                Solution(summary: "Remove the TechnologyRoot directive", replacements: [Replacement(range: range, replacement: "")])
+                                Solution(
+                                    summary: "Remove the TechnologyRoot directive",
+                                    replacements: [Replacement(range: range, replacement: "")])
                             ]
                         } else {
                             solutions = []
                         }
-                        diagnosticEngine.emit(Problem(diagnostic: diagnostic, possibleSolutions: solutions))
+                        diagnosticEngine.emit(
+                            Problem(diagnostic: diagnostic, possibleSolutions: solutions))
                     }
                 } else {
-                    precondition(uncuratedArticles[result.topicGraphNode.reference] == nil, "Article references are unique.")
+                    precondition(
+                        uncuratedArticles[result.topicGraphNode.reference] == nil,
+                        "Article references are unique.")
                     uncuratedArticles[result.topicGraphNode.reference] = result
                     articles.append(result)
                 }
@@ -1030,46 +1193,59 @@ public class DocumentationContext {
                     File contains unexpected markup at top level. Expected only one of \(topLevelDirectives) directives at the top level
                     """
                 let zeroLocation = SourceLocation(line: 1, column: 1, source: nil)
-                let diagnostic = Diagnostic(source: url, severity: .warning, range: zeroLocation..<zeroLocation, identifier: "org.swift.docc.UnexpectedTopLevelMarkup", summary: explanation)
+                let diagnostic = Diagnostic(
+                    source: url, severity: .warning, range: zeroLocation..<zeroLocation,
+                    identifier: "org.swift.docc.UnexpectedTopLevelMarkup", summary: explanation)
                 let problem = Problem(diagnostic: diagnostic, possibleSolutions: [])
                 diagnosticEngine.emit(problem)
             }
         }
-        
-        return (tutorialTableOfContentsResults, tutorials, tutorialArticles, articles, documentationExtensions)
+
+        return (
+            tutorialTableOfContentsResults, tutorials, tutorialArticles, articles,
+            documentationExtensions
+        )
     }
-    
-    private func insertLandmarks(_ landmarks: some Sequence<Landmark>, from topicGraphNode: TopicGraph.Node, source url: URL) {
+
+    private func insertLandmarks(
+        _ landmarks: some Sequence<Landmark>, from topicGraphNode: TopicGraph.Node, source url: URL
+    ) {
         for landmark in landmarks {
             guard let range = landmark.range else {
                 continue
             }
-            
+
             let landmarkReference = topicGraphNode.reference.withFragment(landmark.title)
-            
+
             // Graph node: Landmark
-            let landmarkTopicGraphNode = TopicGraph.Node(reference: landmarkReference, kind: .onPageLandmark, source: .range(range, url: url), title: landmark.title)
+            let landmarkTopicGraphNode = TopicGraph.Node(
+                reference: landmarkReference, kind: .onPageLandmark,
+                source: .range(range, url: url), title: landmark.title)
             topicGraph.addNode(landmarkTopicGraphNode)
-            
+
             // Graph edge: Topic -> Landmark
             topicGraph.addEdge(from: topicGraphNode, to: landmarkTopicGraphNode)
-            
-            documentationCache[landmarkReference] = DocumentationNode(reference: landmarkReference, kind: .onPageLandmark, sourceLanguage: .swift, name: .conceptual(title: landmark.title), markup: landmark.markup, semantic: nil)
+
+            documentationCache[landmarkReference] = DocumentationNode(
+                reference: landmarkReference, kind: .onPageLandmark, sourceLanguage: .swift,
+                name: .conceptual(title: landmark.title), markup: landmark.markup, semantic: nil)
         }
     }
-    
+
     /// A lookup of resolved references based on the reference's absolute string.
     private(set) var referenceIndex = [String: ResolvedTopicReference]()
-    
+
     private func nodeWithInitializedContent(
         reference: ResolvedTopicReference,
         match foundDocumentationExtension: DocumentationContext.SemanticResult<Article>?,
         bundle: DocumentationBundle
     ) -> DocumentationNode {
         guard var updatedNode = documentationCache[reference] else {
-            fatalError("A topic reference that has already been resolved should always exist in the cache.")
+            fatalError(
+                "A topic reference that has already been resolved should always exist in the cache."
+            )
         }
-        
+
         // Pull a matched article out of the cache and attach content to the symbol
         updatedNode.initializeSymbolContent(
             documentationExtension: foundDocumentationExtension?.value,
@@ -1086,34 +1262,55 @@ public class DocumentationContext {
             let symbol = updatedNode.unifiedSymbol?.documentedSymbol
         {
             let directive = articleMarkup.children.mapFirst { child -> BlockDirective? in
-                guard let directive = child as? BlockDirective, directive.name == DeprecationSummary.directiveName else { return nil }
+                guard let directive = child as? BlockDirective,
+                    directive.name == DeprecationSummary.directiveName
+                else { return nil }
                 return directive
             }
-            diagnosticEngine.emit(Problem(diagnostic: Diagnostic(source: foundDocumentationExtension.source, severity: .warning, range: directive?.range, identifier: "org.swift.docc.DeprecationSummaryForAvailableSymbol", summary: "\(symbol.absolutePath.singleQuoted) isn't unconditionally deprecated"), possibleSolutions: []))
+            diagnosticEngine.emit(
+                Problem(
+                    diagnostic: Diagnostic(
+                        source: foundDocumentationExtension.source, severity: .warning,
+                        range: directive?.range,
+                        identifier: "org.swift.docc.DeprecationSummaryForAvailableSymbol",
+                        summary:
+                            "\(symbol.absolutePath.singleQuoted) isn't unconditionally deprecated"),
+                    possibleSolutions: []))
         }
 
         return updatedNode
     }
-    
+
     /// Creates a topic graph node and a documentation node for the given symbol.
-    private func preparedSymbolData(_ symbol: UnifiedSymbolGraph.Symbol, reference: ResolvedTopicReference, module: SymbolGraph.Module, moduleReference: ResolvedTopicReference, fileURL symbolGraphURL: URL?) -> AddSymbolResultWithProblems {
-        let documentation = DocumentationNode(reference: reference, unifiedSymbol: symbol, moduleData: module, moduleReference: moduleReference)
-        let source: TopicGraph.Node.ContentLocation // TODO: use a list of URLs for the files in a unified graph
+    private func preparedSymbolData(
+        _ symbol: UnifiedSymbolGraph.Symbol, reference: ResolvedTopicReference,
+        module: SymbolGraph.Module, moduleReference: ResolvedTopicReference,
+        fileURL symbolGraphURL: URL?
+    ) -> AddSymbolResultWithProblems {
+        let documentation = DocumentationNode(
+            reference: reference, unifiedSymbol: symbol, moduleData: module,
+            moduleReference: moduleReference)
+        let source: TopicGraph.Node.ContentLocation  // TODO: use a list of URLs for the files in a unified graph
         if let symbolGraphURL {
             source = .file(url: symbolGraphURL)
         } else {
             source = .external
         }
-        let graphNode = TopicGraph.Node(reference: reference, kind: documentation.kind, source: source, title: symbol.defaultSymbol!.names.title, isVirtual: module.isVirtual)
+        let graphNode = TopicGraph.Node(
+            reference: reference, kind: documentation.kind, source: source,
+            title: symbol.defaultSymbol!.names.title, isVirtual: module.isVirtual)
 
         return ((reference, symbol.uniqueIdentifier, graphNode, documentation), [])
     }
 
     /// The result of converting a symbol into a documentation node.
-    private typealias AddSymbolResult = (reference: ResolvedTopicReference, preciseIdentifier: String, topicGraphNode: TopicGraph.Node, node: DocumentationNode)
+    private typealias AddSymbolResult = (
+        reference: ResolvedTopicReference, preciseIdentifier: String,
+        topicGraphNode: TopicGraph.Node, node: DocumentationNode
+    )
     /// An optional result of converting a symbol into a documentation along with any related problems.
     private typealias AddSymbolResultWithProblems = (AddSymbolResult, problems: [Problem])
-    
+
     /// Concurrently adds a symbol to the graph, index, and cache, or replaces an existing symbol with the same precise identifier
     /// (for light updates to symbols already in the graph).
     ///
@@ -1133,21 +1330,28 @@ public class DocumentationContext {
     ///  └──────────────────┘             `───────────'
     ///                                       Symbol
     /// ```
-    private func addSymbolsToTopicGraph(symbolGraph: UnifiedSymbolGraph, url: URL?, symbolReferences: [SymbolGraph.Symbol.Identifier: ResolvedTopicReference], moduleReference: ResolvedTopicReference) {
+    private func addSymbolsToTopicGraph(
+        symbolGraph: UnifiedSymbolGraph, url: URL?,
+        symbolReferences: [SymbolGraph.Symbol.Identifier: ResolvedTopicReference],
+        moduleReference: ResolvedTopicReference
+    ) {
         let symbols = Array(symbolGraph.symbols.values)
         let results: [AddSymbolResultWithProblems] = symbols.concurrentPerform { symbol, results in
             if let selector = symbol.defaultSelector, let module = symbol.modules[selector] {
                 guard let reference = symbolReferences[symbol.defaultIdentifier] else {
-                    fatalError("Symbol with identifier '\(symbol.uniqueIdentifier)' has no reference. A symbol will always have at least one reference.")
+                    fatalError(
+                        "Symbol with identifier '\(symbol.uniqueIdentifier)' has no reference. A symbol will always have at least one reference."
+                    )
                 }
-                
-                results.append(preparedSymbolData(
-                    symbol,
-                    reference: reference,
-                    module: module,
-                    moduleReference: moduleReference,
-                    fileURL: url
-                ))
+
+                results.append(
+                    preparedSymbolData(
+                        symbol,
+                        reference: reference,
+                        module: module,
+                        moduleReference: moduleReference,
+                        fileURL: url
+                    ))
             }
         }
         results.forEach { addPreparedSymbolToContext($0) }
@@ -1157,15 +1361,17 @@ public class DocumentationContext {
     private func addPreparedSymbolToContext(_ result: AddSymbolResultWithProblems) {
         let symbolData = result.0
         topicGraph.addNode(symbolData.topicGraphNode)
-        documentationCache.add(symbolData.node, reference: symbolData.reference, symbolID: symbolData.preciseIdentifier)
-        
+        documentationCache.add(
+            symbolData.node, reference: symbolData.reference, symbolID: symbolData.preciseIdentifier
+        )
+
         for anchor in result.0.node.anchorSections {
             nodeAnchorSections[anchor.reference] = anchor
         }
-        
+
         diagnosticEngine.emit(result.problems)
     }
-    
+
     /// Loads all graph files from a given `bundle` and merges them together while building the symbol relationships and loading any available markdown documentation for those symbols.
     ///
     /// - Parameter bundle: The bundle to load symbol graph files from.
@@ -1177,25 +1383,29 @@ public class DocumentationContext {
     ) throws {
         // Making sure that we correctly let decoding memory get released, do not remove the autorelease pool.
         try autoreleasepool {
-            let signpostHandle = signposter.beginInterval("Register symbols", id: signposter.makeSignpostID())
+            let signpostHandle = signposter.beginInterval(
+                "Register symbols", id: signposter.makeSignpostID())
             defer {
                 signposter.endInterval("Register symbols", signpostHandle)
             }
-            
+
             /// We need only unique relationships so we'll collect them in a set.
-            var combinedRelationshipsBySelector = [UnifiedSymbolGraph.Selector: Set<SymbolGraph.Relationship>]()
+            var combinedRelationshipsBySelector = [
+                UnifiedSymbolGraph.Selector: Set<SymbolGraph.Relationship>
+            ]()
             /// Also track the unique relationships across all languages and platforms
             var uniqueRelationships = Set<SymbolGraph.Relationship>()
             /// Collect symbols from all symbol graphs.
             var combinedSymbols = [String: UnifiedSymbolGraph.Symbol]()
-            
+
             var moduleReferences = [String: ResolvedTopicReference]()
-            
+
             // Build references for all symbols in all of this module's symbol graphs.
             let symbolReferences = signposter.withIntervalSignpost("Disambiguate references") {
-                linkResolver.localResolver.referencesForSymbols(in: symbolGraphLoader.unifiedGraphs, bundle: bundle, context: self)
+                linkResolver.localResolver.referencesForSymbols(
+                    in: symbolGraphLoader.unifiedGraphs, bundle: bundle, context: self)
             }
-            
+
             // Set the index and cache storage capacity to avoid ad-hoc storage resizing.
             documentationCache.reserveCapacity(symbolReferences.count)
             documentLocationMap.reserveCapacity(symbolReferences.count)
@@ -1204,14 +1414,14 @@ public class DocumentationContext {
             combinedRelationshipsBySelector.reserveCapacity(symbolReferences.count)
             uniqueRelationships.reserveCapacity(symbolReferences.count)
             combinedSymbols.reserveCapacity(symbolReferences.count)
-            
+
             // Iterate over batches of symbol graphs, each batch describing one module.
             // Each batch contains one or more symbol graph files.
             for (moduleName, unifiedSymbolGraph) in symbolGraphLoader.unifiedGraphs {
                 try shouldContinueRegistration()
 
                 let fileURL = symbolGraphLoader.mainModuleURL(forModule: moduleName)
-                
+
                 let moduleInterfaceLanguages: Set<SourceLanguage>
                 // FIXME: Update with new SymbolKit API once available.
                 // This is a very inefficient way to gather the source languages
@@ -1220,58 +1430,74 @@ public class DocumentationContext {
                 let symbolGraphLanguages = Set(
                     unifiedSymbolGraph.symbols.flatMap(\.value.sourceLanguages)
                 )
-                
+
                 // If the symbol graph has no symbols, we cannot determine what languages is it available for,
                 // so fall back to Swift.
-                moduleInterfaceLanguages = symbolGraphLanguages.isEmpty ? [.swift] : symbolGraphLanguages
-                
+                moduleInterfaceLanguages =
+                    symbolGraphLanguages.isEmpty ? [.swift] : symbolGraphLanguages
+
                 // If it's an existing module, update the interface languages
-                moduleReferences[moduleName] = moduleReferences[moduleName]?.addingSourceLanguages(moduleInterfaceLanguages)
-                
+                moduleReferences[moduleName] = moduleReferences[moduleName]?.addingSourceLanguages(
+                    moduleInterfaceLanguages)
+
                 // Import the symbol graph symbols
                 let moduleReference: ResolvedTopicReference
-                
+
                 // If it's a repeating module, diff & merge matching declarations.
                 if let existingModuleReference = moduleReferences[moduleName] {
                     // This node is known to exist
                     moduleReference = existingModuleReference
-                    
-                    try mergeSymbolDeclarations(from: unifiedSymbolGraph, references: symbolReferences, moduleReference: moduleReference, fileURL: fileURL)
+
+                    try mergeSymbolDeclarations(
+                        from: unifiedSymbolGraph, references: symbolReferences,
+                        moduleReference: moduleReference, fileURL: fileURL)
                 } else {
                     guard symbolGraphLoader.hasPrimaryURL(moduleName: moduleName) else { continue }
-                    
+
                     // Create a module symbol
                     let moduleIdentifier = SymbolGraph.Symbol.Identifier(
                         precise: moduleName,
                         interfaceLanguage: moduleInterfaceLanguages.first!.id
                     )
-                    
+
                     // Use the default module kind for this bundle if one was provided,
                     // otherwise fall back to 'Framework'
                     let moduleKindDisplayName = bundle.info.defaultModuleKind ?? "Framework"
                     let moduleSymbol = SymbolGraph.Symbol(
-                            identifier: moduleIdentifier,
-                            names: SymbolGraph.Symbol.Names(title: moduleName, navigator: nil, subHeading: nil, prose: nil),
-                            pathComponents: [moduleName],
-                            docComment: nil,
-                            accessLevel: SymbolGraph.Symbol.AccessControl(rawValue: "public"),
-                            kind: SymbolGraph.Symbol.Kind(parsedIdentifier: .module, displayName: moduleKindDisplayName),
-                            mixins: [:])
-                    let moduleSymbolReference = SymbolReference(moduleName, interfaceLanguages: moduleInterfaceLanguages, defaultSymbol: moduleSymbol)
-                    moduleReference = ResolvedTopicReference(symbolReference: moduleSymbolReference, moduleName: moduleName, bundle: bundle)
-                    
-                    signposter.withIntervalSignpost("Add symbols to topic graph", id: signposter.makeSignpostID()) {
-                        addSymbolsToTopicGraph(symbolGraph: unifiedSymbolGraph, url: fileURL, symbolReferences: symbolReferences, moduleReference: moduleReference)
+                        identifier: moduleIdentifier,
+                        names: SymbolGraph.Symbol.Names(
+                            title: moduleName, navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: [moduleName],
+                        docComment: nil,
+                        accessLevel: SymbolGraph.Symbol.AccessControl(rawValue: "public"),
+                        kind: SymbolGraph.Symbol.Kind(
+                            parsedIdentifier: .module, displayName: moduleKindDisplayName),
+                        mixins: [:])
+                    let moduleSymbolReference = SymbolReference(
+                        moduleName, interfaceLanguages: moduleInterfaceLanguages,
+                        defaultSymbol: moduleSymbol)
+                    moduleReference = ResolvedTopicReference(
+                        symbolReference: moduleSymbolReference, moduleName: moduleName,
+                        bundle: bundle)
+
+                    signposter.withIntervalSignpost(
+                        "Add symbols to topic graph", id: signposter.makeSignpostID()
+                    ) {
+                        addSymbolsToTopicGraph(
+                            symbolGraph: unifiedSymbolGraph, url: fileURL,
+                            symbolReferences: symbolReferences, moduleReference: moduleReference)
                     }
-                    
+
                     // For inherited symbols we remove the source docs (if inheriting docs is disabled) before creating their documentation nodes.
                     for (_, relationships) in unifiedSymbolGraph.relationshipsByLanguage {
                         for relationship in relationships {
                             // Check for an origin key.
-                            if let sourceOrigin = relationship[mixin: SymbolGraph.Relationship.SourceOrigin.self],
+                            if let sourceOrigin = relationship[
+                                mixin: SymbolGraph.Relationship.SourceOrigin.self],
                                 // Check if it's a memberOf or implementation relationship.
-                                (relationship.kind == .memberOf || relationship.kind == .defaultImplementationOf)
-                            {    
+                                relationship.kind == .memberOf
+                                    || relationship.kind == .defaultImplementationOf
+                            {
                                 SymbolGraphRelationshipsBuilder.addInheritedDefaultImplementation(
                                     sourceOrigin: sourceOrigin,
                                     inheritedSymbolID: relationship.source,
@@ -1284,31 +1510,40 @@ public class DocumentationContext {
                     }
 
                     let overloadGroups: [String: Set<String>] =
-                    unifiedSymbolGraph.relationshipsByLanguage.values.flatMap({
-                        $0.filter { $0.kind == .overloadOf }
-                    }).reduce(into: [:], { acc, relationship in
-                        acc[relationship.target, default: []].insert(relationship.source)
-                    })
+                        unifiedSymbolGraph.relationshipsByLanguage.values.flatMap({
+                            $0.filter { $0.kind == .overloadOf }
+                        }).reduce(
+                            into: [:],
+                            { acc, relationship in
+                                acc[relationship.target, default: []].insert(relationship.source)
+                            })
                     addOverloadGroupReferences(overloadGroups: overloadGroups)
 
-                    if let rootURL = symbolGraphLoader.mainModuleURL(forModule: moduleName), let rootModule = unifiedSymbolGraph.moduleData[rootURL] {
+                    if let rootURL = symbolGraphLoader.mainModuleURL(forModule: moduleName),
+                        let rootModule = unifiedSymbolGraph.moduleData[rootURL]
+                    {
                         addPreparedSymbolToContext(
-                            preparedSymbolData(.init(fromSingleSymbol: moduleSymbol, module: rootModule, isMainGraph: true), reference: moduleReference, module: rootModule, moduleReference: moduleReference, fileURL: fileURL)
+                            preparedSymbolData(
+                                .init(
+                                    fromSingleSymbol: moduleSymbol, module: rootModule,
+                                    isMainGraph: true), reference: moduleReference,
+                                module: rootModule, moduleReference: moduleReference,
+                                fileURL: fileURL)
                         )
                     }
 
                     // Add this module to the dictionary of processed modules to keep track of repeat symbol graphs
                     moduleReferences[moduleName] = moduleReference
                 }
-                
+
                 // Collect symbols and relationships
                 combinedSymbols.merge(unifiedSymbolGraph.symbols, uniquingKeysWith: { $1 })
-                
+
                 for (selector, relationships) in unifiedSymbolGraph.relationshipsByLanguage {
                     combinedRelationshipsBySelector[selector, default: []].formUnion(relationships)
                     uniqueRelationships.formUnion(relationships)
                 }
-                
+
                 // Keep track of relationships that refer to symbols that are absent from the symbol graph, so that
                 // we can diagnose them.
                 combinedRelationshipsBySelector[
@@ -1317,36 +1552,46 @@ public class DocumentationContext {
                 ].formUnion(unifiedSymbolGraph.orphanRelationships)
                 uniqueRelationships.formUnion(unifiedSymbolGraph.orphanRelationships)
             }
-            
+
             try shouldContinueRegistration()
-            
+
             // Only add the symbol mapping now if the path hierarchy based resolver is the main implementation.
             // If it is only used for mismatch checking then we must wait until the documentation cache code path has traversed and updated all the colliding nodes.
             // Otherwise the mappings will save the unmodified references and the hierarchy based resolver won't find the expected parent nodes when resolving links.
             linkResolver.localResolver.addMappingForSymbols(localCache: documentationCache)
-            
+
             // Track the symbols that have multiple matching documentation extension files for diagnostics.
-            var symbolsWithMultipleDocumentationExtensionMatches = [ResolvedTopicReference: [SemanticResult<Article>]]()
+            var symbolsWithMultipleDocumentationExtensionMatches = [
+                ResolvedTopicReference: [SemanticResult<Article>]
+            ]()
             for documentationExtension in documentationExtensions {
                 guard let link = documentationExtension.value.title?.child(at: 0) as? AnyLink else {
-                    fatalError("An article shouldn't have ended up in the documentation extension list unless its title was a link. File: \(documentationExtension.source.absoluteString.singleQuoted)")
+                    fatalError(
+                        "An article shouldn't have ended up in the documentation extension list unless its title was a link. File: \(documentationExtension.source.absoluteString.singleQuoted)"
+                    )
                 }
-                
+
                 guard let destination = link.destination else {
-                    let diagnostic = Diagnostic(source: documentationExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.emptyLinkDestination", summary: """
-                        Documentation extension with an empty link doesn't correspond to any symbol.
-                        """, explanation: nil, notes: [])
+                    let diagnostic = Diagnostic(
+                        source: documentationExtension.source, severity: .warning,
+                        range: link.range, identifier: "org.swift.docc.emptyLinkDestination",
+                        summary: """
+                            Documentation extension with an empty link doesn't correspond to any symbol.
+                            """, explanation: nil, notes: [])
                     diagnosticEngine.emit(Problem(diagnostic: diagnostic))
                     continue
                 }
                 guard let url = ValidatedURL(parsingAuthoredLink: destination) else {
-                    let diagnostic = Diagnostic(source: documentationExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.invalidLinkDestination", summary: """
-                        \(destination.singleQuoted) is not a valid RFC 3986 URL.
-                        """, explanation: nil, notes: [])
+                    let diagnostic = Diagnostic(
+                        source: documentationExtension.source, severity: .warning,
+                        range: link.range, identifier: "org.swift.docc.invalidLinkDestination",
+                        summary: """
+                            \(destination.singleQuoted) is not a valid RFC 3986 URL.
+                            """, explanation: nil, notes: [])
                     diagnosticEngine.emit(Problem(diagnostic: diagnostic))
                     continue
                 }
-                
+
                 // FIXME: Resolve the link relative to the module https://github.com/swiftlang/swift-docc/issues/516
                 let reference = TopicReference.unresolved(.init(topicURL: url))
                 switch resolve(reference, in: bundle.rootReference, fromSymbolLink: true) {
@@ -1355,12 +1600,16 @@ public class DocumentationContext {
                         if symbolsWithMultipleDocumentationExtensionMatches[resolved] == nil {
                             symbolsWithMultipleDocumentationExtensionMatches[resolved] = [existing]
                         }
-                        symbolsWithMultipleDocumentationExtensionMatches[resolved]!.append(documentationExtension)
+                        symbolsWithMultipleDocumentationExtensionMatches[resolved]!.append(
+                            documentationExtension)
                     } else {
                         uncuratedDocumentationExtensions[resolved] = documentationExtension
                     }
                 case .failure(_, let errorInfo):
-                    guard !configuration.convertServiceConfiguration.considerDocumentationExtensionsThatDoNotMatchSymbolsAsResolved else {
+                    guard
+                        !configuration.convertServiceConfiguration
+                            .considerDocumentationExtensionsThatDoNotMatchSymbolsAsResolved
+                    else {
                         // The ConvertService relies on old implementation detail where documentation extension files were always considered "resolved" even when they didn't match a symbol.
                         //
                         // Don't rely on this behavior for new functionality. The behavior will be removed once we have a new solution to meets the needs of the ConvertService. (rdar://108563483)
@@ -1372,38 +1621,54 @@ public class DocumentationContext {
                         // the process that interacts with the convert service is responsible for maintaining it's own link resolutions implementation to match the behavior of a regular build.
                         // - Diagnosing documentation extension files that don't match any symbols.
                         let reference = documentationExtension.topicGraphNode.reference
-                        
-                        let symbolPath = NodeURLGenerator.Path.documentation(path: url.components.path).stringValue
+
+                        let symbolPath = NodeURLGenerator.Path.documentation(
+                            path: url.components.path
+                        ).stringValue
                         let symbolReference = ResolvedTopicReference(
                             bundleID: reference.bundleID,
                             path: symbolPath,
                             fragment: nil,
                             sourceLanguages: reference.sourceLanguages
                         )
-                        
+
                         if let existing = uncuratedDocumentationExtensions[symbolReference] {
-                            if symbolsWithMultipleDocumentationExtensionMatches[symbolReference] == nil {
-                                symbolsWithMultipleDocumentationExtensionMatches[symbolReference] = [existing]
+                            if symbolsWithMultipleDocumentationExtensionMatches[symbolReference]
+                                == nil
+                            {
+                                symbolsWithMultipleDocumentationExtensionMatches[symbolReference] =
+                                    [existing]
                             }
-                            symbolsWithMultipleDocumentationExtensionMatches[symbolReference]!.append(documentationExtension)
+                            symbolsWithMultipleDocumentationExtensionMatches[symbolReference]!
+                                .append(documentationExtension)
                         } else {
-                            uncuratedDocumentationExtensions[symbolReference] = documentationExtension
+                            uncuratedDocumentationExtensions[symbolReference] =
+                                documentationExtension
                         }
                         continue
                     }
-                    
+
                     // Present a diagnostic specific to documentation extension files but get the solutions and notes from the general unresolved link problem.
-                    let unresolvedLinkProblem = unresolvedReferenceProblem(source: documentationExtension.source, range: link.range, severity: .warning, uncuratedArticleMatch: nil, errorInfo: errorInfo, fromSymbolLink: link is SymbolLink)
-                    
+                    let unresolvedLinkProblem = unresolvedReferenceProblem(
+                        source: documentationExtension.source, range: link.range,
+                        severity: .warning, uncuratedArticleMatch: nil, errorInfo: errorInfo,
+                        fromSymbolLink: link is SymbolLink)
+
                     diagnosticEngine.emit(
                         Problem(
-                            diagnostic: Diagnostic(source: documentationExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.SymbolUnmatched", summary: "No symbol matched \(destination.singleQuoted). \(errorInfo.message).", notes: unresolvedLinkProblem.diagnostic.notes),
+                            diagnostic: Diagnostic(
+                                source: documentationExtension.source, severity: .warning,
+                                range: link.range, identifier: "org.swift.docc.SymbolUnmatched",
+                                summary:
+                                    "No symbol matched \(destination.singleQuoted). \(errorInfo.message).",
+                                notes: unresolvedLinkProblem.diagnostic.notes),
                             possibleSolutions: unresolvedLinkProblem.possibleSolutions
                         )
                     )
                 }
             }
-            emitWarningsForSymbolsMatchedInMultipleDocumentationExtensions(with: symbolsWithMultipleDocumentationExtensionMatches)
+            emitWarningsForSymbolsMatchedInMultipleDocumentationExtensions(
+                with: symbolsWithMultipleDocumentationExtensionMatches)
             symbolsWithMultipleDocumentationExtensionMatches.removeAll()
 
             // Create inherited API collections
@@ -1414,7 +1679,9 @@ public class DocumentationContext {
             )
 
             // Parse and prepare the nodes' content concurrently.
-            let updatedNodes = signposter.withIntervalSignpost("Parse symbol markup", id: signposter.makeSignpostID()) {
+            let updatedNodes = signposter.withIntervalSignpost(
+                "Parse symbol markup", id: signposter.makeSignpostID()
+            ) {
                 Array(documentationCache.symbolReferences).concurrentMap { finalReference in
                     // Match the symbol's documentation extension and initialize the node content.
                     let match = uncuratedDocumentationExtensions[finalReference]
@@ -1423,14 +1690,15 @@ public class DocumentationContext {
                         match: match,
                         bundle: bundle
                     )
-                    
-                    return ((
-                        node: updatedNode,
-                        matchedArticleURL: match?.source
-                    ))
+
+                    return
+                        ((
+                            node: updatedNode,
+                            matchedArticleURL: match?.source
+                        ))
                 }
             }
-            
+
             // Update cache with up-to-date nodes
             for (updatedNode, matchedArticleURL) in updatedNodes {
                 let reference = updatedNode.reference
@@ -1441,7 +1709,8 @@ public class DocumentationContext {
                 // Update cache with the updated node value
                 if let symbol = updatedNode.symbol {
                     // If the node was a symbol, add both the reference and the symbol ID
-                    documentationCache.add(updatedNode, reference: reference, symbolID: symbol.identifier.precise)
+                    documentationCache.add(
+                        updatedNode, reference: reference, symbolID: symbol.identifier.precise)
                 } else {
                     documentationCache[reference] = updatedNode
                 }
@@ -1453,11 +1722,15 @@ public class DocumentationContext {
             }
 
             // Resolve any external references first
-            preResolveExternalLinks(references: Array(moduleReferences.values) + combinedSymbols.keys.compactMap({ documentationCache.reference(symbolID: $0) }), localBundleID: bundle.id)
-            
+            preResolveExternalLinks(
+                references: Array(moduleReferences.values)
+                    + combinedSymbols.keys.compactMap({ documentationCache.reference(symbolID: $0) }
+                    ), localBundleID: bundle.id)
+
             // Look up and add symbols that are _referenced_ in the symbol graph but don't exist in the symbol graph.
-            try resolveExternalSymbols(in: combinedSymbols, relationships: combinedRelationshipsBySelector)
-            
+            try resolveExternalSymbols(
+                in: combinedSymbols, relationships: combinedRelationshipsBySelector)
+
             for (selector, relationships) in combinedRelationshipsBySelector {
                 // Build relationships in the completed graph
                 buildRelationships(relationships, selector: selector, bundle: bundle)
@@ -1489,7 +1762,9 @@ public class DocumentationContext {
         bundle: DocumentationBundle
     ) {
         // Find all of the relationships which refer to an extended module.
-        let extendedModuleRelationships = ExtendedTypeFormatTransformation.collapsedExtendedModuleRelationships(from: relationships)
+        let extendedModuleRelationships =
+            ExtendedTypeFormatTransformation.collapsedExtendedModuleRelationships(
+                from: relationships)
 
         for edge in relationships {
             switch edge.kind {
@@ -1558,7 +1833,7 @@ public class DocumentationContext {
             }
         }
     }
-    
+
     /// Identifies all the dictionary keys and records them in the appropriate target dictionaries.
     private func populateOnPageMemberRelationships(
         from relationships: Set<SymbolGraph.Relationship>,
@@ -1569,42 +1844,56 @@ public class DocumentationContext {
         var bodyByTarget = [String: HTTPBody]()
         var bodyParametersByTarget = [String: [HTTPParameter]]()
         var responsesByTarget = [String: [HTTPResponse]]()
-        
+
         for edge in relationships {
             if edge.kind == .memberOf || edge.kind == .optionalMemberOf {
-                if let source = documentationCache[edge.source], let target = documentationCache[edge.target],
-                   let sourceSymbol = source.symbol
+                if let source = documentationCache[edge.source],
+                    let target = documentationCache[edge.target],
+                    let sourceSymbol = source.symbol
                 {
                     switch (source.kind, target.kind) {
                     case (.dictionaryKey, .dictionary):
-                        let dictionaryKey = DictionaryKey(name: sourceSymbol.names.title, contents: [], symbol: sourceSymbol, required: (edge.kind == .memberOf))
+                        let dictionaryKey = DictionaryKey(
+                            name: sourceSymbol.names.title, contents: [], symbol: sourceSymbol,
+                            required: (edge.kind == .memberOf))
                         if keysByTarget[edge.target] == nil {
                             keysByTarget[edge.target] = [dictionaryKey]
                         } else {
                             keysByTarget[edge.target]?.append(dictionaryKey)
                         }
                     case (.httpParameter, .httpRequest):
-                        let parameter = HTTPParameter(name: sourceSymbol.names.title, source: (sourceSymbol.httpParameterSource ?? "query"), contents: [], symbol: sourceSymbol, required: (edge.kind == .memberOf))
+                        let parameter = HTTPParameter(
+                            name: sourceSymbol.names.title,
+                            source: (sourceSymbol.httpParameterSource ?? "query"), contents: [],
+                            symbol: sourceSymbol, required: (edge.kind == .memberOf))
                         if parametersByTarget[edge.target] == nil {
                             parametersByTarget[edge.target] = [parameter]
                         } else {
                             parametersByTarget[edge.target]?.append(parameter)
                         }
                     case (.httpBody, .httpRequest):
-                        let body = HTTPBody(mediaType: sourceSymbol.httpMediaType, contents: [], symbol: sourceSymbol)
+                        let body = HTTPBody(
+                            mediaType: sourceSymbol.httpMediaType, contents: [],
+                            symbol: sourceSymbol)
                         bodyByTarget[edge.target] = body
                     case (.httpParameter, .httpBody):
-                        let parameter = HTTPParameter(name: sourceSymbol.names.title, source: "body", contents: [], symbol: sourceSymbol, required: (edge.kind == .memberOf))
+                        let parameter = HTTPParameter(
+                            name: sourceSymbol.names.title, source: "body", contents: [],
+                            symbol: sourceSymbol, required: (edge.kind == .memberOf))
                         if bodyParametersByTarget[edge.target] == nil {
                             bodyParametersByTarget[edge.target] = [parameter]
                         } else {
                             bodyParametersByTarget[edge.target]?.append(parameter)
                         }
                     case (.httpResponse, .httpRequest):
-                        let statusParts = sourceSymbol.names.title.split(separator: " ", maxSplits: 1)
+                        let statusParts = sourceSymbol.names.title.split(
+                            separator: " ", maxSplits: 1)
                         let statusCode = UInt(statusParts[0]) ?? 0
                         let reason = statusParts.count > 1 ? String(statusParts[1]) : nil
-                        let response = HTTPResponse(statusCode: statusCode, reason: reason, mediaType: sourceSymbol.httpMediaType, contents: [], symbol: sourceSymbol)
+                        let response = HTTPResponse(
+                            statusCode: statusCode, reason: reason,
+                            mediaType: sourceSymbol.httpMediaType, contents: [],
+                            symbol: sourceSymbol)
                         if responsesByTarget[edge.target] == nil {
                             responsesByTarget[edge.target] = [response]
                         } else {
@@ -1616,7 +1905,7 @@ public class DocumentationContext {
                 }
             }
         }
-        
+
         // Merge in all the dictionary keys for each target into their section variants.
         keysByTarget.forEach { targetIdentifier, keys in
             let target = documentationCache[targetIdentifier]
@@ -1629,7 +1918,7 @@ public class DocumentationContext {
                 }
             }
         }
-        
+
         // Merge in all the parameters for each target into their section variants.
         parametersByTarget.forEach { targetIdentifier, parameters in
             let target = documentationCache[targetIdentifier]
@@ -1642,14 +1931,16 @@ public class DocumentationContext {
                 }
             }
         }
-        
+
         // Merge in the body for each target into their section variants.
         bodyByTarget.forEach { targetIdentifier, body in
             let target = documentationCache[targetIdentifier]
             if let semantic = target?.semantic as? Symbol {
                 // Add any body parameters to existing body record
                 var localBody = body
-                if let identifier = body.symbol?.identifier.precise, let bodyParameters = bodyParametersByTarget[identifier] {
+                if let identifier = body.symbol?.identifier.precise,
+                    let bodyParameters = bodyParametersByTarget[identifier]
+                {
                     localBody.parameters = bodyParameters.sorted(by: \.name)
                 }
                 if semantic.httpBodySection == nil {
@@ -1659,7 +1950,7 @@ public class DocumentationContext {
                 }
             }
         }
-        
+
         // Merge in all the responses for each target into their section variants.
         responsesByTarget.forEach { targetIdentifier, responses in
             let target = documentationCache[targetIdentifier]
@@ -1673,20 +1964,22 @@ public class DocumentationContext {
             }
         }
     }
-    
+
     /// Look up and add symbols that are _referenced_ in the symbol graph but don't exist in the symbol graph, using an `globalExternalSymbolResolver` (if not `nil`).
     func resolveExternalSymbols(
         in symbols: [String: UnifiedSymbolGraph.Symbol],
         relationships: [UnifiedSymbolGraph.Selector: Set<SymbolGraph.Relationship>]
     ) throws {
-        if configuration.externalDocumentationConfiguration.globalSymbolResolver == nil, linkResolver.externalResolvers.isEmpty {
+        if configuration.externalDocumentationConfiguration.globalSymbolResolver == nil,
+            linkResolver.externalResolvers.isEmpty
+        {
             // Context has no mechanism for resolving external symbol links. No reason to gather any symbols to resolve.
             return
         }
-        
+
         // Gather all the references to symbols that don't exist in the combined symbol graph file and add then by resolving these "external" symbols.
         var symbolsToResolve = Set<String>()
-        
+
         // Add all the symbols that are the target of a relationship. These could for example be protocols that are being conformed to,
         // classes that are being subclassed, or methods that are being overridden.
         for (_, relationships) in relationships {
@@ -1694,24 +1987,32 @@ public class DocumentationContext {
                 symbolsToResolve.insert(edge.target)
             }
         }
-        
+
         // Add all the types that are referenced in a declaration. These could for example be the type of an argument or return value.
         for symbol in symbols.values {
-            guard let defaultSymbol = symbol.defaultSymbol, let declaration = defaultSymbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self] else {
+            guard let defaultSymbol = symbol.defaultSymbol,
+                let declaration = defaultSymbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self]
+            else {
                 continue
             }
             for fragment in declaration.declarationFragments {
-                guard let preciseIdentifier = fragment.preciseIdentifier, documentationCache[preciseIdentifier] == nil else {
+                guard let preciseIdentifier = fragment.preciseIdentifier,
+                    documentationCache[preciseIdentifier] == nil
+                else {
                     continue
                 }
                 symbolsToResolve.insert(preciseIdentifier)
             }
         }
-        
+
         // TODO: When the symbol graph includes the precise identifiers for conditional availability, those symbols should also be resolved (rdar://63768609).
-        
-        func resolveSymbol(symbolID: String) -> (ResolvedTopicReference, LinkResolver.ExternalEntity)? {
-            if let globalResult = configuration.externalDocumentationConfiguration.globalSymbolResolver?.symbolReferenceAndEntity(withPreciseIdentifier: symbolID) {
+
+        func resolveSymbol(symbolID: String) -> (
+            ResolvedTopicReference, LinkResolver.ExternalEntity
+        )? {
+            if let globalResult = configuration.externalDocumentationConfiguration
+                .globalSymbolResolver?.symbolReferenceAndEntity(withPreciseIdentifier: symbolID)
+            {
                 return globalResult
             }
             for externalResolver in linkResolver.externalResolvers.values {
@@ -1721,7 +2022,7 @@ public class DocumentationContext {
             }
             return nil
         }
-        
+
         // Resolve all the collected symbol identifiers and add them do the topic graph.
         for symbolID in symbolsToResolve {
             if let (reference, entity) = resolveSymbol(symbolID: symbolID) {
@@ -1731,48 +2032,72 @@ public class DocumentationContext {
             // The build doesn't necessarily include all documentation dependencies that appear in declarations, conformances, etc.
         }
     }
-    
+
     /// When building multi-platform documentation symbols might have more than one declaration
     /// depending on variances in their implementation across platforms (e.g. use `NSPoint` vs `CGPoint` parameter in a method).
     /// This method finds matching symbols between graphs and merges their declarations in case there are differences.
-    func mergeSymbolDeclarations(from otherSymbolGraph: UnifiedSymbolGraph, references: [SymbolGraph.Symbol.Identifier: ResolvedTopicReference], moduleReference: ResolvedTopicReference, fileURL otherSymbolGraphURL: URL?) throws {
+    func mergeSymbolDeclarations(
+        from otherSymbolGraph: UnifiedSymbolGraph,
+        references: [SymbolGraph.Symbol.Identifier: ResolvedTopicReference],
+        moduleReference: ResolvedTopicReference, fileURL otherSymbolGraphURL: URL?
+    ) throws {
         let mergeError = Synchronized<Error?>(nil)
-        
-        let results: [AddSymbolResultWithProblems] = Array(otherSymbolGraph.symbols.values).concurrentPerform { symbol, result in
-            guard let defaultSymbol = symbol.defaultSymbol, let swiftSelector = symbol.defaultSelector, let module = symbol.modules[swiftSelector] else {
-                fatalError("""
-                    Only Swift symbols are currently supported. \
-                    This initializer is only called with symbols from the symbol graph, which currently only supports Swift.
-                    """
-                )
-            }
-            guard defaultSymbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self] != nil else {
-                diagnosticEngine.emit(Problem(diagnostic: Diagnostic(source: nil, severity: .error, range: nil, identifier: "org.swift.docc.SymbolDeclarationNotFound", summary: "Symbol with identifier '\(symbol.uniqueIdentifier)' has no declaration"), possibleSolutions: []))
-                return
-            }
-            
-            guard let existingNode = documentationCache[symbol.uniqueIdentifier], existingNode.semantic is Symbol else {
-                // New symbols that didn't exist in the previous graphs should be added.
-                guard let reference = references[symbol.defaultIdentifier] else {
-                    fatalError("Symbol with identifier '\(symbol.uniqueIdentifier)' has no reference. A symbol will always have at least one reference.")
+
+        let results: [AddSymbolResultWithProblems] = Array(otherSymbolGraph.symbols.values)
+            .concurrentPerform { symbol, result in
+                guard let defaultSymbol = symbol.defaultSymbol,
+                    let swiftSelector = symbol.defaultSelector,
+                    let module = symbol.modules[swiftSelector]
+                else {
+                    fatalError(
+                        """
+                        Only Swift symbols are currently supported. \
+                        This initializer is only called with symbols from the symbol graph, which currently only supports Swift.
+                        """
+                    )
                 }
-                
-                result.append(preparedSymbolData(symbol, reference: reference, module: module, moduleReference: moduleReference, fileURL: otherSymbolGraphURL))
-                return
+                guard defaultSymbol[mixin: SymbolGraph.Symbol.DeclarationFragments.self] != nil
+                else {
+                    diagnosticEngine.emit(
+                        Problem(
+                            diagnostic: Diagnostic(
+                                source: nil, severity: .error, range: nil,
+                                identifier: "org.swift.docc.SymbolDeclarationNotFound",
+                                summary:
+                                    "Symbol with identifier '\(symbol.uniqueIdentifier)' has no declaration"
+                            ), possibleSolutions: []))
+                    return
+                }
+
+                guard let existingNode = documentationCache[symbol.uniqueIdentifier],
+                    existingNode.semantic is Symbol
+                else {
+                    // New symbols that didn't exist in the previous graphs should be added.
+                    guard let reference = references[symbol.defaultIdentifier] else {
+                        fatalError(
+                            "Symbol with identifier '\(symbol.uniqueIdentifier)' has no reference. A symbol will always have at least one reference."
+                        )
+                    }
+
+                    result.append(
+                        preparedSymbolData(
+                            symbol, reference: reference, module: module,
+                            moduleReference: moduleReference, fileURL: otherSymbolGraphURL))
+                    return
+                }
+
+                do {
+                    // It's safe to force unwrap since we validated the data above.
+                    // We update the node in place so avoid copying the data around.
+                    try (existingNode.semantic as! Symbol).mergeDeclarations(unifiedSymbol: symbol)
+                } catch {
+                    // Invalid input data, throw the error.
+                    mergeError.sync({
+                        if $0 == nil { $0 = error }
+                    })
+                }
             }
-            
-            do {
-                // It's safe to force unwrap since we validated the data above.
-                // We update the node in place so avoid copying the data around.
-                try (existingNode.semantic as! Symbol).mergeDeclarations(unifiedSymbol: symbol)
-            } catch {
-                // Invalid input data, throw the error.
-                mergeError.sync({
-                    if $0 == nil { $0 = error }
-                })
-            }
-        }
-        
+
         // If there was an invalid input error re-throw it.
         if let error = mergeError.sync({ $0 }) {
             throw error
@@ -1781,19 +2106,19 @@ public class DocumentationContext {
         // Add any new symbols to the documentation cache.
         results.forEach { addPreparedSymbolToContext($0) }
     }
-    
+
     private static let supportedImageExtensions: Set<String> = ["png", "jpg", "jpeg", "svg", "gif"]
     private static let supportedVideoExtensions: Set<String> = ["mov", "mp4"]
 
     // TODO: Move this functionality to ``DocumentationBundleFileTypes`` (rdar://68156425).
-    
+
     /// A type of asset.
     public enum AssetType: CustomStringConvertible {
         /// An image asset.
         case image
         /// A video asset.
         case video
-        
+
         public var description: String {
             switch self {
             case .image:
@@ -1813,17 +2138,21 @@ public class DocumentationContext {
     public static func isFileExtension(_ fileExtension: String, supported type: AssetType) -> Bool {
         let fileExtension = fileExtension.lowercased()
         switch type {
-            case .image: return supportedImageExtensions.contains(fileExtension)
-            case .video: return supportedVideoExtensions.contains(fileExtension)
+        case .image: return supportedImageExtensions.contains(fileExtension)
+        case .video: return supportedVideoExtensions.contains(fileExtension)
         }
     }
-    
+
     private func registerMiscResources(from bundle: DocumentationBundle) throws {
         let miscResources = Set(bundle.miscResourceURLs)
         try assetManagers[bundle.id, default: DataAssetManager()].register(data: miscResources)
     }
-    
-    private func registeredAssets(withExtensions extensions: Set<String>? = nil, inContexts contexts: [DataAsset.Context] = DataAsset.Context.allCases, forBundleID bundleID: DocumentationBundle.Identifier) -> [DataAsset] {
+
+    private func registeredAssets(
+        withExtensions extensions: Set<String>? = nil,
+        inContexts contexts: [DataAsset.Context] = DataAsset.Context.allCases,
+        forBundleID bundleID: DocumentationBundle.Identifier
+    ) -> [DataAsset] {
         guard let resources = assetManagers[bundleID]?.storage.values else {
             return []
         }
@@ -1845,24 +2174,36 @@ public class DocumentationContext {
     /// - Parameter bundleID: The identifier of the bundle to return image assets for.
     /// - Returns: A list of all the image assets for the given bundle.
     public func registeredImageAssets(for bundleID: DocumentationBundle.Identifier) -> [DataAsset] {
-        registeredAssets(withExtensions: DocumentationContext.supportedImageExtensions, forBundleID: bundleID)
+        registeredAssets(
+            withExtensions: DocumentationContext.supportedImageExtensions, forBundleID: bundleID)
     }
-    
-    @available(*, deprecated, renamed: "registeredImageAssets(for:)", message: "registeredImageAssets(for:)' instead. This deprecated API will be removed after 6.2 is released")
-    public func registeredImageAssets(forBundleID bundleIdentifier: BundleIdentifier) -> [DataAsset] {
+
+    @available(
+        *, deprecated, renamed: "registeredImageAssets(for:)",
+        message:
+            "registeredImageAssets(for:)' instead. This deprecated API will be removed after 6.2 is released"
+    )
+    public func registeredImageAssets(forBundleID bundleIdentifier: BundleIdentifier) -> [DataAsset]
+    {
         registeredImageAssets(for: DocumentationBundle.Identifier(rawValue: bundleIdentifier))
     }
-    
+
     /// Returns a list of all the video assets that registered for a given `bundleIdentifier`.
     ///
     /// - Parameter bundleID: The identifier of the bundle to return video assets for.
     /// - Returns: A list of all the video assets for the given bundle.
     public func registeredVideoAssets(for bundleID: DocumentationBundle.Identifier) -> [DataAsset] {
-        registeredAssets(withExtensions: DocumentationContext.supportedVideoExtensions, forBundleID: bundleID)
+        registeredAssets(
+            withExtensions: DocumentationContext.supportedVideoExtensions, forBundleID: bundleID)
     }
-    
-    @available(*, deprecated, renamed: "registeredVideoAssets(for:)", message: "registeredImageAssets(for:)' instead. This deprecated API will be removed after 6.2 is released")
-    public func registeredVideoAssets(forBundleID bundleIdentifier: BundleIdentifier) -> [DataAsset] {
+
+    @available(
+        *, deprecated, renamed: "registeredVideoAssets(for:)",
+        message:
+            "registeredImageAssets(for:)' instead. This deprecated API will be removed after 6.2 is released"
+    )
+    public func registeredVideoAssets(forBundleID bundleIdentifier: BundleIdentifier) -> [DataAsset]
+    {
         registeredVideoAssets(for: DocumentationBundle.Identifier(rawValue: bundleIdentifier))
     }
 
@@ -1870,12 +2211,20 @@ public class DocumentationContext {
     ///
     /// - Parameter bundleID: The identifier of the bundle to return download assets for.
     /// - Returns: A list of all the download assets for the given bundle.
-    public func registeredDownloadsAssets(for bundleID: DocumentationBundle.Identifier) -> [DataAsset] {
+    public func registeredDownloadsAssets(for bundleID: DocumentationBundle.Identifier)
+        -> [DataAsset]
+    {
         registeredAssets(inContexts: [DataAsset.Context.download], forBundleID: bundleID)
     }
-    
-    @available(*, deprecated, renamed: "registeredDownloadsAssets(for:)", message: "registeredDownloadsAssets(for:)' instead. This deprecated API will be removed after 6.2 is released")
-    public func registeredDownloadsAssets(forBundleID bundleIdentifier: BundleIdentifier) -> [DataAsset] {
+
+    @available(
+        *, deprecated, renamed: "registeredDownloadsAssets(for:)",
+        message:
+            "registeredDownloadsAssets(for:)' instead. This deprecated API will be removed after 6.2 is released"
+    )
+    public func registeredDownloadsAssets(forBundleID bundleIdentifier: BundleIdentifier)
+        -> [DataAsset]
+    {
         registeredDownloadsAssets(for: DocumentationBundle.Identifier(rawValue: bundleIdentifier))
     }
 
@@ -1883,7 +2232,8 @@ public class DocumentationContext {
     private typealias ArticlesTuple = (articles: Articles, rootPageArticles: Articles)
 
     private func splitArticles(_ articles: Articles) -> ArticlesTuple {
-        return articles.reduce(into: ArticlesTuple(articles: [], rootPageArticles: [])) { result, article in
+        return articles.reduce(into: ArticlesTuple(articles: [], rootPageArticles: [])) {
+            result, article in
             if article.value.metadata?.technologyRoot != nil {
                 result.rootPageArticles.append(article)
             } else {
@@ -1891,34 +2241,40 @@ public class DocumentationContext {
             }
         }
     }
-    
+
     private func registerRootPages(from articles: Articles, in bundle: DocumentationBundle) {
         // Create a root leaf node for all root page articles
         for article in articles {
             // Create the documentation data
-            guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(for: article, kind: .collection, in: bundle) else { continue }
+            guard
+                let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
+                    for: article, kind: .collection, in: bundle)
+            else { continue }
             let reference = documentation.reference
-            
+
             // Create the documentation node
             documentLocationMap[article.source] = reference
             let topicGraphKind = DocumentationNode.Kind.module
-            let graphNode = TopicGraph.Node(reference: reference, kind: topicGraphKind, source: .file(url: article.source), title: title)
+            let graphNode = TopicGraph.Node(
+                reference: reference, kind: topicGraphKind, source: .file(url: article.source),
+                title: title)
             topicGraph.addNode(graphNode)
             documentationCache[reference] = documentation
-            
-            linkResolver.localResolver.addRootArticle(article, anchorSections: documentation.anchorSections)
+
+            linkResolver.localResolver.addRootArticle(
+                article, anchorSections: documentation.anchorSections)
             for anchor in documentation.anchorSections {
                 nodeAnchorSections[anchor.reference] = anchor
             }
-            
+
             // Remove the article from the context
             uncuratedArticles.removeValue(forKey: article.topicGraphNode.reference)
         }
     }
-    
+
     /// When `true` bundle registration will be cancelled asap.
     private var isRegistrationEnabled = Synchronized<Bool>(true)
-    
+
     /// Enables or disables bundle registration.
     ///
     /// When given `false` the context will try to cancel as quick as possible
@@ -1927,7 +2283,7 @@ public class DocumentationContext {
     public func setRegistrationEnabled(_ value: Bool) {
         isRegistrationEnabled.sync({ $0 = value })
     }
-    
+
     /// Adds articles that are not root pages to the documentation cache.
     ///
     /// This method adds all of the `articles` to the documentation cache and inserts a node representing
@@ -1944,26 +2300,33 @@ public class DocumentationContext {
         in bundle: DocumentationBundle
     ) -> DocumentationContext.Articles {
         articles.map { article in
-            guard let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
-                for: article,
-                // By default, articles are available in the languages the module that's being documented
-                // is available in. It's possible to override that behavior using the `@SupportedLanguage`
-                // directive though; see its documentation for more details.
-                availableSourceLanguages: soleRootModuleReference.map { sourceLanguages(for: $0) },
-                kind: .article,
-                in: bundle
-            ) else {
+            guard
+                let (documentation, title) = DocumentationContext.documentationNodeAndTitle(
+                    for: article,
+                    // By default, articles are available in the languages the module that's being documented
+                    // is available in. It's possible to override that behavior using the `@SupportedLanguage`
+                    // directive though; see its documentation for more details.
+                    availableSourceLanguages: soleRootModuleReference.map {
+                        sourceLanguages(for: $0)
+                    },
+                    kind: .article,
+                    in: bundle
+                )
+            else {
                 return article
             }
             let reference = documentation.reference
-            
+
             documentationCache[reference] = documentation
-            
+
             documentLocationMap[article.source] = reference
-            let graphNode = TopicGraph.Node(reference: reference, kind: .article, source: .file(url: article.source), title: title)
+            let graphNode = TopicGraph.Node(
+                reference: reference, kind: .article, source: .file(url: article.source),
+                title: title)
             topicGraph.addNode(graphNode)
-            
-            linkResolver.localResolver.addArticle(article, anchorSections: documentation.anchorSections)
+
+            linkResolver.localResolver.addArticle(
+                article, anchorSections: documentation.anchorSections)
             for anchor in documentation.anchorSections {
                 nodeAnchorSections[anchor.reference] = anchor
             }
@@ -1974,7 +2337,7 @@ public class DocumentationContext {
             return article
         }
     }
-    
+
     /// Registers a synthesized root page for a catalog with only non-root articles.
     ///
     /// If the catalog only has one article or has an article with the same name as the catalog itself, that article is turned into the root page instead of creating a new article.
@@ -1982,9 +2345,11 @@ public class DocumentationContext {
     /// - Parameters:
     ///   - articles: On input, a list of articles. If an article is used as a root it is removed from this list.
     ///   - bundle: The bundle containing the articles.
-    private func synthesizeArticleOnlyRootPage(articles: inout [DocumentationContext.SemanticResult<Article>], bundle: DocumentationBundle) {
+    private func synthesizeArticleOnlyRootPage(
+        articles: inout [DocumentationContext.SemanticResult<Article>], bundle: DocumentationBundle
+    ) {
         let title = bundle.displayName
-        
+
         // An inner helper function to register a new root node from an article
         func registerAsNewRootNode(_ articleResult: SemanticResult<Article>) {
             uncuratedArticles.removeValue(forKey: articleResult.topicGraphNode.reference)
@@ -1993,20 +2358,30 @@ public class DocumentationContext {
             let reference = ResolvedTopicReference(
                 bundleID: bundle.id,
                 path: NodeURLGenerator.Path.documentation(path: title).stringValue,
-                sourceLanguages: [DocumentationContext.defaultLanguage(in: nil /* article-only content has no source language information */)]
+                sourceLanguages: [
+                    DocumentationContext.defaultLanguage(
+                        in: nil /* article-only content has no source language information */)
+                ]
             )
             // Add the technology root to the article's metadata
             let metadataMarkup: BlockDirective
             if let markup = articleResult.value.metadata?.originalMarkup as? BlockDirective {
-                assert(!markup.children.contains(where: { ($0 as? BlockDirective)?.name == "TechnologyRoot" }),
-                       "Nothing should try to synthesize a root page if there's already an explicit authored root page")
-                metadataMarkup = markup.withUncheckedChildren(
-                    markup.children + [BlockDirective(name: "TechnologyRoot", children: [])]
-                ) as! BlockDirective
+                assert(
+                    !markup.children.contains(where: {
+                        ($0 as? BlockDirective)?.name == "TechnologyRoot"
+                    }),
+                    "Nothing should try to synthesize a root page if there's already an explicit authored root page"
+                )
+                metadataMarkup =
+                    markup.withUncheckedChildren(
+                        markup.children + [BlockDirective(name: "TechnologyRoot", children: [])]
+                    ) as! BlockDirective
             } else {
-                metadataMarkup = BlockDirective(name: "Metadata", children: [
-                    BlockDirective(name: "TechnologyRoot", children: [])
-                ])
+                metadataMarkup = BlockDirective(
+                    name: "Metadata",
+                    children: [
+                        BlockDirective(name: "TechnologyRoot", children: [])
+                    ])
             }
             let article = Article(
                 markup: articleResult.value.markup,
@@ -2014,31 +2389,42 @@ public class DocumentationContext {
                 redirects: articleResult.value.redirects,
                 options: articleResult.value.options
             )
-            
-            let graphNode = TopicGraph.Node(reference: reference, kind: .module, source: articleResult.topicGraphNode.source, title: title)
-            registerRootPages(from: [.init(value: article, source: articleResult.source, topicGraphNode: graphNode)], in: bundle)
+
+            let graphNode = TopicGraph.Node(
+                reference: reference, kind: .module, source: articleResult.topicGraphNode.source,
+                title: title)
+            registerRootPages(
+                from: [
+                    .init(value: article, source: articleResult.source, topicGraphNode: graphNode)
+                ], in: bundle)
         }
-        
+
         if articles.count == 1 {
             // This catalog only has one article, so we make that the root.
             registerAsNewRootNode(articles.removeFirst())
-        } else if let nameMatchIndex = articles.firstIndex(where: { $0.source.deletingPathExtension().lastPathComponent == title }) {
+        } else if let nameMatchIndex = articles.firstIndex(where: {
+            $0.source.deletingPathExtension().lastPathComponent == title
+        }) {
             // This catalog has an article with the same name as the catalog itself, so we make that the root.
             registerAsNewRootNode(articles.remove(at: nameMatchIndex))
         } else {
             // There's no particular article to make into the root. Instead, create a new minimal root page.
             let path = NodeURLGenerator.Path.documentation(path: title).stringValue
             let sourceLanguage = DocumentationContext.defaultLanguage(in: [])
-            
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguages: [sourceLanguage])
-            
-            let graphNode = TopicGraph.Node(reference: reference, kind: .module, source: .external, title: title)
+
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: path, sourceLanguages: [sourceLanguage])
+
+            let graphNode = TopicGraph.Node(
+                reference: reference, kind: .module, source: .external, title: title)
             topicGraph.addNode(graphNode)
-            
+
             // Build up the "full" markup for an empty technology root article
-            let metadataDirectiveMarkup = BlockDirective(name: "Metadata", children: [
-                BlockDirective(name: "TechnologyRoot", children: [])
-            ])
+            let metadataDirectiveMarkup = BlockDirective(
+                name: "Metadata",
+                children: [
+                    BlockDirective(name: "TechnologyRoot", children: [])
+                ])
             let markup = Document(
                 Heading(level: 1, Text(title)),
                 metadataDirectiveMarkup
@@ -2057,7 +2443,7 @@ public class DocumentationContext {
             documentationCache[reference] = documentationNode
         }
     }
-    
+
     /// Creates a documentation node and title for the given article semantic result.
     ///
     /// - Parameters:
@@ -2074,26 +2460,28 @@ public class DocumentationContext {
         guard let articleMarkup = article.value.markup else {
             return nil
         }
-        
-        let path = NodeURLGenerator.pathForSemantic(article.value, source: article.source, bundle: bundle)
-        
+
+        let path = NodeURLGenerator.pathForSemantic(
+            article.value, source: article.source, bundle: bundle)
+
         // Use the languages specified by the `@SupportedLanguage` directives if present.
-        let availableSourceLanguages = article.value
+        let availableSourceLanguages =
+            article.value
             .metadata
             .flatMap { metadata in
                 let languages = Set(
                     metadata.supportedLanguages
                         .map(\.language)
                 )
-                
+
                 return languages.isEmpty ? nil : languages
             }
-        ?? availableSourceLanguages
-        
+            ?? availableSourceLanguages
+
         // If available source languages are provided and it contains Swift, use Swift as the default language of
         // the article.
         let defaultSourceLanguage = defaultLanguage(in: availableSourceLanguages)
-        
+
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: path,
@@ -2102,9 +2490,9 @@ public class DocumentationContext {
                 // (github.com/swiftlang/swift-docc/issues/240).
                 ?? [.swift]
         )
-        
+
         let title = article.topicGraphNode.title
-        
+
         let documentationNode = DocumentationNode(
             reference: reference,
             kind: kind,
@@ -2114,10 +2502,10 @@ public class DocumentationContext {
             markup: articleMarkup,
             semantic: article.value
         )
-        
+
         return (documentationNode, title)
     }
-    
+
     /// Curates articles under the root module.
     ///
     /// This method creates a new task group under the root page containing references to all of the articles
@@ -2128,7 +2516,9 @@ public class DocumentationContext {
     ///   - rootNode: The node that will serve as the source of any topic graph edges created by this method.
     /// - Throws: If looking up a `DocumentationNode` for the root module reference fails.
     /// - Returns: An array of resolved references to the articles that were automatically curated.
-    private func autoCurateArticles(_ otherArticles: DocumentationContext.Articles, startingFrom rootNode: TopicGraph.Node) throws -> [ResolvedTopicReference] {
+    private func autoCurateArticles(
+        _ otherArticles: DocumentationContext.Articles, startingFrom rootNode: TopicGraph.Node
+    ) throws -> [ResolvedTopicReference] {
         let articlesToAutoCurate = otherArticles.filter { article in
             let reference = article.topicGraphNode.reference
             return topicGraph.edges[reference] == nil && topicGraph.reverseEdges[reference] == nil
@@ -2136,34 +2526,36 @@ public class DocumentationContext {
         guard !articlesToAutoCurate.isEmpty else {
             return []
         }
-        
+
         for article in articlesToAutoCurate {
             topicGraph.addEdge(from: rootNode, to: article.topicGraphNode)
             uncuratedArticles.removeValue(forKey: article.topicGraphNode.reference)
         }
-        
+
         let articleReferences = articlesToAutoCurate.map(\.topicGraphNode.reference)
         let automaticTaskGroup = AutomaticTaskGroupSection(
             title: "Articles",
             references: articleReferences,
             renderPositionPreference: .top
         )
-            
+
         let node = try entity(with: rootNode.reference)
-        
+
         // If the node we're automatically curating the article under is a symbol, automatically curate the article
         // for each language it's available in.
         if let symbol = node.semantic as? Symbol {
             for sourceLanguage in node.availableSourceLanguages {
-                symbol.automaticTaskGroupsVariants[.init(interfaceLanguage: sourceLanguage.id)] = [automaticTaskGroup]
+                symbol.automaticTaskGroupsVariants[.init(interfaceLanguage: sourceLanguage.id)] = [
+                    automaticTaskGroup
+                ]
             }
         } else if var taskGroupProviding = node.semantic as? AutomaticTaskGroupsProviding {
             taskGroupProviding.automaticTaskGroups = [automaticTaskGroup]
         }
-        
+
         return articleReferences
     }
-    
+
     /**
      Register a documentation bundle with this context.
      */
@@ -2177,18 +2569,24 @@ public class DocumentationContext {
 
             for unknownFeatureFlag in bundleFlags.unknownFeatureFlags {
                 let suggestions = NearMiss.bestMatches(
-                    for: DocumentationBundle.Info.BundleFeatureFlags.CodingKeys.allCases.map({ $0.stringValue }),
+                    for: DocumentationBundle.Info.BundleFeatureFlags.CodingKeys.allCases.map({
+                        $0.stringValue
+                    }),
                     against: unknownFeatureFlag)
-                var summary: String = "Unknown feature flag in Info.plist: \(unknownFeatureFlag.singleQuoted)"
+                var summary: String =
+                    "Unknown feature flag in Info.plist: \(unknownFeatureFlag.singleQuoted)"
                 if !suggestions.isEmpty {
-                    summary += ". Possible suggestions: \(suggestions.map(\.singleQuoted).joined(separator: ", "))"
+                    summary +=
+                        ". Possible suggestions: \(suggestions.map(\.singleQuoted).joined(separator: ", "))"
                 }
-                diagnosticEngine.emit(.init(diagnostic:
-                        .init(
-                            severity: .warning,
-                            identifier: "org.swift.docc.UnknownBundleFeatureFlag",
-                            summary: summary
-                        )))
+                diagnosticEngine.emit(
+                    .init(
+                        diagnostic:
+                            .init(
+                                severity: .warning,
+                                identifier: "org.swift.docc.UnknownBundleFeatureFlag",
+                                summary: summary
+                            )))
             }
         } else {
             currentFeatureFlags = nil
@@ -2201,34 +2599,42 @@ public class DocumentationContext {
 
         // Note: Each bundle is registered and processed separately.
         // Documents and symbols may both reference each other so the bundle is registered in 4 steps
-        
+
         // In the bundle discovery phase all tasks run in parallel as they don't depend on each other.
         let discoveryGroup = DispatchGroup()
-        let discoveryQueue = DispatchQueue(label: "org.swift.docc.Discovery", qos: .unspecified, attributes: .concurrent, autoreleaseFrequency: .workItem)
-        
+        let discoveryQueue = DispatchQueue(
+            label: "org.swift.docc.Discovery", qos: .unspecified, attributes: .concurrent,
+            autoreleaseFrequency: .workItem)
+
         let discoveryError = Synchronized<Error?>(nil)
 
         // Load all bundle symbol graphs into the loader.
         var symbolGraphLoader: SymbolGraphLoader!
         var hierarchyBasedResolver: PathHierarchyBasedLinkResolver!
-        
+
         discoveryGroup.async(queue: discoveryQueue) { [unowned self] in
             symbolGraphLoader = SymbolGraphLoader(
                 bundle: bundle,
                 dataLoader: { try self.contentsOfURL($0, in: $1) },
-                symbolGraphTransformer: configuration.convertServiceConfiguration.symbolGraphTransformer
+                symbolGraphTransformer: configuration.convertServiceConfiguration
+                    .symbolGraphTransformer
             )
-            
+
             do {
-                try signposter.withIntervalSignpost("Load symbols", id: signposter.makeSignpostID()) {
+                try signposter.withIntervalSignpost("Load symbols", id: signposter.makeSignpostID())
+                {
                     try symbolGraphLoader.loadAll()
                 }
-                hierarchyBasedResolver = signposter.withIntervalSignpost("Build PathHierarchy", id: signposter.makeSignpostID()) {
-                    PathHierarchyBasedLinkResolver(pathHierarchy: PathHierarchy(
-                        symbolGraphLoader: symbolGraphLoader,
-                        bundleName: urlReadablePath(bundle.displayName),
-                        knownDisambiguatedPathComponents: configuration.convertServiceConfiguration.knownDisambiguatedSymbolPathComponents
-                    ))
+                hierarchyBasedResolver = signposter.withIntervalSignpost(
+                    "Build PathHierarchy", id: signposter.makeSignpostID()
+                ) {
+                    PathHierarchyBasedLinkResolver(
+                        pathHierarchy: PathHierarchy(
+                            symbolGraphLoader: symbolGraphLoader,
+                            bundleName: urlReadablePath(bundle.displayName),
+                            knownDisambiguatedPathComponents: configuration
+                                .convertServiceConfiguration.knownDisambiguatedSymbolPathComponents
+                        ))
                 }
             } catch {
                 // Pipe the error out of the dispatch queue.
@@ -2241,7 +2647,9 @@ public class DocumentationContext {
         // First, all the resources are added since they don't reference anything else.
         discoveryGroup.async(queue: discoveryQueue) { [unowned self] in
             do {
-                try signposter.withIntervalSignpost("Load resources", id: signposter.makeSignpostID()) {
+                try signposter.withIntervalSignpost(
+                    "Load resources", id: signposter.makeSignpostID()
+                ) {
                     try self.registerMiscResources(from: bundle)
                 }
             } catch {
@@ -2251,23 +2659,26 @@ public class DocumentationContext {
                 })
             }
         }
-        
+
         // Second, all the documents and symbols are added.
         //
         // Note: Documents and symbols may look up resources at this point but shouldn't lookup other documents or
         //       symbols or attempt to resolve links/references since the topic graph may not contain all documents
         //       or all symbols yet.
-        var result: (
-            tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
-            tutorials: [SemanticResult<Tutorial>],
-            tutorialArticles: [SemanticResult<TutorialArticle>],
-            articles: [SemanticResult<Article>],
-            documentationExtensions: [SemanticResult<Article>]
-        )!
-        
+        var result:
+            (
+                tutorialTableOfContentsResults: [SemanticResult<TutorialTableOfContents>],
+                tutorials: [SemanticResult<Tutorial>],
+                tutorialArticles: [SemanticResult<TutorialArticle>],
+                articles: [SemanticResult<Article>],
+                documentationExtensions: [SemanticResult<Article>]
+            )!
+
         discoveryGroup.async(queue: discoveryQueue) { [unowned self] in
             do {
-                result = try signposter.withIntervalSignpost("Load documents", id: signposter.makeSignpostID()) {
+                result = try signposter.withIntervalSignpost(
+                    "Load documents", id: signposter.makeSignpostID()
+                ) {
                     try self.registerDocuments(from: bundle)
                 }
             } catch {
@@ -2277,11 +2688,15 @@ public class DocumentationContext {
                 })
             }
         }
-        
+
         discoveryGroup.async(queue: discoveryQueue) { [unowned self] in
             do {
-                try signposter.withIntervalSignpost("Load external resolvers", id: signposter.makeSignpostID()) {
-                    try linkResolver.loadExternalResolvers(dependencyArchives: configuration.externalDocumentationConfiguration.dependencyArchives)
+                try signposter.withIntervalSignpost(
+                    "Load external resolvers", id: signposter.makeSignpostID()
+                ) {
+                    try linkResolver.loadExternalResolvers(
+                        dependencyArchives: configuration.externalDocumentationConfiguration
+                            .dependencyArchives)
                 }
             } catch {
                 // Pipe the error out of the dispatch queue.
@@ -2290,7 +2705,7 @@ public class DocumentationContext {
                 })
             }
         }
-        
+
         discoveryGroup.wait()
 
         try shouldContinueRegistration()
@@ -2299,15 +2714,18 @@ public class DocumentationContext {
         if let encounteredError = discoveryError.sync({ $0 }) {
             throw encounteredError
         }
-        
+
         // All discovery went well, process the inputs.
-        let (tutorialTableOfContentsResults, tutorials, tutorialArticles, allArticles, documentationExtensions) = result
+        let (
+            tutorialTableOfContentsResults, tutorials, tutorialArticles, allArticles,
+            documentationExtensions
+        ) = result
         var (otherArticles, rootPageArticles) = splitArticles(allArticles)
-        
+
         let globalOptions = (allArticles + documentationExtensions).compactMap { article in
             return article.value.options[.global]
         }
-        
+
         if globalOptions.count > 1 {
             let extraGlobalOptionsProblems = globalOptions.map { extraOptionsDirective -> Problem in
                 let diagnostic = Diagnostic(
@@ -2315,32 +2733,34 @@ public class DocumentationContext {
                     severity: .warning,
                     range: extraOptionsDirective.originalMarkup.range,
                     identifier: "org.swift.docc.DuplicateGlobalOptions",
-                    summary: "Duplicate \(extraOptionsDirective.scope) \(Options.directiveName.singleQuoted) directive",
+                    summary:
+                        "Duplicate \(extraOptionsDirective.scope) \(Options.directiveName.singleQuoted) directive",
                     explanation: """
-                    A DocC catalog can only contain a single \(Options.directiveName.singleQuoted) \
-                    directive with the \(extraOptionsDirective.scope.rawValue.singleQuoted) scope.
-                    """
+                        A DocC catalog can only contain a single \(Options.directiveName.singleQuoted) \
+                        directive with the \(extraOptionsDirective.scope.rawValue.singleQuoted) scope.
+                        """
                 )
-                
+
                 guard let range = extraOptionsDirective.originalMarkup.range else {
                     return Problem(diagnostic: diagnostic)
                 }
-                
+
                 let solution = Solution(
-                    summary: "Remove extraneous \(extraOptionsDirective.scope) \(Options.directiveName.singleQuoted) directive",
+                    summary:
+                        "Remove extraneous \(extraOptionsDirective.scope) \(Options.directiveName.singleQuoted) directive",
                     replacements: [
                         Replacement(range: range, replacement: "")
                     ]
                 )
-                
+
                 return Problem(diagnostic: diagnostic, possibleSolutions: [solution])
             }
-            
+
             diagnosticEngine.emit(extraGlobalOptionsProblems)
         } else {
             options = globalOptions.first
         }
-        
+
         self.linkResolver.localResolver = hierarchyBasedResolver
         hierarchyBasedResolver.addMappingForRoots(bundle: bundle)
         for tutorial in tutorials {
@@ -2352,21 +2772,24 @@ public class DocumentationContext {
         for tutorialTableOfContents in tutorialTableOfContentsResults {
             hierarchyBasedResolver.addTutorialTableOfContents(tutorialTableOfContents)
         }
-        
+
         registerRootPages(from: rootPageArticles, in: bundle)
-        try registerSymbols(from: bundle, symbolGraphLoader: symbolGraphLoader, documentationExtensions: documentationExtensions)
+        try registerSymbols(
+            from: bundle, symbolGraphLoader: symbolGraphLoader,
+            documentationExtensions: documentationExtensions)
         // We don't need to keep the loader in memory after we've registered all symbols.
         symbolGraphLoader = nil
-        
+
         try shouldContinueRegistration()
-        
+
         if topicGraph.nodes.isEmpty,
-           !otherArticles.isEmpty,
-           !configuration.convertServiceConfiguration.allowsRegisteringArticlesWithoutTechnologyRoot
+            !otherArticles.isEmpty,
+            !configuration.convertServiceConfiguration
+                .allowsRegisteringArticlesWithoutTechnologyRoot
         {
             synthesizeArticleOnlyRootPage(articles: &otherArticles, bundle: bundle)
         }
-            
+
         // Keep track of the root modules registered from symbol graph files, we'll need them to automatically
         // curate articles.
         rootModules = topicGraph.nodes.values.compactMap { node in
@@ -2375,28 +2798,32 @@ public class DocumentationContext {
             }
             return node.reference
         }
-        
+
         // Articles that will be automatically curated can be resolved but they need to be pre registered before resolving links.
-        let rootNodeForAutomaticCuration = soleRootModuleReference.flatMap(topicGraph.nodeWithReference(_:))
-        if configuration.convertServiceConfiguration.allowsRegisteringArticlesWithoutTechnologyRoot || rootNodeForAutomaticCuration != nil {
+        let rootNodeForAutomaticCuration = soleRootModuleReference.flatMap(
+            topicGraph.nodeWithReference(_:))
+        if configuration.convertServiceConfiguration.allowsRegisteringArticlesWithoutTechnologyRoot
+            || rootNodeForAutomaticCuration != nil
+        {
             otherArticles = registerArticles(otherArticles, in: bundle)
             try shouldContinueRegistration()
         }
-        
+
         // Third, any processing that relies on resolving other content is done, mainly resolving links.
-        preResolveExternalLinks(semanticObjects:
-            tutorialTableOfContentsResults.map(referencedSemanticObject) +
-            tutorials.map(referencedSemanticObject) +
-            tutorialArticles.map(referencedSemanticObject),
-                                localBundleID: bundle.id)
-        
+        preResolveExternalLinks(
+            semanticObjects:
+                tutorialTableOfContentsResults.map(referencedSemanticObject)
+                + tutorials.map(referencedSemanticObject)
+                + tutorialArticles.map(referencedSemanticObject),
+            localBundleID: bundle.id)
+
         resolveLinks(
             tutorialTableOfContents: tutorialTableOfContentsResults,
             tutorials: tutorials,
             tutorialArticles: tutorialArticles,
             bundle: bundle
         )
-        
+
         // After the resolving links in tutorial content all the local references are known and can be added to the referenceIndex for fast lookup.
         referenceIndex.reserveCapacity(knownIdentifiers.count + nodeAnchorSections.count)
         for reference in knownIdentifiers {
@@ -2405,29 +2832,33 @@ public class DocumentationContext {
         for reference in nodeAnchorSections.keys {
             referenceIndex[reference.absoluteString] = reference
         }
-        
+
         try shouldContinueRegistration()
-        var allCuratedReferences = try crawlSymbolCuration(in: linkResolver.localResolver.topLevelSymbols(), bundle: bundle)
-        
+        var allCuratedReferences = try crawlSymbolCuration(
+            in: linkResolver.localResolver.topLevelSymbols(), bundle: bundle)
+
         // Store the list of manually curated references if doc coverage is on.
         if configuration.experimentalCoverageConfiguration.shouldStoreManuallyCuratedReferences {
             manuallyCuratedReferences = allCuratedReferences
         }
-        
+
         try shouldContinueRegistration()
 
         // Fourth, automatically curate all symbols that haven't been curated manually
-        let automaticallyCurated = signposter.withIntervalSignpost("Auto-curate symbols ", id: signposter.makeSignpostID()) {
+        let automaticallyCurated = signposter.withIntervalSignpost(
+            "Auto-curate symbols ", id: signposter.makeSignpostID()
+        ) {
             autoCurateSymbolsInTopicGraph()
         }
-        
+
         // Crawl the rest of the symbols that haven't been crawled so far in hierarchy pre-order.
-        allCuratedReferences = try crawlSymbolCuration(in: automaticallyCurated.map(\.symbol), bundle: bundle, initial: allCuratedReferences)
+        allCuratedReferences = try crawlSymbolCuration(
+            in: automaticallyCurated.map(\.symbol), bundle: bundle, initial: allCuratedReferences)
 
         // Remove curation paths that have been created automatically above
         // but we've found manual curation for in the second crawl pass.
         removeUnneededAutomaticCuration(automaticallyCurated)
-        
+
         // Automatically curate articles that haven't been manually curated
         // Article curation is only done automatically if there is only one root module
         if let rootNode = rootNodeForAutomaticCuration {
@@ -2443,9 +2874,9 @@ public class DocumentationContext {
 
         // Emit warnings for any remaining uncurated files.
         emitWarningsForUncuratedTopics()
-        
+
         linkResolver.localResolver.addAnchorForSymbols(localCache: documentationCache)
-        
+
         // Fifth, resolve links in nodes that are added solely via curation
         preResolveExternalLinks(references: Array(allCuratedReferences), localBundleID: bundle.id)
         resolveLinks(curatedReferences: allCuratedReferences, bundle: bundle)
@@ -2456,25 +2887,25 @@ public class DocumentationContext {
             // the single page. To ensure that links are resolved, explicitly visit all pages.
             resolveLinks(curatedReferences: Set(knownPages), bundle: bundle)
         }
-        
+
         // We should use a read-only context during render time (rdar://65130130).
 
         // Sixth - fetch external entities and merge them in the context
         for case .success(let reference) in externallyResolvedLinks.values {
             referenceIndex[reference.absoluteString] = reference
         }
-        
+
         // Seventh, the complete topic graph—with all nodes and all edges added—is analyzed.
         signposter.withIntervalSignpost("Analyze topic graph", id: signposter.makeSignpostID()) {
             topicGraphGlobalAnalysis()
         }
-        
+
         preResolveModuleNames()
     }
-    
+
     /// Given a list of topics that have been automatically curated, checks if a topic has been additionally manually curated
     /// and if so removes the automatic curation.
-    /// 
+    ///
     /// During the first crawl pass we skip over all automatically curated nodes (as they are not in the topic graph yet.
     /// After adding all symbols automatically to their parents and running a second crawl pass we discover any manual
     /// curations that we could not crawl in the first pass.
@@ -2490,7 +2921,8 @@ public class DocumentationContext {
         //
         // Similarly, it might look like it would be correct to only check `parents(of: symbol).count > 1` here,
         // but that would incorrectly remove the automatic curation for symbols with different language representations with different parents.
-        for (symbol, parent, counterpartParent) in automaticallyCurated where parents(of: symbol).count > (counterpartParent != nil ? 2 : 1) {
+        for (symbol, parent, counterpartParent) in automaticallyCurated
+        where parents(of: symbol).count > (counterpartParent != nil ? 2 : 1) {
             topicGraph.removeEdge(fromReference: parent, toReference: symbol)
             if let counterpartParent {
                 topicGraph.removeEdge(fromReference: counterpartParent, toReference: symbol)
@@ -2501,10 +2933,13 @@ public class DocumentationContext {
     /// Remove unneeded "Extended Symbol" pages whose children have been curated elsewhere.
     func trimEmptyExtendedSymbolPages(under nodeReference: ResolvedTopicReference) {
         // Get the children of this node that are an "Extended Symbol" page.
-        let extendedSymbolChildren = topicGraph.edges[nodeReference]?.filter({ childReference in
-            guard let childNode = topicGraph.nodeWithReference(childReference) else { return false }
-            return childNode.kind.isExtendedSymbolKind
-        }) ?? []
+        let extendedSymbolChildren =
+            topicGraph.edges[nodeReference]?.filter({ childReference in
+                guard let childNode = topicGraph.nodeWithReference(childReference) else {
+                    return false
+                }
+                return childNode.kind.isExtendedSymbolKind
+            }) ?? []
 
         // First recurse to clean up the tree depth-first.
         for child in extendedSymbolChildren {
@@ -2514,60 +2949,78 @@ public class DocumentationContext {
         // Finally, if this node was left with no children and does not have an extension file,
         // remove it from the topic graph.
         if let node = topicGraph.nodeWithReference(nodeReference),
-           node.kind.isExtendedSymbolKind,
-           topicGraph[node].isEmpty,
-           documentationExtensionURL(for: nodeReference) == nil
+            node.kind.isExtendedSymbolKind,
+            topicGraph[node].isEmpty,
+            documentationExtensionURL(for: nodeReference) == nil
         {
             topicGraph.removeEdges(to: node)
             topicGraph.removeEdges(from: node)
             topicGraph.edges.removeValue(forKey: nodeReference)
             topicGraph.reverseEdges.removeValue(forKey: nodeReference)
 
-            topicGraph.replaceNode(node, with: .init(
-                reference: node.reference,
-                kind: node.kind,
-                source: node.source,
-                title: node.title,
-                isResolvable: false, // turn isResolvable off to prevent a link from being made
-                isVirtual: true, // set isVirtual to keep it from generating a page later on
-                isEmptyExtension: true
-            ))
+            topicGraph.replaceNode(
+                node,
+                with: .init(
+                    reference: node.reference,
+                    kind: node.kind,
+                    source: node.source,
+                    title: node.title,
+                    isResolvable: false,  // turn isResolvable off to prevent a link from being made
+                    isVirtual: true,  // set isVirtual to keep it from generating a page later on
+                    isEmptyExtension: true
+                ))
         }
     }
-    
-    typealias AutoCuratedSymbolRecord = (symbol: ResolvedTopicReference, parent: ResolvedTopicReference, counterpartParent: ResolvedTopicReference?)
-    
+
+    typealias AutoCuratedSymbolRecord = (
+        symbol: ResolvedTopicReference, parent: ResolvedTopicReference,
+        counterpartParent: ResolvedTopicReference?
+    )
+
     /// Curate all remaining uncurated symbols under their natural parent from the symbol graph.
     ///
     /// This will include all symbols that were not manually curated by the documentation author.
     /// - Returns: An ordered list of symbol references that have been added to the topic graph automatically.
     private func autoCurateSymbolsInTopicGraph() -> [AutoCuratedSymbolRecord] {
         var automaticallyCuratedSymbols = [AutoCuratedSymbolRecord]()
-        linkResolver.localResolver.traverseSymbolAndParents { reference, parentReference, counterpartParentReference in
+        linkResolver.localResolver.traverseSymbolAndParents {
+            reference, parentReference, counterpartParentReference in
             guard let topicGraphNode = topicGraph.nodeWithReference(reference),
-                  // Check that the node isn't already manually curated
-                  topicGraphNode.shouldAutoCurateInCanonicalLocation
+                // Check that the node isn't already manually curated
+                topicGraphNode.shouldAutoCurateInCanonicalLocation
             else { return }
-            
+
             // Check that the symbol doesn't already have parent's that aren't either language representation's hierarchical parent.
             // This for example happens for default implementation and symbols that are requirements of protocol conformances.
-            guard parents(of: reference).allSatisfy({ $0 == parentReference || $0 == counterpartParentReference }) else {
+            guard
+                parents(of: reference).allSatisfy({
+                    $0 == parentReference || $0 == counterpartParentReference
+                })
+            else {
                 return
             }
-            
+
             guard let topicGraphParentNode = topicGraph.nodeWithReference(parentReference) else {
-                preconditionFailure("Node with reference \(parentReference.absoluteString) exist in link resolver but not in topic graph.")
+                preconditionFailure(
+                    "Node with reference \(parentReference.absoluteString) exist in link resolver but not in topic graph."
+                )
             }
             topicGraph.addEdge(from: topicGraphParentNode, to: topicGraphNode)
-            
+
             if let counterpartParentReference {
-                guard let topicGraphCounterpartParentNode = topicGraph.nodeWithReference(counterpartParentReference) else {
-                    preconditionFailure("Node with reference \(counterpartParentReference.absoluteString) exist in link resolver but not in topic graph.")
+                guard
+                    let topicGraphCounterpartParentNode = topicGraph.nodeWithReference(
+                        counterpartParentReference)
+                else {
+                    preconditionFailure(
+                        "Node with reference \(counterpartParentReference.absoluteString) exist in link resolver but not in topic graph."
+                    )
                 }
                 topicGraph.addEdge(from: topicGraphCounterpartParentNode, to: topicGraphNode)
             }
             // Collect a single automatic curation record for both language representation parents.
-            automaticallyCuratedSymbols.append((reference, parentReference, counterpartParentReference))
+            automaticallyCuratedSymbols.append(
+                (reference, parentReference, counterpartParentReference))
         }
         return automaticallyCuratedSymbols
     }
@@ -2576,10 +3029,12 @@ public class DocumentationContext {
         guard FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled else {
             return
         }
-        
+
         for (overloadGroupID, overloadSymbolIDs) in overloadGroups {
             guard overloadSymbolIDs.count > 1 else {
-                assertionFailure("Overload group \(overloadGroupID) contained \(overloadSymbolIDs.count) symbols, but should have more than one symbol to be valid.")
+                assertionFailure(
+                    "Overload group \(overloadGroupID) contained \(overloadSymbolIDs.count) symbols, but should have more than one symbol to be valid."
+                )
                 continue
             }
             guard let overloadGroupNode = documentationCache[overloadGroupID] else {
@@ -2597,12 +3052,15 @@ public class DocumentationContext {
             }) {
                 // If SymbolKit saved its sort of the symbols, use that ordering here
                 overloadSymbolNodes.sort(by: { lhs, rhs in
-                    let lhsIndex = (lhs.semantic as! Symbol).overloadsVariants.firstValue!.displayIndex
-                    let rhsIndex = (rhs.semantic as! Symbol).overloadsVariants.firstValue!.displayIndex
+                    let lhsIndex = (lhs.semantic as! Symbol).overloadsVariants.firstValue!
+                        .displayIndex
+                    let rhsIndex = (rhs.semantic as! Symbol).overloadsVariants.firstValue!
+                        .displayIndex
                     return lhsIndex < rhsIndex
                 })
             } else {
-                assertionFailure("""
+                assertionFailure(
+                    """
                     Overload group \(overloadGroupNode.reference.absoluteString.singleQuoted) was not properly initialized with overload data from SymbolKit.
                     Symbols without overload data: \(Array(overloadSymbolNodes.filter({ ($0.semantic as? Symbol)?.overloadsVariants.firstValue == nil }).map(\.reference.absoluteString.singleQuoted)))
                     """)
@@ -2615,23 +3073,26 @@ public class DocumentationContext {
                 overloadSymbolReferences: [DocumentationNode]
             ) {
                 guard let symbol = documentationNode.semantic as? Symbol else {
-                    preconditionFailure("""
-                    Only symbols can be overloads. Found non-symbol overload for \(documentationNode.reference.absoluteString.singleQuoted).
-                    Non-symbols should already have been filtered out by SymbolKit.
-                    """)
+                    preconditionFailure(
+                        """
+                        Only symbols can be overloads. Found non-symbol overload for \(documentationNode.reference.absoluteString.singleQuoted).
+                        Non-symbols should already have been filtered out by SymbolKit.
+                        """)
                 }
                 guard documentationNode.reference.sourceLanguage == .swift else {
-                    assertionFailure("""
-                    Overload groups are only supported for Swift symbols.
-                    The symbol at \(documentationNode.reference.absoluteString.singleQuoted) is listed as \(documentationNode.reference.sourceLanguage.name).
-                    """)
+                    assertionFailure(
+                        """
+                        Overload groups are only supported for Swift symbols.
+                        The symbol at \(documentationNode.reference.absoluteString.singleQuoted) is listed as \(documentationNode.reference.sourceLanguage.name).
+                        """)
                     return
                 }
 
                 var otherOverloadedSymbolReferences = overloadSymbolReferences.map(\.reference)
                 otherOverloadedSymbolReferences.remove(at: index)
                 let displayIndex = symbol.overloadsVariants.firstValue?.displayIndex ?? index
-                let overloads = Symbol.Overloads(references: otherOverloadedSymbolReferences, displayIndex: displayIndex)
+                let overloads = Symbol.Overloads(
+                    references: otherOverloadedSymbolReferences, displayIndex: displayIndex)
                 symbol.overloadsVariants = .init(swiftVariant: overloads)
             }
 
@@ -2639,25 +3100,31 @@ public class DocumentationContext {
             // swap out the first element in the overload references to create the alternate
             // declarations section properly. However, it is also a distinct symbol, node, and page,
             // so the first overload itself should also be handled separately in the loop below.
-            addOverloadReferences(to: overloadGroupNode, at: 0, overloadSymbolReferences: overloadSymbolNodes)
+            addOverloadReferences(
+                to: overloadGroupNode, at: 0, overloadSymbolReferences: overloadSymbolNodes)
 
             for (index, node) in overloadSymbolNodes.indexed() {
-                addOverloadReferences(to: node, at: index, overloadSymbolReferences: overloadSymbolNodes)
+                addOverloadReferences(
+                    to: node, at: index, overloadSymbolReferences: overloadSymbolNodes)
             }
         }
     }
-    
+
     /// A closure type getting the information about a reference in a context and returns any possible problems with it.
     public typealias ReferenceCheck = (DocumentationContext, ResolvedTopicReference) -> [Problem]
-    
+
     /// Adds new checks to be run during the global topic analysis; after a bundle has been fully registered and its topic graph has been fully built.
     ///
     /// - Parameter newChecks: The new checks to add.
-    @available(*, deprecated, message: "Use 'TopicAnalysisConfiguration.additionalChecks' instead. This deprecated API will be removed after 6.2 is released")
+    @available(
+        *, deprecated,
+        message:
+            "Use 'TopicAnalysisConfiguration.additionalChecks' instead. This deprecated API will be removed after 6.2 is released"
+    )
     public func addGlobalChecks(_ newChecks: [ReferenceCheck]) {
         configuration.topicAnalysisConfiguration.additionalChecks.append(contentsOf: newChecks)
     }
-    
+
     /// Crawls the hierarchy of the given list of nodes, adding relationships in the topic graph for all resolvable task group references.
     /// - Parameters:
     ///   - references: A list of references to crawl.
@@ -2665,12 +3132,16 @@ public class DocumentationContext {
     ///   - initial: A list of references to skip when crawling.
     /// - Returns: The references of all the symbols that were curated.
     @discardableResult
-    func crawlSymbolCuration(in references: [ResolvedTopicReference], bundle: DocumentationBundle, initial: Set<ResolvedTopicReference> = []) throws -> Set<ResolvedTopicReference> {
-        let signpostHandle = signposter.beginInterval("Curate symbols", id: signposter.makeSignpostID())
+    func crawlSymbolCuration(
+        in references: [ResolvedTopicReference], bundle: DocumentationBundle,
+        initial: Set<ResolvedTopicReference> = []
+    ) throws -> Set<ResolvedTopicReference> {
+        let signpostHandle = signposter.beginInterval(
+            "Curate symbols", id: signposter.makeSignpostID())
         defer {
             signposter.endInterval("Curate symbols", signpostHandle)
         }
-        
+
         var crawler = DocumentationCurator(in: self, bundle: bundle, initial: initial)
 
         for reference in references {
@@ -2678,23 +3149,27 @@ public class DocumentationContext {
                 of: reference,
                 relateNodes: { container, descendant in
                     topicGraph.unsafelyAddEdge(source: container, target: descendant)
-                    
-                    guard topicGraph.nodes[descendant]?.shouldAutoCurateInCanonicalLocation == true else {
+
+                    guard topicGraph.nodes[descendant]?.shouldAutoCurateInCanonicalLocation == true
+                    else {
                         // Descendant is already marked to be removed from automatic curation.
                         return
                     }
-                    
+
                     // An inner function called below
                     func stopAutoCuratingDescendant() {
                         topicGraph.nodes[descendant]?.shouldAutoCurateInCanonicalLocation = false
                     }
-                    
-                    guard let (canonicalContainer, counterpartContainer) = linkResolver.localResolver.nearestContainers(ofSymbol: descendant) else {
+
+                    guard
+                        let (canonicalContainer, counterpartContainer) = linkResolver.localResolver
+                            .nearestContainers(ofSymbol: descendant)
+                    else {
                         // Any curation of a non-symbol removes it from automatic curation
                         stopAutoCuratingDescendant()
                         return
                     }
-                    
+
                     // For symbols we only stop automatic curation if they are curated within their canonical container's sub-hierarchy
                     // or if a top-level symbol is curated under another top-level symbol (more on that below).
                     //
@@ -2724,45 +3199,52 @@ public class DocumentationContext {
                     // The reason for this exception is to allow developers to group top-level types under one-another without requiring an API collection.
                     // For example, in DocC one could curate `DiagnosticConsumer`, `DiagnosticFormattingOptions`, and `Diagnostic` under `DiagnosticEngine`,
                     // treating the `DiagnosticEngine` as the top-level topic for all diagnostic related types.
-                    
-                    
+
                     // To determine if `container` exists in the curated symbol's canonical container's sub-hierarchy,
                     // first find its nearest container symbol (in case `container` is a series of API collections).
                     //
                     // If the `container` is a symbol, this returns the container.
-                    guard let nearestSymbolContainer = topicGraph.reverseEdgesGraph
-                        .breadthFirstSearch(from: container)
-                        .first(where: { topicGraph.nodes[$0]?.kind.isSymbol == true })
+                    guard
+                        let nearestSymbolContainer = topicGraph.reverseEdgesGraph
+                            .breadthFirstSearch(from: container)
+                            .first(where: { topicGraph.nodes[$0]?.kind.isSymbol == true })
                     else {
                         // The container doesn't exist in the same module as the curated symbol.
                         // Continue to automatically curate the descendant under its canonical container.
                         return
                     }
-                    
-                    if nearestSymbolContainer == canonicalContainer || nearestSymbolContainer == counterpartContainer {
+
+                    if nearestSymbolContainer == canonicalContainer
+                        || nearestSymbolContainer == counterpartContainer
+                    {
                         // The descendant is curated in its canonical container (in either language representation)
                         stopAutoCuratingDescendant()
                         return
                     }
-                    
+
                     // An inner function called below
                     func isModule(_ reference: ResolvedTopicReference) -> Bool {
                         topicGraph.nodes[reference]?.kind == .module
                     }
-                    
+
                     if isModule(canonicalContainer) || counterpartContainer.map(isModule) == true {
-                        guard let curationLocationContainers = linkResolver.localResolver.nearestContainers(ofSymbol: nearestSymbolContainer) else {
-                            assertionFailure("""
+                        guard
+                            let curationLocationContainers = linkResolver.localResolver
+                                .nearestContainers(ofSymbol: nearestSymbolContainer)
+                        else {
+                            assertionFailure(
+                                """
                                 Unexpectedly didn't find any canonical containers for symbol \(nearestSymbolContainer.absoluteString.singleQuoted).
                                 Every non-module symbol should have a canonical container.
                                 """)
                             return
                         }
-                        
-                        if canonicalContainer   == curationLocationContainers.main        ||
-                           canonicalContainer   == curationLocationContainers.counterpart ||
-                           counterpartContainer == curationLocationContainers.main        ||
-                           counterpartContainer == curationLocationContainers.counterpart && counterpartContainer != nil
+
+                        if canonicalContainer == curationLocationContainers.main
+                            || canonicalContainer == curationLocationContainers.counterpart
+                            || counterpartContainer == curationLocationContainers.main
+                            || counterpartContainer == curationLocationContainers.counterpart
+                                && counterpartContainer != nil
                         {
                             // The descendant is a top-level symbol, curated under another top-level symbol in the same module
                             stopAutoCuratingDescendant()
@@ -2772,43 +3254,70 @@ public class DocumentationContext {
                 }
             )
         }
-        
+
         diagnosticEngine.emit(crawler.problems)
-        
+
         return crawler.curatedNodes
     }
 
     /// Emits warnings for symbols that are matched by multiple documentation extensions.
-    private func emitWarningsForSymbolsMatchedInMultipleDocumentationExtensions(with symbolsWithMultipleDocumentationExtensionMatches: [ResolvedTopicReference : [DocumentationContext.SemanticResult<Article>]]) {
-        for (reference, documentationExtensions) in symbolsWithMultipleDocumentationExtensionMatches {
+    private func emitWarningsForSymbolsMatchedInMultipleDocumentationExtensions(
+        with symbolsWithMultipleDocumentationExtensionMatches: [ResolvedTopicReference:
+            [DocumentationContext.SemanticResult<Article>]]
+    ) {
+        for (reference, documentationExtensions) in symbolsWithMultipleDocumentationExtensionMatches
+        {
             let symbolPath = reference.url.pathComponents.dropFirst(2).joined(separator: "/")
             let firstExtension = documentationExtensions.first!
-            
+
             guard let link = firstExtension.value.title?.child(at: 0) as? AnyLink else {
-                fatalError("An article shouldn't have ended up in the documentation extension list unless its title was a link. File: \(firstExtension.source.absoluteString.singleQuoted)")
+                fatalError(
+                    "An article shouldn't have ended up in the documentation extension list unless its title was a link. File: \(firstExtension.source.absoluteString.singleQuoted)"
+                )
             }
-            let zeroRange = SourceLocation(line: 1, column: 1, source: nil)..<SourceLocation(line: 1, column: 1, source: nil)
-            let notes: [DiagnosticNote] = documentationExtensions.dropFirst().map { documentationExtension in
+            let zeroRange =
+                SourceLocation(
+                    line: 1, column: 1, source: nil)..<SourceLocation(
+                    line: 1, column: 1, source: nil)
+            let notes: [DiagnosticNote] = documentationExtensions.dropFirst().map {
+                documentationExtension in
                 guard let link = documentationExtension.value.title?.child(at: 0) as? AnyLink else {
-                    fatalError("An article shouldn't have ended up in the documentation extension list unless its title was a link. File: \(documentationExtension.source.absoluteString.singleQuoted)")
+                    fatalError(
+                        "An article shouldn't have ended up in the documentation extension list unless its title was a link. File: \(documentationExtension.source.absoluteString.singleQuoted)"
+                    )
                 }
-                return DiagnosticNote(source: documentationExtension.source, range: link.range ?? zeroRange, message: "\(symbolPath.singleQuoted) is also documented here.")
+                return DiagnosticNote(
+                    source: documentationExtension.source, range: link.range ?? zeroRange,
+                    message: "\(symbolPath.singleQuoted) is also documented here.")
             }
-            
+
             diagnosticEngine.emit(
-                Problem(diagnostic: Diagnostic(source: firstExtension.source, severity: .warning, range: link.range, identifier: "org.swift.docc.DuplicateMarkdownTitleSymbolReferences", summary: "Multiple documentation extensions matched \(symbolPath.singleQuoted).", notes: notes), possibleSolutions: [])
+                Problem(
+                    diagnostic: Diagnostic(
+                        source: firstExtension.source, severity: .warning, range: link.range,
+                        identifier: "org.swift.docc.DuplicateMarkdownTitleSymbolReferences",
+                        summary:
+                            "Multiple documentation extensions matched \(symbolPath.singleQuoted).",
+                        notes: notes), possibleSolutions: [])
             )
         }
     }
-    
+
     /// Emits information diagnostics for uncurated articles.
     private func emitWarningsForUncuratedTopics() {
         // Check that all articles are curated
         for articleResult in uncuratedArticles.values {
-            diagnosticEngine.emit(Problem(diagnostic: Diagnostic(source: articleResult.source, severity: .information, range: nil, identifier: "org.swift.docc.ArticleUncurated", summary: "You haven't curated \(articleResult.topicGraphNode.reference.description.singleQuoted)"), possibleSolutions: []))
+            diagnosticEngine.emit(
+                Problem(
+                    diagnostic: Diagnostic(
+                        source: articleResult.source, severity: .information, range: nil,
+                        identifier: "org.swift.docc.ArticleUncurated",
+                        summary:
+                            "You haven't curated \(articleResult.topicGraphNode.reference.description.singleQuoted)"
+                    ), possibleSolutions: []))
         }
     }
-    
+
     /**
      Analysis that runs after all nodes are successfully registered in the context.
      Useful for checks that need the complete node graph.
@@ -2821,7 +3330,7 @@ public class DocumentationContext {
             }
         }
         diagnosticEngine.emit(problems)
-        
+
         // Run pre-defined global analysis.
         for node in topicGraph.nodes.values {
             switch node.kind {
@@ -2832,10 +3341,10 @@ public class DocumentationContext {
             default: break
             }
         }
-        
+
         // Run analysis to determine whether manually configured alternate representations are valid.
         analyzeAlternateRepresentations()
-        
+
         // Run global ``TopicGraph`` global analysis.
         analyzeTopicGraph()
     }
@@ -2847,7 +3356,7 @@ public class DocumentationContext {
         let referencesToRemove = topicGraph.nodes.keys.filter {
             $0.bundleID == bundle.id
         }
-        
+
         for reference in referencesToRemove {
             topicGraph.edges[reference]?.removeAll(where: { $0.bundleID == bundle.id })
             topicGraph.reverseEdges[reference]?.removeAll(where: { $0.bundleID == bundle.id })
@@ -2866,40 +3375,50 @@ public class DocumentationContext {
      - Returns: A `Foundation.Data` object with the data for the given ``ResourceReference``.
      - Throws: ``ContextError/notFound(_:)` if a resource with the given was not found.
      */
-    public func resource(with identifier: ResourceReference, trait: DataTraitCollection = .init()) throws -> Data {
+    public func resource(with identifier: ResourceReference, trait: DataTraitCollection = .init())
+        throws -> Data
+    {
         guard let bundle,
-              let assetManager = assetManagers[identifier.bundleID],
-              let asset = assetManager.allData(named: identifier.path) else {
+            let assetManager = assetManagers[identifier.bundleID],
+            let asset = assetManager.allData(named: identifier.path)
+        else {
             throw ContextError.notFound(identifier.url)
         }
-        
+
         let resource = asset.data(bestMatching: trait)
-        
+
         return try contentsOfURL(resource.url, in: bundle)
     }
-    
+
     /// Returns true if a resource with the given identifier exists in the registered bundle.
-    public func resourceExists(with identifier: ResourceReference, ofType expectedAssetType: AssetType? = nil) -> Bool {
+    public func resourceExists(
+        with identifier: ResourceReference, ofType expectedAssetType: AssetType? = nil
+    ) -> Bool {
         guard let assetManager = assetManagers[identifier.bundleID] else {
             return false
         }
-        
+
         guard let key = assetManager.bestKey(forAssetName: identifier.path) else {
             return false
         }
-        
+
         guard let expectedAssetType, let asset = assetManager.storage[key] else {
             return true
         }
-        
+
         return asset.hasVariant(withAssetType: expectedAssetType)
     }
-    
-    private func externalEntity(with reference: ResolvedTopicReference) -> LinkResolver.ExternalEntity? {
-        return configuration.externalDocumentationConfiguration.sources[reference.bundleID].map({ $0.entity(with: reference) })
-            ?? configuration.convertServiceConfiguration.fallbackResolver?.entityIfPreviouslyResolved(with: reference)
+
+    private func externalEntity(with reference: ResolvedTopicReference) -> LinkResolver
+        .ExternalEntity?
+    {
+        return configuration.externalDocumentationConfiguration.sources[reference.bundleID].map({
+            $0.entity(with: reference)
+        })
+            ?? configuration.convertServiceConfiguration.fallbackResolver?
+            .entityIfPreviouslyResolved(with: reference)
     }
-    
+
     /**
      Look for a documentation node among the registered bundles and via any external resolvers.
 
@@ -2910,10 +3429,10 @@ public class DocumentationContext {
         if let cached = documentationCache[reference] {
             return cached
         }
-        
+
         throw ContextError.notFound(reference.url)
     }
-    
+
     private func knownEntityValue<Result>(
         reference: ResolvedTopicReference,
         valueInLocalEntity: (DocumentationNode) -> Result,
@@ -2934,7 +3453,7 @@ public class DocumentationContext {
             fatalError("Unexpected error when retrieving entity: \(error)")
         }
     }
-    
+
     /// Returns the set of languages the entity corresponding to the given reference is available in.
     ///
     /// - Precondition: The entity associated with the given reference must be registered in the context.
@@ -2945,7 +3464,7 @@ public class DocumentationContext {
             valueInExternalEntity: \.sourceLanguages
         )
     }
-    
+
     /// Returns whether the given reference corresponds to a symbol.
     func isSymbol(reference: ResolvedTopicReference) -> Bool {
         knownEntityValue(
@@ -2956,7 +3475,7 @@ public class DocumentationContext {
     }
 
     // MARK: - Relationship queries
-    
+
     /// Fetch the child nodes of a documentation node with the given `reference`, optionally filtering to only children of the given `kind`.
     ///
     /// > Important: The returned list can't be used to determine source language specific children.
@@ -2965,7 +3484,9 @@ public class DocumentationContext {
     ///   - reference: The reference of the node to fetch children for.
     ///   - kind: An optional documentation node kind to filter the children by.
     /// - Returns: A list of the reference and kind for each matching child node.
-    public func children(of reference: ResolvedTopicReference, kind: DocumentationNode.Kind? = nil) -> [(reference: ResolvedTopicReference, kind: DocumentationNode.Kind)] {
+    public func children(of reference: ResolvedTopicReference, kind: DocumentationNode.Kind? = nil)
+        -> [(reference: ResolvedTopicReference, kind: DocumentationNode.Kind)]
+    {
         guard let node = topicGraph.nodeWithReference(reference) else {
             return []
         }
@@ -2979,7 +3500,7 @@ public class DocumentationContext {
             return nil
         }
     }
-    
+
     /// Fetches the parents of the documentation node with the given `reference`.
     ///
     /// - Parameter reference: The reference of the node to fetch parents for.
@@ -2987,7 +3508,7 @@ public class DocumentationContext {
     public func parents(of reference: ResolvedTopicReference) -> [ResolvedTopicReference] {
         return topicGraph.reverseEdges[reference] ?? []
     }
-    
+
     /// Returns the document URL for the given article or tutorial reference.
     ///
     /// - Parameter reference: The identifier for the topic whose file URL to locate.
@@ -2998,7 +3519,7 @@ public class DocumentationContext {
         }
         return nil
     }
-    
+
     /// Returns the URL of the documentation extension of the given reference.
     ///
     /// - Parameter reference: The reference to the symbol this function should return the documentation extension URL for.
@@ -3009,7 +3530,7 @@ public class DocumentationContext {
         }
         return documentLocationMap[reference]
     }
-    
+
     /// Attempt to locate the reference for a given file.
     ///
     /// - Parameter url: The file whose reference to locate.
@@ -3020,51 +3541,59 @@ public class DocumentationContext {
 
     /**
      Attempt to retrieve the title for a given `reference`.
-     
+
      - Parameter reference: The reference for the topic whose title is desired.
      - Returns: The title of the topic if it could be found, otherwise `nil`.
      */
     public func title(for reference: ResolvedTopicReference) -> String? {
         return topicGraph.nodes[reference]?.title
     }
-    
+
     /// Returns a sequence that traverses the topic graph in breadth first order from a given reference, without visiting the same node more than once.
-    func breadthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<TopicGraph.Node> {
+    func breadthFirstSearch(from reference: ResolvedTopicReference) -> some Sequence<
+        TopicGraph.Node
+    > {
         topicGraph.breadthFirstSearch(from: reference)
     }
-    
+
     /**
      Attempt to resolve a ``TopicReference``.
-     
+
      > Note: If the reference is already resolved, the original reference is returned.
-     
+
      - Parameters:
        - reference: An unresolved (or resolved) reference.
        - parent: The *resolved* reference that serves as an enclosing search context, especially the parent reference's bundle identifier.
        - isCurrentlyResolvingSymbolLink: If `true` will try to resolve relative links *only* in documentation symbol locations in the hierarchy. If `false` it will try to resolve relative links as tutorials, articles, symbols, etc.
      - Returns: Either the successfully resolved reference for the topic or error information about why the reference couldn't resolve.
      */
-    public func resolve(_ reference: TopicReference, in parent: ResolvedTopicReference, fromSymbolLink isCurrentlyResolvingSymbolLink: Bool = false) -> TopicReferenceResolutionResult {
+    public func resolve(
+        _ reference: TopicReference, in parent: ResolvedTopicReference,
+        fromSymbolLink isCurrentlyResolvingSymbolLink: Bool = false
+    ) -> TopicReferenceResolutionResult {
         switch reference {
         case .unresolved(let unresolvedReference):
-            return linkResolver.resolve(unresolvedReference, in: parent, fromSymbolLink: isCurrentlyResolvingSymbolLink, context: self)
-            
+            return linkResolver.resolve(
+                unresolvedReference, in: parent, fromSymbolLink: isCurrentlyResolvingSymbolLink,
+                context: self)
+
         case .resolved(let resolved):
             // This reference is already resolved (either as a success or a failure), so don't change anything.
             return resolved
         }
     }
-    
+
     /// Update the asset with a new value given the assets name and the topic it's referenced in.
     ///
     /// - Parameters:
     ///   - name: The name of the asset to update.
     ///   - asset: The new asset for this name.
     ///   - parent: The topic where the asset is referenced.
-    public func updateAsset(named name: String, asset: DataAsset, in parent: ResolvedTopicReference) {
+    public func updateAsset(named name: String, asset: DataAsset, in parent: ResolvedTopicReference)
+    {
         assetManagers[parent.bundleID]?.update(name: name, asset: asset)
     }
-    
+
     /// Attempt to resolve an asset given its name and the topic it's referenced in.
     ///
     /// - Parameters:
@@ -3072,41 +3601,50 @@ public class DocumentationContext {
     ///   - parent: The topic where the asset is referenced.
     ///   - type: A restriction for what type of asset to resolve.
     /// - Returns: The data that's associated with an image asset if it was found, otherwise `nil`.
-    public func resolveAsset(named name: String, in parent: ResolvedTopicReference, withType type: AssetType? = nil) -> DataAsset? {
+    public func resolveAsset(
+        named name: String, in parent: ResolvedTopicReference, withType type: AssetType? = nil
+    ) -> DataAsset? {
         resolveAsset(named: name, bundleID: parent.bundleID, withType: type)
     }
-    
-    func resolveAsset(named name: String, bundleID: DocumentationBundle.Identifier, withType expectedType: AssetType?) -> DataAsset? {
+
+    func resolveAsset(
+        named name: String, bundleID: DocumentationBundle.Identifier,
+        withType expectedType: AssetType?
+    ) -> DataAsset? {
         if let localAsset = assetManagers[bundleID]?.allData(named: name) {
             if let expectedType {
                 guard localAsset.hasVariant(withAssetType: expectedType) else {
                     return nil
                 }
             }
-            
+
             return localAsset
         }
-        
+
         if let fallbackAssetResolver = configuration.convertServiceConfiguration.fallbackResolver,
-           let externallyResolvedAsset = fallbackAssetResolver.resolve(assetNamed: name) {
+            let externallyResolvedAsset = fallbackAssetResolver.resolve(assetNamed: name)
+        {
             assetManagers[bundleID, default: DataAssetManager()]
                 .register(dataAsset: externallyResolvedAsset, forName: name)
             return externallyResolvedAsset
         }
-        
+
         // If no fallbackAssetResolver is set, try to treat it as external media link
         if let externalMediaLink = URL(string: name),
-           externalMediaLink.isAbsoluteWebURL {
+            externalMediaLink.isAbsoluteWebURL
+        {
             var asset = DataAsset()
             asset.context = .display
-            asset.register(externalMediaLink, with: DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard))
+            asset.register(
+                externalMediaLink,
+                with: DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard))
             return asset
         }
         return nil
     }
-    
+
     /// Finds the identifier for a given asset name.
-    /// 
+    ///
     /// `name` is one of the following formats:
     /// - "image" - asset name without extension
     /// - "image.png" - asset name including extension
@@ -3116,11 +3654,14 @@ public class DocumentationContext {
     ///   - parent: The topic where the asset is referenced.
     ///
     /// - Returns: The best matching storage key if it was found, otherwise `nil`.
-    public func identifier(forAssetName name: String, in parent: ResolvedTopicReference) -> String? {
+    public func identifier(forAssetName name: String, in parent: ResolvedTopicReference) -> String?
+    {
         if let assetManager = assetManagers[parent.bundleID] {
             if let localName = assetManager.bestKey(forAssetName: name) {
                 return localName
-            } else if let fallbackAssetManager = configuration.convertServiceConfiguration.fallbackResolver {
+            } else if let fallbackAssetManager = configuration.convertServiceConfiguration
+                .fallbackResolver
+            {
                 return fallbackAssetManager.resolve(assetNamed: name) != nil ? name : nil
             }
             return nil
@@ -3135,27 +3676,31 @@ public class DocumentationContext {
     ///   - unresolvedCodeListingReference: The code listing reference to resolve.
     ///   - parent: The topic the code listing reference appears in.
     @available(*, deprecated, message: "This deprecated API will be removed after 6.1 is released")
-    public func resolveCodeListing(_ unresolvedCodeListingReference: UnresolvedCodeListingReference, in parent: ResolvedTopicReference) -> AttributedCodeListing? {
+    public func resolveCodeListing(
+        _ unresolvedCodeListingReference: UnresolvedCodeListingReference,
+        in parent: ResolvedTopicReference
+    ) -> AttributedCodeListing? {
         switch dataProvider {
         case .legacy(let legacyDataProvider):
-            legacyDataProvider.bundles[parent.bundleIdentifier]?.attributedCodeListings[unresolvedCodeListingReference.identifier]
+            legacyDataProvider.bundles[parent.bundleIdentifier]?.attributedCodeListings[
+                unresolvedCodeListingReference.identifier]
         case .new:
             nil
         }
     }
-    
+
     /// The references of all nodes in the topic graph.
     public var knownIdentifiers: [ResolvedTopicReference] {
         return Array(topicGraph.nodes.keys)
     }
-    
+
     /// The references of all the pages in the topic graph.
     public var knownPages: [ResolvedTopicReference] {
         return topicGraph.nodes.values
             .filter { !$0.isVirtual && $0.kind.isPage }
             .map { $0.reference }
     }
-    
+
     func dumpGraph() -> String {
         return topicGraph.nodes.values
             .filter { parents(of: $0.reference).isEmpty }
@@ -3165,8 +3710,9 @@ public class DocumentationContext {
             }
             .joined()
     }
-    
-    private static func defaultLanguage(in sourceLanguages: Set<SourceLanguage>?) -> SourceLanguage {
+
+    private static func defaultLanguage(in sourceLanguages: Set<SourceLanguage>?) -> SourceLanguage
+    {
         sourceLanguages.map { sourceLanguages in
             if sourceLanguages.contains(.swift) {
                 return .swift
@@ -3192,15 +3738,25 @@ extension DocumentationContext {
         let problems = unexpectedRoots.compactMap { node -> Problem? in
             let source: URL
             switch node.source {
-            case .file(url: let url): source = url
+            case .file(let url): source = url
             case .range(_, let url): source = url
             case .external: return nil
             }
-            return Problem(diagnostic: Diagnostic(source: source, severity: .information, range: nil, identifier: "org.swift.docc.SymbolNotCurated", summary: "You haven't curated \(node.reference.absoluteString.singleQuoted)"), possibleSolutions: [Solution(summary: "Add a link to \(node.reference.absoluteString.singleQuoted) from a Topics group of another documentation node.", replacements: [])])
+            return Problem(
+                diagnostic: Diagnostic(
+                    source: source, severity: .information, range: nil,
+                    identifier: "org.swift.docc.SymbolNotCurated",
+                    summary: "You haven't curated \(node.reference.absoluteString.singleQuoted)"),
+                possibleSolutions: [
+                    Solution(
+                        summary:
+                            "Add a link to \(node.reference.absoluteString.singleQuoted) from a Topics group of another documentation node.",
+                        replacements: [])
+                ])
         }
         diagnosticEngine.emit(problems)
     }
-        
+
     func analyzeAlternateRepresentations() {
         var problems = [Problem]()
 
@@ -3214,102 +3770,148 @@ extension DocumentationContext {
                 }
             }).map(\.name).list(finalConjunction: .and)
         }
-        func removeAlternateRepresentationSolution(_ alternateRepresentation: AlternateRepresentation) -> [Solution] {
-            [Solution(
-                summary: "Remove this alternate representation",
-                replacements: alternateRepresentation.originalMarkup.range.map { [Replacement(range: $0, replacement: "")] } ?? [])]
+        func removeAlternateRepresentationSolution(
+            _ alternateRepresentation: AlternateRepresentation
+        ) -> [Solution] {
+            [
+                Solution(
+                    summary: "Remove this alternate representation",
+                    replacements: alternateRepresentation.originalMarkup.range.map {
+                        [Replacement(range: $0, replacement: "")]
+                    } ?? [])
+            ]
         }
 
         for reference in knownPages {
-            guard let entity = try? self.entity(with: reference), let alternateRepresentations = entity.metadata?.alternateRepresentations else { continue }
-            
+            guard let entity = try? self.entity(with: reference),
+                let alternateRepresentations = entity.metadata?.alternateRepresentations
+            else { continue }
+
             var sourceLanguageToReference: [SourceLanguage: AlternateRepresentation] = [:]
             for alternateRepresentation in alternateRepresentations {
                 // Check if the entity is not a symbol, as only symbols are allowed to specify custom alternate representations
                 guard entity.symbol != nil else {
-                    problems.append(Problem(
-                        diagnostic: Diagnostic(
-                            source: alternateRepresentation.originalMarkup.range?.source,
-                            severity: .warning,
-                            range: alternateRepresentation.originalMarkup.range,
-                            identifier: "org.swift.docc.AlternateRepresentation.UnsupportedPageKind",
-                            summary: "Custom alternate representations are not supported for page kind \(entity.kind.name.singleQuoted)",
-                            explanation: "Alternate representations are only supported for symbols."
-                        ),
-                        possibleSolutions: removeAlternateRepresentationSolution(alternateRepresentation)
-                    ))
+                    problems.append(
+                        Problem(
+                            diagnostic: Diagnostic(
+                                source: alternateRepresentation.originalMarkup.range?.source,
+                                severity: .warning,
+                                range: alternateRepresentation.originalMarkup.range,
+                                identifier:
+                                    "org.swift.docc.AlternateRepresentation.UnsupportedPageKind",
+                                summary:
+                                    "Custom alternate representations are not supported for page kind \(entity.kind.name.singleQuoted)",
+                                explanation:
+                                    "Alternate representations are only supported for symbols."
+                            ),
+                            possibleSolutions: removeAlternateRepresentationSolution(
+                                alternateRepresentation)
+                        ))
                     continue
                 }
 
-                guard case .resolved(.success(let alternateRepresentationReference)) = alternateRepresentation.reference,
-                      let alternateRepresentationEntity = try? self.entity(with: alternateRepresentationReference) else {
+                guard
+                    case .resolved(.success(let alternateRepresentationReference)) =
+                        alternateRepresentation.reference,
+                    let alternateRepresentationEntity = try? self.entity(
+                        with: alternateRepresentationReference)
+                else {
                     continue
                 }
-                
+
                 // Check if the resolved entity is not a symbol, as only symbols are allowed as custom alternate representations
                 guard alternateRepresentationEntity.symbol != nil else {
-                    problems.append(Problem(
-                        diagnostic: Diagnostic(
-                            source: alternateRepresentation.originalMarkup.range?.source,
-                            severity: .warning,
-                            range: alternateRepresentation.originalMarkup.range,
-                            identifier: "org.swift.docc.AlternateRepresentation.UnsupportedPageKind",
-                            summary: "Page kind \(alternateRepresentationEntity.kind.name.singleQuoted) is not allowed as a custom alternate language representation",
-                            explanation: "Symbols can only specify other symbols as custom language representations."
-                        ),
-                        possibleSolutions: removeAlternateRepresentationSolution(alternateRepresentation)
-                    ))
+                    problems.append(
+                        Problem(
+                            diagnostic: Diagnostic(
+                                source: alternateRepresentation.originalMarkup.range?.source,
+                                severity: .warning,
+                                range: alternateRepresentation.originalMarkup.range,
+                                identifier:
+                                    "org.swift.docc.AlternateRepresentation.UnsupportedPageKind",
+                                summary:
+                                    "Page kind \(alternateRepresentationEntity.kind.name.singleQuoted) is not allowed as a custom alternate language representation",
+                                explanation:
+                                    "Symbols can only specify other symbols as custom language representations."
+                            ),
+                            possibleSolutions: removeAlternateRepresentationSolution(
+                                alternateRepresentation)
+                        ))
                     continue
                 }
-                
+
                 // Check if the documented symbol already has alternate representations from in-source annotations.
-                let duplicateSourceLanguages = alternateRepresentationEntity.availableSourceLanguages.intersection(entity.availableSourceLanguages)
+                let duplicateSourceLanguages = alternateRepresentationEntity
+                    .availableSourceLanguages.intersection(entity.availableSourceLanguages)
                 if !duplicateSourceLanguages.isEmpty {
-                    problems.append(Problem(
-                        diagnostic: Diagnostic(
-                            source: alternateRepresentation.originalMarkup.range?.source,
-                            severity: .warning,
-                            range: alternateRepresentation.originalMarkup.range,
-                            identifier: "org.swift.docc.AlternateRepresentation.DuplicateLanguageDefinition",
-                            summary: "\(entity.name.plainText.singleQuoted) already has a representation in \(listSourceLanguages(duplicateSourceLanguages))",
-                            explanation: "Symbols can only specify custom alternate language representations for languages that the documented symbol doesn't already have a representation for."
-                        ),
-                        possibleSolutions: [Solution(summary: "Replace this alternate language representation with a symbol which isn't available in \(listSourceLanguages(entity.availableSourceLanguages))", replacements: [])]
-                    ))
+                    problems.append(
+                        Problem(
+                            diagnostic: Diagnostic(
+                                source: alternateRepresentation.originalMarkup.range?.source,
+                                severity: .warning,
+                                range: alternateRepresentation.originalMarkup.range,
+                                identifier:
+                                    "org.swift.docc.AlternateRepresentation.DuplicateLanguageDefinition",
+                                summary:
+                                    "\(entity.name.plainText.singleQuoted) already has a representation in \(listSourceLanguages(duplicateSourceLanguages))",
+                                explanation:
+                                    "Symbols can only specify custom alternate language representations for languages that the documented symbol doesn't already have a representation for."
+                            ),
+                            possibleSolutions: [
+                                Solution(
+                                    summary:
+                                        "Replace this alternate language representation with a symbol which isn't available in \(listSourceLanguages(entity.availableSourceLanguages))",
+                                    replacements: [])
+                            ]
+                        ))
                 }
-                
-                let duplicateAlternateLanguages = Set(sourceLanguageToReference.keys).intersection(alternateRepresentationEntity.availableSourceLanguages)
+
+                let duplicateAlternateLanguages = Set(sourceLanguageToReference.keys).intersection(
+                    alternateRepresentationEntity.availableSourceLanguages)
                 if !duplicateAlternateLanguages.isEmpty {
-                    let notes: [DiagnosticNote] = duplicateAlternateLanguages.compactMap { duplicateAlternateLanguage in
-                        guard let alreadyExistingRepresentation = sourceLanguageToReference[duplicateAlternateLanguage],
-                              let range = alreadyExistingRepresentation.originalMarkup.range,
-                              let source = range.source else {
+                    let notes: [DiagnosticNote] = duplicateAlternateLanguages.compactMap {
+                        duplicateAlternateLanguage in
+                        guard
+                            let alreadyExistingRepresentation = sourceLanguageToReference[
+                                duplicateAlternateLanguage],
+                            let range = alreadyExistingRepresentation.originalMarkup.range,
+                            let source = range.source
+                        else {
                             return nil
                         }
-                        
-                        return DiagnosticNote(source: source, range: range, message: "This directive already specifies an alternate \(duplicateAlternateLanguage.name) representation.")
+
+                        return DiagnosticNote(
+                            source: source, range: range,
+                            message:
+                                "This directive already specifies an alternate \(duplicateAlternateLanguage.name) representation."
+                        )
                     }
-                    problems.append(Problem(
-                        diagnostic: Diagnostic(
-                            source: alternateRepresentation.originalMarkup.range?.source,
-                            severity: .warning,
-                            range: alternateRepresentation.originalMarkup.range,
-                            identifier: "org.swift.docc.AlternateRepresentation.DuplicateLanguageDefinition",
-                            summary: "A custom alternate language representation for \(listSourceLanguages(duplicateAlternateLanguages)) has already been specified",
-                            explanation: "Only one custom alternate language representation can be specified per language.",
-                            notes: notes
-                        ),
-                        possibleSolutions: removeAlternateRepresentationSolution(alternateRepresentation)
-                    ))
+                    problems.append(
+                        Problem(
+                            diagnostic: Diagnostic(
+                                source: alternateRepresentation.originalMarkup.range?.source,
+                                severity: .warning,
+                                range: alternateRepresentation.originalMarkup.range,
+                                identifier:
+                                    "org.swift.docc.AlternateRepresentation.DuplicateLanguageDefinition",
+                                summary:
+                                    "A custom alternate language representation for \(listSourceLanguages(duplicateAlternateLanguages)) has already been specified",
+                                explanation:
+                                    "Only one custom alternate language representation can be specified per language.",
+                                notes: notes
+                            ),
+                            possibleSolutions: removeAlternateRepresentationSolution(
+                                alternateRepresentation)
+                        ))
                 }
-                
+
                 // Update mapping from source language to alternate declaration, for diagnostic purposes
                 for alreadySeenLanguage in alternateRepresentationEntity.availableSourceLanguages {
                     sourceLanguageToReference[alreadySeenLanguage] = alternateRepresentation
                 }
             }
         }
-        
+
         diagnosticEngine.emit(problems)
     }
 }
@@ -3363,3 +3965,44 @@ extension DataAsset {
 
 @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
 extension DocumentationContext: DocumentationContextDataProviderDelegate {}
+
+extension Diagnostic {
+    static func multipleRootPagesWarning(roots: [ResolvedTopicReference]) -> Diagnostic {
+        let primaryRoot = roots.first!
+        let additionalRoots = Array(roots.dropFirst())
+
+        return Diagnostic(
+            source: nil,
+            severity: .warning,
+            diagnostic: "Documentation contains multiple root pages",
+            identifier: "org.swift.docc.MultipleRootPages",
+            summary: "Found \(roots.count) root pages in documentation",
+            explanation: """
+                Documentation should have exactly one root page. Found root pages:
+                - Primary: \(primaryRoot.path)
+                - Additional: \(additionalRoots.map { $0.path }.joined(separator: "\n  "))
+                """
+        )
+    }
+}
+
+extension DocumentationContext {
+    private func validateRootPageCount() {
+        // Get all root pages
+        let roots = topicGraph.nodes.values.filter { node in
+            return node.kind == .article && parents(of: node.reference).isEmpty
+        }.map { $0.reference }
+
+        // Warn if multiple roots found
+        if roots.count > 1 {
+            let diagnostic = Diagnostic.multipleRootPagesWarning(roots: roots)
+            diagnosticEngine.emit(diagnostic)
+        }
+    }
+}
+
+extension DocumentationContext {
+    func processRootModules() throws {
+        validateRootPageCount()
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -3974,13 +3974,13 @@ extension Diagnostic {
         return Diagnostic(
             source: nil,
             severity: .warning,
-            diagnostic: "Documentation contains multiple root pages",
             identifier: "org.swift.docc.MultipleRootPages",
             summary: "Found \(roots.count) root pages in documentation",
             explanation: """
-                Documentation should have exactly one root page. Found root pages:
-                - Primary: \(primaryRoot.path)
-                - Additional: \(additionalRoots.map { $0.path }.joined(separator: "\n  "))
+                Documentation should have exactly one root page. Found these root pages:
+                Primary: \(primaryRoot.path)
+                Additional:
+                \(additionalRoots.map { $0.path }.joined(separator: "\n"))
                 """
         )
     }
@@ -3996,7 +3996,8 @@ extension DocumentationContext {
         // Warn if multiple roots found
         if roots.count > 1 {
             let diagnostic = Diagnostic.multipleRootPagesWarning(roots: roots)
-            diagnosticEngine.emit(diagnostic)
+            let problem = Problem(diagnostic: diagnostic)
+            diagnosticEngine.emit(problem)
         }
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -8,11 +8,12 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-import SymbolKit
-@testable @_spi(ExternalLinks) import SwiftDocC
 import Markdown
 import SwiftDocCTestUtilities
+import SymbolKit
+import XCTest
+
+@testable @_spi(ExternalLinks) import SwiftDocC
 
 func diffDescription(lhs: String, rhs: String) -> String {
     let leftLines = lhs.components(separatedBy: .newlines)
@@ -45,401 +46,432 @@ class DocumentationContextTests: XCTestCase {
         let bundle = try testBundle(named: "LegacyBundle_DoNotUseInNewTests")
         let dataProvider = PrebuiltLocalFileSystemDataProvider(bundles: [bundle])
         try workspace.registerProvider(dataProvider)
-        
+
         // Test resolving
-        let unresolved = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:/TestTutorial")!)
-        let parent = ResolvedTopicReference(bundleIdentifier: bundle.id.rawValue, path: "", sourceLanguage: .swift)
-        
-        guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent) else {
+        let unresolved = UnresolvedTopicReference(
+            topicURL: ValidatedURL(parsingExact: "doc:/TestTutorial")!)
+        let parent = ResolvedTopicReference(
+            bundleIdentifier: bundle.id.rawValue, path: "", sourceLanguage: .swift)
+
+        guard case let .success(resolved) = context.resolve(.unresolved(unresolved), in: parent)
+        else {
             XCTFail("Couldn't resolve \(unresolved)")
             return
         }
-        
+
         XCTAssertEqual(parent.bundleIdentifier, resolved.bundleIdentifier)
         XCTAssertEqual("/tutorials/Test-Bundle/TestTutorial", resolved.path)
-        
+
         // Test lowercasing of path
-        let unresolvedUppercase = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:/TESTTUTORIAL")!)
+        let unresolvedUppercase = UnresolvedTopicReference(
+            topicURL: ValidatedURL(parsingExact: "doc:/TESTTUTORIAL")!)
         guard case .failure = context.resolve(.unresolved(unresolvedUppercase), in: parent) else {
             XCTFail("Did incorrectly resolve \(unresolvedUppercase)")
             return
         }
-        
+
         // Test expected URLs
-        let expectedURL = URL(string: "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial")
+        let expectedURL = URL(
+            string: "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial")
         XCTAssertEqual(expectedURL, resolved.url)
-        
+
         guard context.documentURL(for: resolved) != nil else {
             XCTFail("Couldn't resolve file URL for \(resolved)")
             return
         }
-        
+
         try workspace.unregisterProvider(dataProvider)
-        
+
         guard case .failure = context.resolve(.unresolved(unresolved), in: parent) else {
-            XCTFail("Unexpectedly resolved \(unresolved.topicURL) despite removing a data provider for it")
+            XCTFail(
+                "Unexpectedly resolved \(unresolved.topicURL) despite removing a data provider for it"
+            )
             return
         }
     }
-    
+
     func testLoadEntity() throws {
         let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
-        
-        let identifier = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
-        
-        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: "some.other.bundle", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)))
-        
-        XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/Test-Bundle/wrongIdentifier", sourceLanguage: .swift)))
+
+        let identifier = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift
+        )
+
+        XCTAssertThrowsError(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "some.other.bundle", path: "/tutorials/Test-Bundle/TestTutorial",
+                    sourceLanguage: .swift)))
+
+        XCTAssertThrowsError(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example", path: "/Test-Bundle/wrongIdentifier",
+                    sourceLanguage: .swift)))
 
         let node = try context.entity(with: identifier)
-                
+
         // FIXME: The ranges for Link destination elements is offset by 2.
-        
+
         let expectedDump = """
-├─ BlockDirective name: "Tutorial"
-│  ├─ Argument text segments:
-│  |    "time: 20, projectFiles: project.zip"
-│  ├─ BlockDirective name: "Comment"
-│  │  └─ Paragraph
-│  │     └─ Text "This is a comment."
-│  ├─ BlockDirective name: "XcodeRequirement"
-│  │  ├─ Argument text segments:
-│  │  |    "title: \\"Xcode X.Y Beta Z\\", destination: \\"https://www.example.com/download\\" "
-│  ├─ BlockDirective name: "Comment"
-│  │  ├─ Paragraph
-│  │  │  └─ Text "This is a comment."
-│  │  ├─ Paragraph
-│  │  │  └─ Text "This Intro should not get picked up."
-│  │  └─ BlockDirective name: "Intro"
-│  │     ├─ Argument text segments:
-│  │     |    "title: \\"Basic Augmented Reality App\\""
-│  │     ├─ Paragraph
-│  │     │  └─ Text "This is the tutorial abstract."
-│  │     ├─ BlockDirective name: "Comment"
-│  │     │  └─ Paragraph
-│  │     │     └─ Text "This is a comment."
-│  │     └─ BlockDirective name: "Video"
-│  │        ├─ Argument text segments:
-│  │        |    "source: introvideo.mp4, poster: introposter.png "
-│  ├─ BlockDirective name: "Intro"
-│  │  ├─ Argument text segments:
-│  │  |    "title: \\"Basic Augmented Reality App\\""
-│  │  ├─ Paragraph
-│  │  │  └─ Text "This is the tutorial abstract."
-│  │  ├─ BlockDirective name: "Comment"
-│  │  │  └─ Paragraph
-│  │  │     └─ Text "This is a comment."
-│  │  └─ BlockDirective name: "Video"
-│  │     ├─ Argument text segments:
-│  │     |    "source: introvideo.mp4, poster: introposter.png "
-│  ├─ BlockDirective name: "Section"
-│  │  ├─ Argument text segments:
-│  │  |    "title: \\"Create a New AR Project 💻\\""
-│  │  ├─ BlockDirective name: "ContentAndMedia"
-│  │  │  ├─ Paragraph
-│  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This section link refers to this section itself: "
-│  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
-│  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
-│  │  │  │  ├─ Text "."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This is an external link to Swift documentation: "
-│  │  │  │  ├─ Link destination: "https://swift.org/documentation/"
-│  │  │  │  │  └─ Text "Swift Documentation"
-│  │  │  │  ├─ Text "."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This section link refers to the next section in this file: "
-│  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection"
-│  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection"
-│  │  │  │  ├─ Text "."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This link will never resolve: "
-│  │  │  │  ├─ Link destination: "doc:ThisWillNeverResolve"
-│  │  │  │  │  └─ Text "doc:ThisWillNeverResolve"
-│  │  │  │  ├─ Text "."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This link needs an external resolver: "
-│  │  │  │  ├─ Link destination: "doc://com.test.external/path/to/external/symbol"
-│  │  │  │  │  └─ Text "doc://com.test.external/path/to/external/symbol"
-│  │  │  │  └─ Text "."
-│  │  │  ├─ BlockDirective name: "Comment"
-│  │  │  │  └─ Paragraph
-│  │  │  │     └─ Text "This is a comment."
-│  │  │  ├─ BlockQuote
-│  │  │  │  └─ Paragraph
-│  │  │  │     └─ Text "Note: This is a note."
-│  │  │  ├─ BlockQuote
-│  │  │  │  └─ Paragraph
-│  │  │  │     └─ Text "Important: This is important."
-│  │  │  ├─ BlockDirective name: "Image"
-│  │  │  │  ├─ Argument text segments:
-│  │  │  │  |    "source: figure1.png, alt: figure1 "
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Image source: "figure1"
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Image source: "images/figure1"
-│  │  │  └─ Paragraph
-│  │  │     └─ Text "Quis auctor elit sed vulputate mi sit amet."
-│  │  ├─ BlockDirective name: "Comment"
-│  │  │  └─ Paragraph
-│  │  │     └─ Text "This is a comment."
-│  │  └─ BlockDirective name: "Steps"
-│  │     ├─ Paragraph
-│  │     │  └─ Text "Let’s get started building the Augmented Reality app."
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  └─ BlockDirective name: "Image"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "source: step.png, alt: step "
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  ├─ BlockDirective name: "Comment"
-│  │     │  │  └─ Paragraph
-│  │     │  │     └─ Text "This is a comment."
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "This is a step caption."
-│  │     │  └─ BlockDirective name: "Code"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "file: helloworld1.swift, name: MyCode.swift"
-│  │     │     └─ BlockDirective name: "Image"
-│  │     │        ├─ Argument text segments:
-│  │     │        |    "source: step.png, alt: step "
-│  │     ├─ BlockQuote
-│  │     │  └─ Paragraph
-│  │     │     └─ Text "Experiment: Do something cool."
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  └─ BlockDirective name: "Code"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "file: helloworld2.swift, name: MyCode.swift"
-│  │     │     └─ BlockDirective name: "Image"
-│  │     │        ├─ Argument text segments:
-│  │     │        |    "source: intro.png, alt: intro "
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  └─ BlockDirective name: "Image"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "source: step.png, alt: step "
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  └─ BlockDirective name: "Code"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "file: helloworld3.swift, name: MyCode.swift"
-│  │     │     └─ BlockDirective name: "Image"
-│  │     │        ├─ Argument text segments:
-│  │     │        |    "source: titled2up.png, alt: titled2up "
-│  │     └─ BlockDirective name: "Step"
-│  │        ├─ Paragraph
-│  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │        └─ BlockDirective name: "Code"
-│  │           ├─ Argument text segments:
-│  │           |    "file: helloworld4.swift, name: MyCode.swift"
-│  │           └─ BlockDirective name: "Image"
-│  │              ├─ Argument text segments:
-│  │              |    "source: titled2up.png, alt: titled2up "
-│  ├─ BlockDirective name: "Section"
-│  │  ├─ Argument text segments:
-│  │  |    "title: \\"Initiate ARKit Plane Detection\\""
-│  │  ├─ BlockDirective name: "Comment"
-│  │  │  └─ Paragraph
-│  │  │     └─ Text "This is a comment."
-│  │  ├─ BlockDirective name: "ContentAndMedia"
-│  │  │  ├─ Paragraph
-│  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This section link refers to the previous section: "
-│  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
-│  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
-│  │  │  │  ├─ Text "."
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  ├─ Text "This section link refers to the first section in another tutorial: "
-│  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial2#Create-a-New-AR-Project"
-│  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial2#Create-a-New-AR-Project"
-│  │  │  │  └─ Text "."
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
-│  │  │  └─ BlockDirective name: "Image"
-│  │  │     ├─ Argument text segments:
-│  │  │     |    "source: titled2up.png, alt: titled2up "
-│  │  └─ BlockDirective name: "Steps"
-│  │     ├─ Paragraph
-│  │     │  └─ Text "Let’s get started building the Augmented Reality app."
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  └─ BlockDirective name: "Image"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "source: xcode.png, alt: xcode "
-│  │     ├─ BlockDirective name: "Step"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │     │  └─ BlockDirective name: "Video"
-│  │     │     ├─ Argument text segments:
-│  │     │     |    "source: app.mov "
-│  │     └─ BlockDirective name: "Step"
-│  │        ├─ Paragraph
-│  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │        └─ BlockDirective name: "Video"
-│  │           ├─ Argument text segments:
-│  │           |    "source: app2.mov "
-│  ├─ BlockDirective name: "Section"
-│  │  ├─ Argument text segments:
-│  │  |    "title: \\"Duplicate\\""
-│  │  ├─ BlockDirective name: "ContentAndMedia"
-│  │  │  ├─ Paragraph
-│  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  └─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
-│  │  │  └─ BlockDirective name: "Image"
-│  │  │     ├─ Argument text segments:
-│  │  │     |    "source: titled2up.png, alt: titled2up "
-│  │  └─ BlockDirective name: "Steps"
-│  │     ├─ Paragraph
-│  │     │  └─ Text "Let’s get started building the Augmented Reality app."
-│  │     └─ BlockDirective name: "Step"
-│  │        ├─ Paragraph
-│  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │        └─ BlockDirective name: "Image"
-│  │           ├─ Argument text segments:
-│  │           |    "source: xcode.png, alt: xcode "
-│  ├─ BlockDirective name: "Section"
-│  │  ├─ Argument text segments:
-│  │  |    "title: \\"Duplicate\\""
-│  │  ├─ BlockDirective name: "ContentAndMedia"
-│  │  │  ├─ Paragraph
-│  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
-│  │  │  │  ├─ SoftBreak
-│  │  │  │  └─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
-│  │  │  └─ BlockDirective name: "Image"
-│  │  │     ├─ Argument text segments:
-│  │  │     |    "source: titled2up.png, alt: titled2up "
-│  │  └─ BlockDirective name: "Steps"
-│  │     ├─ Paragraph
-│  │     │  └─ Text "Let’s get started building the Augmented Reality app."
-│  │     └─ BlockDirective name: "Step"
-│  │        ├─ Paragraph
-│  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
-│  │        └─ BlockDirective name: "Image"
-│  │           ├─ Argument text segments:
-│  │           |    "source: xcode.png, alt: xcode "
-│  ├─ BlockDirective name: "Assessments"
-│  │  ├─ BlockDirective name: "Comment"
-│  │  │  └─ Paragraph
-│  │  │     └─ Text "This is a comment."
-│  │  ├─ BlockDirective name: "MultipleChoice"
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Text "Lorem ipsum dolor sit amet?"
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Text "Phasellus faucibus scelerisque eleifend donec pretium."
-│  │  │  ├─ Paragraph
-│  │  │  │  └─ Image source: "something.png"
-│  │  │  │     └─ Text "Diagram"
-│  │  │  ├─ CodeBlock language: swift
-│  │  │  │  let scene = ARSCNView()
-│  │  │  │  let anchor = scene.anchor(for: node)
-│  │  │  ├─ BlockDirective name: "Choice"
-│  │  │  │  ├─ Argument text segments:
-│  │  │  │  |    "isCorrect: true"
-│  │  │  │  ├─ Paragraph
-│  │  │  │  │  └─ InlineCode `anchor.hitTest(view)`
-│  │  │  │  └─ BlockDirective name: "Justification"
-│  │  │  │     └─ Paragraph
-│  │  │  │        └─ Text "This is correct because it is."
-│  │  │  ├─ BlockDirective name: "Choice"
-│  │  │  │  ├─ Argument text segments:
-│  │  │  │  |    "isCorrect: false"
-│  │  │  │  ├─ Paragraph
-│  │  │  │  │  └─ InlineCode `anchor.intersects(view)`
-│  │  │  │  └─ BlockDirective name: "Justification"
-│  │  │  │     └─ Paragraph
-│  │  │  │        └─ Text "This is incorrect because it is."
-│  │  │  └─ BlockDirective name: "Choice"
-│  │  │     ├─ Argument text segments:
-│  │  │     |    "isCorrect: false"
-│  │  │     ├─ Paragraph
-│  │  │     │  └─ InlineCode `anchor.intersects(view)`
-│  │  │     └─ BlockDirective name: "Justification"
-│  │  │        └─ Paragraph
-│  │  │           └─ Text "This is incorrect because it is."
-│  │  └─ BlockDirective name: "MultipleChoice"
-│  │     ├─ Paragraph
-│  │     │  └─ Text "Lorem ipsum dolor sit amet?"
-│  │     ├─ Paragraph
-│  │     │  └─ Text "Phasellus faucibus scelerisque eleifend donec pretium."
-│  │     ├─ CodeBlock language: swift
-│  │     │  let scene = ARSCNView()
-│  │     │  let anchor = scene.anchor(for: node)
-│  │     ├─ BlockDirective name: "Choice"
-│  │     │  ├─ Argument text segments:
-│  │     │  |    "isCorrect: true"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ InlineCode `anchor.hitTest(view)`
-│  │     │  └─ BlockDirective name: "Justification"
-│  │     │     └─ Paragraph
-│  │     │        └─ Text "This is correct because it is."
-│  │     ├─ BlockDirective name: "Choice"
-│  │     │  ├─ Argument text segments:
-│  │     │  |    "isCorrect: false"
-│  │     │  ├─ Paragraph
-│  │     │  │  └─ InlineCode `anchor.intersects(view)`
-│  │     │  └─ BlockDirective name: "Justification"
-│  │     │     └─ Paragraph
-│  │     │        └─ Text "This is incorrect because it is."
-│  │     └─ BlockDirective name: "Choice"
-│  │        ├─ Argument text segments:
-│  │        |    "isCorrect: false"
-│  │        ├─ Paragraph
-│  │        │  └─ InlineCode `anchor.intersects(view)`
-│  │        └─ BlockDirective name: "Justification"
-│  │           └─ Paragraph
-│  │              └─ Text "This is incorrect because it is."
-│  └─ BlockDirective name: "Image"
-│     ├─ Argument text segments:
-│     |    "source: introposter2.png, alt: \\"Titled 2-up\\" "
-"""
-        XCTAssertEqual(expectedDump, node.markup.debugDescription(), diffDescription(lhs: expectedDump, rhs: node.markup.debugDescription()))
+            ├─ BlockDirective name: "Tutorial"
+            │  ├─ Argument text segments:
+            │  |    "time: 20, projectFiles: project.zip"
+            │  ├─ BlockDirective name: "Comment"
+            │  │  └─ Paragraph
+            │  │     └─ Text "This is a comment."
+            │  ├─ BlockDirective name: "XcodeRequirement"
+            │  │  ├─ Argument text segments:
+            │  │  |    "title: \\"Xcode X.Y Beta Z\\", destination: \\"https://www.example.com/download\\" "
+            │  ├─ BlockDirective name: "Comment"
+            │  │  ├─ Paragraph
+            │  │  │  └─ Text "This is a comment."
+            │  │  ├─ Paragraph
+            │  │  │  └─ Text "This Intro should not get picked up."
+            │  │  └─ BlockDirective name: "Intro"
+            │  │     ├─ Argument text segments:
+            │  │     |    "title: \\"Basic Augmented Reality App\\""
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "This is the tutorial abstract."
+            │  │     ├─ BlockDirective name: "Comment"
+            │  │     │  └─ Paragraph
+            │  │     │     └─ Text "This is a comment."
+            │  │     └─ BlockDirective name: "Video"
+            │  │        ├─ Argument text segments:
+            │  │        |    "source: introvideo.mp4, poster: introposter.png "
+            │  ├─ BlockDirective name: "Intro"
+            │  │  ├─ Argument text segments:
+            │  │  |    "title: \\"Basic Augmented Reality App\\""
+            │  │  ├─ Paragraph
+            │  │  │  └─ Text "This is the tutorial abstract."
+            │  │  ├─ BlockDirective name: "Comment"
+            │  │  │  └─ Paragraph
+            │  │  │     └─ Text "This is a comment."
+            │  │  └─ BlockDirective name: "Video"
+            │  │     ├─ Argument text segments:
+            │  │     |    "source: introvideo.mp4, poster: introposter.png "
+            │  ├─ BlockDirective name: "Section"
+            │  │  ├─ Argument text segments:
+            │  │  |    "title: \\"Create a New AR Project 💻\\""
+            │  │  ├─ BlockDirective name: "ContentAndMedia"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This section link refers to this section itself: "
+            │  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
+            │  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
+            │  │  │  │  ├─ Text "."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This is an external link to Swift documentation: "
+            │  │  │  │  ├─ Link destination: "https://swift.org/documentation/"
+            │  │  │  │  │  └─ Text "Swift Documentation"
+            │  │  │  │  ├─ Text "."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This section link refers to the next section in this file: "
+            │  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection"
+            │  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection"
+            │  │  │  │  ├─ Text "."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This link will never resolve: "
+            │  │  │  │  ├─ Link destination: "doc:ThisWillNeverResolve"
+            │  │  │  │  │  └─ Text "doc:ThisWillNeverResolve"
+            │  │  │  │  ├─ Text "."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This link needs an external resolver: "
+            │  │  │  │  ├─ Link destination: "doc://com.test.external/path/to/external/symbol"
+            │  │  │  │  │  └─ Text "doc://com.test.external/path/to/external/symbol"
+            │  │  │  │  └─ Text "."
+            │  │  │  ├─ BlockDirective name: "Comment"
+            │  │  │  │  └─ Paragraph
+            │  │  │  │     └─ Text "This is a comment."
+            │  │  │  ├─ BlockQuote
+            │  │  │  │  └─ Paragraph
+            │  │  │  │     └─ Text "Note: This is a note."
+            │  │  │  ├─ BlockQuote
+            │  │  │  │  └─ Paragraph
+            │  │  │  │     └─ Text "Important: This is important."
+            │  │  │  ├─ BlockDirective name: "Image"
+            │  │  │  │  ├─ Argument text segments:
+            │  │  │  │  |    "source: figure1.png, alt: figure1 "
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Image source: "figure1"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Image source: "images/figure1"
+            │  │  │  └─ Paragraph
+            │  │  │     └─ Text "Quis auctor elit sed vulputate mi sit amet."
+            │  │  ├─ BlockDirective name: "Comment"
+            │  │  │  └─ Paragraph
+            │  │  │     └─ Text "This is a comment."
+            │  │  └─ BlockDirective name: "Steps"
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "Let’s get started building the Augmented Reality app."
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  └─ BlockDirective name: "Image"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "source: step.png, alt: step "
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  ├─ BlockDirective name: "Comment"
+            │  │     │  │  └─ Paragraph
+            │  │     │  │     └─ Text "This is a comment."
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "This is a step caption."
+            │  │     │  └─ BlockDirective name: "Code"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "file: helloworld1.swift, name: MyCode.swift"
+            │  │     │     └─ BlockDirective name: "Image"
+            │  │     │        ├─ Argument text segments:
+            │  │     │        |    "source: step.png, alt: step "
+            │  │     ├─ BlockQuote
+            │  │     │  └─ Paragraph
+            │  │     │     └─ Text "Experiment: Do something cool."
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  └─ BlockDirective name: "Code"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "file: helloworld2.swift, name: MyCode.swift"
+            │  │     │     └─ BlockDirective name: "Image"
+            │  │     │        ├─ Argument text segments:
+            │  │     │        |    "source: intro.png, alt: intro "
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  └─ BlockDirective name: "Image"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "source: step.png, alt: step "
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  └─ BlockDirective name: "Code"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "file: helloworld3.swift, name: MyCode.swift"
+            │  │     │     └─ BlockDirective name: "Image"
+            │  │     │        ├─ Argument text segments:
+            │  │     │        |    "source: titled2up.png, alt: titled2up "
+            │  │     └─ BlockDirective name: "Step"
+            │  │        ├─ Paragraph
+            │  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │        └─ BlockDirective name: "Code"
+            │  │           ├─ Argument text segments:
+            │  │           |    "file: helloworld4.swift, name: MyCode.swift"
+            │  │           └─ BlockDirective name: "Image"
+            │  │              ├─ Argument text segments:
+            │  │              |    "source: titled2up.png, alt: titled2up "
+            │  ├─ BlockDirective name: "Section"
+            │  │  ├─ Argument text segments:
+            │  │  |    "title: \\"Initiate ARKit Plane Detection\\""
+            │  │  ├─ BlockDirective name: "Comment"
+            │  │  │  └─ Paragraph
+            │  │  │     └─ Text "This is a comment."
+            │  │  ├─ BlockDirective name: "ContentAndMedia"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This section link refers to the previous section: "
+            │  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
+            │  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB"
+            │  │  │  │  ├─ Text "."
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  ├─ Text "This section link refers to the first section in another tutorial: "
+            │  │  │  │  ├─ Link destination: "doc:/tutorials/Test-Bundle/TestTutorial2#Create-a-New-AR-Project"
+            │  │  │  │  │  └─ Text "doc:/tutorials/Test-Bundle/TestTutorial2#Create-a-New-AR-Project"
+            │  │  │  │  └─ Text "."
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
+            │  │  │  └─ BlockDirective name: "Image"
+            │  │  │     ├─ Argument text segments:
+            │  │  │     |    "source: titled2up.png, alt: titled2up "
+            │  │  └─ BlockDirective name: "Steps"
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "Let’s get started building the Augmented Reality app."
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  └─ BlockDirective name: "Image"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "source: xcode.png, alt: xcode "
+            │  │     ├─ BlockDirective name: "Step"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │     │  └─ BlockDirective name: "Video"
+            │  │     │     ├─ Argument text segments:
+            │  │     │     |    "source: app.mov "
+            │  │     └─ BlockDirective name: "Step"
+            │  │        ├─ Paragraph
+            │  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │        └─ BlockDirective name: "Video"
+            │  │           ├─ Argument text segments:
+            │  │           |    "source: app2.mov "
+            │  ├─ BlockDirective name: "Section"
+            │  │  ├─ Argument text segments:
+            │  │  |    "title: \\"Duplicate\\""
+            │  │  ├─ BlockDirective name: "ContentAndMedia"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  └─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
+            │  │  │  └─ BlockDirective name: "Image"
+            │  │  │     ├─ Argument text segments:
+            │  │  │     |    "source: titled2up.png, alt: titled2up "
+            │  │  └─ BlockDirective name: "Steps"
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "Let’s get started building the Augmented Reality app."
+            │  │     └─ BlockDirective name: "Step"
+            │  │        ├─ Paragraph
+            │  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │        └─ BlockDirective name: "Image"
+            │  │           ├─ Argument text segments:
+            │  │           |    "source: xcode.png, alt: xcode "
+            │  ├─ BlockDirective name: "Section"
+            │  │  ├─ Argument text segments:
+            │  │  |    "title: \\"Duplicate\\""
+            │  │  ├─ BlockDirective name: "ContentAndMedia"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  ├─ Text "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
+            │  │  │  │  ├─ SoftBreak
+            │  │  │  │  └─ Text "ut labore et dolore magna aliqua. Phasellus faucibus scelerisque eleifend donec pretium."
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Text "Ultrices dui sapien eget mi proin sed libero enim. Quis auctor elit sed vulputate mi sit amet."
+            │  │  │  └─ BlockDirective name: "Image"
+            │  │  │     ├─ Argument text segments:
+            │  │  │     |    "source: titled2up.png, alt: titled2up "
+            │  │  └─ BlockDirective name: "Steps"
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "Let’s get started building the Augmented Reality app."
+            │  │     └─ BlockDirective name: "Step"
+            │  │        ├─ Paragraph
+            │  │        │  └─ Text "Lorem ipsum dolor sit amet, consectetur."
+            │  │        └─ BlockDirective name: "Image"
+            │  │           ├─ Argument text segments:
+            │  │           |    "source: xcode.png, alt: xcode "
+            │  ├─ BlockDirective name: "Assessments"
+            │  │  ├─ BlockDirective name: "Comment"
+            │  │  │  └─ Paragraph
+            │  │  │     └─ Text "This is a comment."
+            │  │  ├─ BlockDirective name: "MultipleChoice"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Text "Lorem ipsum dolor sit amet?"
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Text "Phasellus faucibus scelerisque eleifend donec pretium."
+            │  │  │  ├─ Paragraph
+            │  │  │  │  └─ Image source: "something.png"
+            │  │  │  │     └─ Text "Diagram"
+            │  │  │  ├─ CodeBlock language: swift
+            │  │  │  │  let scene = ARSCNView()
+            │  │  │  │  let anchor = scene.anchor(for: node)
+            │  │  │  ├─ BlockDirective name: "Choice"
+            │  │  │  │  ├─ Argument text segments:
+            │  │  │  │  |    "isCorrect: true"
+            │  │  │  │  ├─ Paragraph
+            │  │  │  │  │  └─ InlineCode `anchor.hitTest(view)`
+            │  │  │  │  └─ BlockDirective name: "Justification"
+            │  │  │  │     └─ Paragraph
+            │  │  │  │        └─ Text "This is correct because it is."
+            │  │  │  ├─ BlockDirective name: "Choice"
+            │  │  │  │  ├─ Argument text segments:
+            │  │  │  │  |    "isCorrect: false"
+            │  │  │  │  ├─ Paragraph
+            │  │  │  │  │  └─ InlineCode `anchor.intersects(view)`
+            │  │  │  │  └─ BlockDirective name: "Justification"
+            │  │  │  │     └─ Paragraph
+            │  │  │  │        └─ Text "This is incorrect because it is."
+            │  │  │  └─ BlockDirective name: "Choice"
+            │  │  │     ├─ Argument text segments:
+            │  │  │     |    "isCorrect: false"
+            │  │  │     ├─ Paragraph
+            │  │  │     │  └─ InlineCode `anchor.intersects(view)`
+            │  │  │     └─ BlockDirective name: "Justification"
+            │  │  │        └─ Paragraph
+            │  │  │           └─ Text "This is incorrect because it is."
+            │  │  └─ BlockDirective name: "MultipleChoice"
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "Lorem ipsum dolor sit amet?"
+            │  │     ├─ Paragraph
+            │  │     │  └─ Text "Phasellus faucibus scelerisque eleifend donec pretium."
+            │  │     ├─ CodeBlock language: swift
+            │  │     │  let scene = ARSCNView()
+            │  │     │  let anchor = scene.anchor(for: node)
+            │  │     ├─ BlockDirective name: "Choice"
+            │  │     │  ├─ Argument text segments:
+            │  │     │  |    "isCorrect: true"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ InlineCode `anchor.hitTest(view)`
+            │  │     │  └─ BlockDirective name: "Justification"
+            │  │     │     └─ Paragraph
+            │  │     │        └─ Text "This is correct because it is."
+            │  │     ├─ BlockDirective name: "Choice"
+            │  │     │  ├─ Argument text segments:
+            │  │     │  |    "isCorrect: false"
+            │  │     │  ├─ Paragraph
+            │  │     │  │  └─ InlineCode `anchor.intersects(view)`
+            │  │     │  └─ BlockDirective name: "Justification"
+            │  │     │     └─ Paragraph
+            │  │     │        └─ Text "This is incorrect because it is."
+            │  │     └─ BlockDirective name: "Choice"
+            │  │        ├─ Argument text segments:
+            │  │        |    "isCorrect: false"
+            │  │        ├─ Paragraph
+            │  │        │  └─ InlineCode `anchor.intersects(view)`
+            │  │        └─ BlockDirective name: "Justification"
+            │  │           └─ Paragraph
+            │  │              └─ Text "This is incorrect because it is."
+            │  └─ BlockDirective name: "Image"
+            │     ├─ Argument text segments:
+            │     |    "source: introposter2.png, alt: \\"Titled 2-up\\" "
+            """
+        XCTAssertEqual(
+            expectedDump, node.markup.debugDescription(),
+            diffDescription(lhs: expectedDump, rhs: node.markup.debugDescription()))
     }
-        
+
     func testThrowsErrorForMissingResource() throws {
         let (_, context) = try testBundleAndContext()
-        XCTAssertThrowsError(try context.resource(with: ResourceReference(bundleID: "com.example.missing", path: "/missing.swift")), "Expected requesting an unknown file to result in an error.")
+        XCTAssertThrowsError(
+            try context.resource(
+                with: ResourceReference(bundleID: "com.example.missing", path: "/missing.swift")),
+            "Expected requesting an unknown file to result in an error.")
     }
 
     func testThrowsErrorForQualifiedImagePaths() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
-            DataFile(name: "figure1.jpg", data: Data())
-        ]))
+        let (bundle, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    DataFile(name: "figure1.jpg", data: Data())
+                ]))
         let id = bundle.id
 
         let figure = ResourceReference(bundleID: id, path: "figure1.jpg")
         let imageFigure = ResourceReference(bundleID: id, path: "images/figure1.jpg")
 
-        XCTAssertNoThrow(try context.resource(with: figure), "\(figure.path) expected in \(bundle.displayName)")
-        XCTAssertThrowsError(try context.resource(with: imageFigure), "Images should be registered (and referred to) by their name, not by their path.")
+        XCTAssertNoThrow(
+            try context.resource(with: figure), "\(figure.path) expected in \(bundle.displayName)")
+        XCTAssertThrowsError(
+            try context.resource(with: imageFigure),
+            "Images should be registered (and referred to) by their name, not by their path.")
     }
-    
+
     func testResourceExists() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
-            DataFile(name: "figure1.jpg", data: Data()),
-            DataFile(name: "introposter.jpg", data: Data()),
-        ]))
-        
+        let (bundle, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    DataFile(name: "figure1.jpg", data: Data()),
+                    DataFile(name: "introposter.jpg", data: Data()),
+                ]))
+
         let existingImageReference = ResourceReference(
             bundleID: bundle.id,
             path: "introposter"
@@ -456,7 +488,7 @@ class DocumentationContextTests: XCTestCase {
             context.resourceExists(with: nonexistentImageReference),
             "\(nonexistentImageReference.path) does not exist in \(bundle.displayName)"
         )
-        
+
         let correctImageReference = ResourceReference(
             bundleID: bundle.id,
             path: "figure1.jpg"
@@ -474,71 +506,85 @@ class DocumentationContextTests: XCTestCase {
             "Images are registered and referenced by name, not path."
         )
     }
-    
+
     func testURLs() throws {
-        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
-            Folder(name: "Symbols", content: []),
-            Folder(name: "Resources", content: [
-                // This whitespace and punctuation in this *file name* will be replaced by dashes in its identifier.
-                // No content in this file result in identifiers.
-                TextFile(name: "Technology file: with - whitespace, and_punctuation.tutorial", utf8Content: """
-                @Tutorials(name: "Technology Name") {
-                   @Intro(title: "Intro Title") {
-                      @Video(source: introvideo.mp4, poster: introposter.png)
-                      @Image(source: intro.png ,alt: "Intro alt text")
-                   }
+        let exampleDocumentation = Folder(
+            name: "unit-test.docc",
+            content: [
+                Folder(name: "Symbols", content: []),
+                Folder(
+                    name: "Resources",
+                    content: [
+                        // This whitespace and punctuation in this *file name* will be replaced by dashes in its identifier.
+                        // No content in this file result in identifiers.
+                        TextFile(
+                            name: "Technology file: with - whitespace, and_punctuation.tutorial",
+                            utf8Content: """
+                                @Tutorials(name: "Technology Name") {
+                                   @Intro(title: "Intro Title") {
+                                      @Video(source: introvideo.mp4, poster: introposter.png)
+                                      @Image(source: intro.png ,alt: "Intro alt text")
+                                   }
 
-                   @Volume(name: "Volume_Section Title: with - various! whitespace, and/punctuation") {
-                      The whiteapace and punctuation in the title above will be replaced with dashes in the volume's identifier.
+                                   @Volume(name: "Volume_Section Title: with - various! whitespace, and/punctuation") {
+                                      The whiteapace and punctuation in the title above will be replaced with dashes in the volume's identifier.
 
-                      @Chapter(name: "Chapter_Title: with - various! whitespace, and/punctuation") {
-                         The whiteapace and punctuation in the name above will be replaced with dashes in the chapter's identifier.
+                                      @Chapter(name: "Chapter_Title: with - various! whitespace, and/punctuation") {
+                                         The whiteapace and punctuation in the name above will be replaced with dashes in the chapter's identifier.
 
-                         @Image(source: image-name.png, alt: "Chapter image alt text")
-                      }
-                   }
-                }
-                """),
-            ]),
-            InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
-        ])
+                                         @Image(source: image-name.png, alt: "Chapter image alt text")
+                                      }
+                                   }
+                                }
+                                """)
+                    ]),
+                InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+            ])
 
         // Parse this test content
         let (_, context) = try loadBundle(catalog: exampleDocumentation)
-        
+
         // Verify all the reference identifiers for this content
         XCTAssertEqual(context.knownIdentifiers.count, 3)
-        let identifierPaths = context.knownIdentifiers.map { $0.path }.sorted(by: { lhs, rhs in lhs.count < rhs.count })
-        XCTAssertEqual(identifierPaths, [
-            // From the two file names
-            "/tutorials/Technology-file:-with---whitespace,-and_punctuation",
-            // From the volume's title and the chapter's names, appended to their technology's identifier
-            "/tutorials/Technology-file:-with---whitespace,-and_punctuation/Volume_Section-Title:-with---various!-whitespace,-and/punctuation",
-            "/tutorials/Technology-file:-with---whitespace,-and_punctuation/Volume_Section-Title:-with---various!-whitespace,-and/punctuation/Chapter_Title:-with---various!-whitespace,-and/punctuation"
-        ])
+        let identifierPaths = context.knownIdentifiers.map { $0.path }.sorted(by: { lhs, rhs in
+            lhs.count < rhs.count
+        })
+        XCTAssertEqual(
+            identifierPaths,
+            [
+                // From the two file names
+                "/tutorials/Technology-file:-with---whitespace,-and_punctuation",
+                // From the volume's title and the chapter's names, appended to their technology's identifier
+                "/tutorials/Technology-file:-with---whitespace,-and_punctuation/Volume_Section-Title:-with---various!-whitespace,-and/punctuation",
+                "/tutorials/Technology-file:-with---whitespace,-and_punctuation/Volume_Section-Title:-with---various!-whitespace,-and/punctuation/Chapter_Title:-with---various!-whitespace,-and/punctuation",
+            ])
     }
-    
+
     func testRegisteredImages() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
-            DataFile(name: "figure1.jpg",          data: Data()),
-            DataFile(name: "figure1.png",          data: Data()),
-            DataFile(name: "figure1~dark.png",     data: Data()),
-            DataFile(name: "intro.png",            data: Data()),
-            DataFile(name: "introposter.png",      data: Data()),
-            DataFile(name: "introposter2.png",     data: Data()),
-            DataFile(name: "something@2x.png",     data: Data()),
-            DataFile(name: "step.png",             data: Data()),
-            DataFile(name: "titled2up.png",        data: Data()),
-            DataFile(name: "titled2upCapital.PNG", data: Data()),
-            DataFile(name: "with spaces.png",      data: Data()),
-            DataFile(name: "with spaces@2x.png",   data: Data()),
-        ]))
-        
-        let imagesRegistered = context
+        let (bundle, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    DataFile(name: "figure1.jpg", data: Data()),
+                    DataFile(name: "figure1.png", data: Data()),
+                    DataFile(name: "figure1~dark.png", data: Data()),
+                    DataFile(name: "intro.png", data: Data()),
+                    DataFile(name: "introposter.png", data: Data()),
+                    DataFile(name: "introposter2.png", data: Data()),
+                    DataFile(name: "something@2x.png", data: Data()),
+                    DataFile(name: "step.png", data: Data()),
+                    DataFile(name: "titled2up.png", data: Data()),
+                    DataFile(name: "titled2upCapital.PNG", data: Data()),
+                    DataFile(name: "with spaces.png", data: Data()),
+                    DataFile(name: "with spaces@2x.png", data: Data()),
+                ]))
+
+        let imagesRegistered =
+            context
             .registeredImageAssets(for: bundle.id)
             .flatMap { $0.variants.map { $0.value.lastPathComponent } }
             .sorted()
-        
+
         XCTAssertEqual(
             [
                 "figure1.jpg",
@@ -557,96 +603,123 @@ class DocumentationContextTests: XCTestCase {
             imagesRegistered.sorted()
         )
     }
-    
+
     func testExternalAssets() throws {
         let (bundle, context) = try testBundleAndContext()
-        
-        let image = context.resolveAsset(named: "https://example.com/figure.png", in: bundle.rootReference)
+
+        let image = context.resolveAsset(
+            named: "https://example.com/figure.png", in: bundle.rootReference)
         XCTAssertNotNil(image)
         guard let image else {
             return
         }
         XCTAssertEqual(image.context, .display)
-        XCTAssertEqual(image.variants, [DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(string: "https://example.com/figure.png")!])
-        
-        let video = context.resolveAsset(named: "https://example.com/introvideo.mp4", in: bundle.rootReference)
+        XCTAssertEqual(
+            image.variants,
+            [
+                DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(
+                    string: "https://example.com/figure.png")!
+            ])
+
+        let video = context.resolveAsset(
+            named: "https://example.com/introvideo.mp4", in: bundle.rootReference)
         XCTAssertNotNil(video)
         guard let video else { return }
         XCTAssertEqual(video.context, .display)
-        XCTAssertEqual(video.variants, [DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(string: "https://example.com/introvideo.mp4")!])
+        XCTAssertEqual(
+            video.variants,
+            [
+                DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(
+                    string: "https://example.com/introvideo.mp4")!
+            ])
     }
-    
+
     func testDownloadAssets() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
-            DataFile(name: "intro.png", data: Data()),
-            DataFile(name: "project.zip", data: Data()),
-            
-            TextFile(name: "TableOfContents.tutorial", utf8Content: """
-            @Tutorials(name: "Something") {
-                @Intro(title: "Test Intro") {
-                    Add one or more paragraphs that introduce your tutorial.
-                }
-                @Chapter(name: "Chapter Name") {
-                    @Image(source: "intro.png", alt: "Some accessible description of the image")
-            
-                    @TutorialReference(tutorial: "doc:Something")
-                }
-            }
-            """),
-            
-            TextFile(name: "Something.tutorial", utf8Content: """
-            @Tutorial(time: 20, projectFiles: project.zip) {
-                @Intro(title: "Test Intro")
-                @Section(title: "Test Section") {
-                    @ContentAndMedia {
-                        Some tutorial content
-                    }
-               }
-               @Assessments {
-               }
-            }
-            """),
-            
-            
-        ]))
-        
+        let (bundle, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    DataFile(name: "intro.png", data: Data()),
+                    DataFile(name: "project.zip", data: Data()),
+
+                    TextFile(
+                        name: "TableOfContents.tutorial",
+                        utf8Content: """
+                            @Tutorials(name: "Something") {
+                                @Intro(title: "Test Intro") {
+                                    Add one or more paragraphs that introduce your tutorial.
+                                }
+                                @Chapter(name: "Chapter Name") {
+                                    @Image(source: "intro.png", alt: "Some accessible description of the image")
+
+                                    @TutorialReference(tutorial: "doc:Something")
+                                }
+                            }
+                            """),
+
+                    TextFile(
+                        name: "Something.tutorial",
+                        utf8Content: """
+                            @Tutorial(time: 20, projectFiles: project.zip) {
+                                @Intro(title: "Test Intro")
+                                @Section(title: "Test Section") {
+                                    @ContentAndMedia {
+                                        Some tutorial content
+                                    }
+                               }
+                               @Assessments {
+                               }
+                            }
+                            """),
+
+                ]))
+
         let downloadsBefore = context.registeredDownloadsAssets(for: bundle.id)
         XCTAssertEqual(downloadsBefore.count, 1)
-        XCTAssertEqual(downloadsBefore.first?.variants.values.first?.lastPathComponent, "project.zip")
-        
-        guard var assetOriginal = context
-            .registeredImageAssets(for: bundle.id)
-            .first(where: { asset -> Bool in
-                return asset.variants.values.first(where: { url -> Bool in
-                    return url.path.contains("intro.png")
-                }) != nil
-            }) else {
+        XCTAssertEqual(
+            downloadsBefore.first?.variants.values.first?.lastPathComponent, "project.zip")
+
+        guard
+            var assetOriginal =
+                context
+                .registeredImageAssets(for: bundle.id)
+                .first(where: { asset -> Bool in
+                    return asset.variants.values.first(where: { url -> Bool in
+                        return url.path.contains("intro.png")
+                    }) != nil
+                })
+        else {
             XCTFail("Failed to find the required registered image")
             return
         }
-        
+
         // Update the asset.
         assetOriginal.context = .download
         context.updateAsset(named: "intro.png", asset: assetOriginal, in: bundle.rootReference)
-        
-        guard let assetUpdated = context
-            .registeredImageAssets(for: bundle.id)
-            .first(where: { asset -> Bool in
-                return asset.variants.values.first(where: { url -> Bool in
-                    return url.path.contains("intro.png")
-                }) != nil
-            }) else {
+
+        guard
+            let assetUpdated =
+                context
+                .registeredImageAssets(for: bundle.id)
+                .first(where: { asset -> Bool in
+                    return asset.variants.values.first(where: { url -> Bool in
+                        return url.path.contains("intro.png")
+                    }) != nil
+                })
+        else {
             XCTFail("Failed to find the required registered image")
             return
         }
-        
+
         // Verify we got back the updated asset.
         XCTAssertEqual(assetUpdated.context, .download)
-        
+
         // Verify the asset is accessible in the downloads collection.
         var downloadsAfter = context.registeredDownloadsAssets(for: bundle.id)
         XCTAssertEqual(downloadsAfter.count, 2)
-        downloadsAfter.removeAll(where: { $0.variants.values.first?.lastPathComponent == "project.zip" })
+        downloadsAfter.removeAll(where: {
+            $0.variants.values.first?.lastPathComponent == "project.zip"
+        })
         XCTAssertEqual(downloadsAfter.count, 1)
         XCTAssertEqual(downloadsAfter.first?.variants.values.first?.lastPathComponent, "intro.png")
     }
@@ -656,139 +729,190 @@ class DocumentationContextTests: XCTestCase {
     @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
     func testCreatesCorrectIdentifiers() throws {
         let testBundleLocation = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-        let workspaceContent = Folder(name: "TestWorkspace", content: [
-            CopyOfFolder(original: testBundleLocation),
-            
-            Folder(name: "TestBundle2.docc", content: [
-                InfoPlist(displayName: "Test Bundle", identifier: "com.example.bundle2"),
-                CopyOfFolder(original: testBundleLocation, newName: "Subfolder", filter: { $0.lastPathComponent != "Info.plist" }),
+            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc",
+            subdirectory: "Test Bundles")!
+        let workspaceContent = Folder(
+            name: "TestWorkspace",
+            content: [
+                CopyOfFolder(original: testBundleLocation),
+
+                Folder(
+                    name: "TestBundle2.docc",
+                    content: [
+                        InfoPlist(displayName: "Test Bundle", identifier: "com.example.bundle2"),
+                        CopyOfFolder(
+                            original: testBundleLocation, newName: "Subfolder",
+                            filter: { $0.lastPathComponent != "Info.plist" }),
+                    ]),
             ])
-        ])
-        
+
         let tempURL = try createTemporaryDirectory()
-        
+
         let workspaceURL = try workspaceContent.write(inside: tempURL)
         let dataProvider = try LocalFileSystemDataProvider(rootURL: workspaceURL)
 
         let workspace = DocumentationWorkspace()
         try workspace.registerProvider(dataProvider)
-        
+
         let context = try DocumentationContext(dataProvider: workspace)
         let identifiers = context.knownIdentifiers
         let identifierSet = Set(identifiers)
         XCTAssertEqual(identifiers.count, identifierSet.count, "Found duplicate identifiers.")
     }
-    
+
     func testDetectsReferenceCollision() throws {
         let (_, context) = try testBundleAndContext(named: "TestBundleWithDupe")
 
-        let problemWithDuplicate = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
+        let problemWithDuplicate = context.problems.filter {
+            $0.diagnostic.identifier == "org.swift.docc.DuplicateReference"
+        }
 
         XCTAssertEqual(problemWithDuplicate.count, 1)
 
         let localizedSummary = try XCTUnwrap(problemWithDuplicate.first?.diagnostic.summary)
-        XCTAssertEqual(localizedSummary, "Redeclaration of 'TestTutorial.tutorial'; this file will be skipped")
+        XCTAssertEqual(
+            localizedSummary, "Redeclaration of 'TestTutorial.tutorial'; this file will be skipped")
 
     }
-    
+
     func testDetectsMultipleMarkdownFilesWithSameName() throws {
         let (_, context) = try testBundleAndContext(named: "TestBundleWithDupMD")
 
-        let problemWithDuplicateReference = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
+        let problemWithDuplicateReference = context.problems.filter {
+            $0.diagnostic.identifier == "org.swift.docc.DuplicateReference"
+        }
 
         XCTAssertEqual(problemWithDuplicateReference.count, 2)
 
-        let localizedSummary = try XCTUnwrap(problemWithDuplicateReference.first?.diagnostic.summary)
-        XCTAssertEqual(localizedSummary, "Redeclaration of \'overview.md\'; this file will be skipped")
+        let localizedSummary = try XCTUnwrap(
+            problemWithDuplicateReference.first?.diagnostic.summary)
+        XCTAssertEqual(
+            localizedSummary, "Redeclaration of \'overview.md\'; this file will be skipped")
 
-        let localizedSummarySecond = try XCTUnwrap(problemWithDuplicateReference[1].diagnostic.summary)
-        XCTAssertEqual(localizedSummarySecond, "Redeclaration of \'overview.md\'; this file will be skipped")
+        let localizedSummarySecond = try XCTUnwrap(
+            problemWithDuplicateReference[1].diagnostic.summary)
+        XCTAssertEqual(
+            localizedSummarySecond, "Redeclaration of \'overview.md\'; this file will be skipped")
     }
-    
+
     func testUsesMultipleDocExtensionFilesWithSameName() throws {
-        
+
         // Generate 2 different symbols with the same name.
-        let someSymbol = makeSymbol(id: "someEnumSymbol-id", kind: .init(rawValue: "enum"), pathComponents: ["SomeDirectory", "MyEnum"])
-        let anotherSymbol = makeSymbol(id: "anotherEnumSymbol-id", kind: .init(rawValue: "enum"), pathComponents: ["AnotherDirectory", "MyEnum"])
+        let someSymbol = makeSymbol(
+            id: "someEnumSymbol-id", kind: .init(rawValue: "enum"),
+            pathComponents: ["SomeDirectory", "MyEnum"])
+        let anotherSymbol = makeSymbol(
+            id: "anotherEnumSymbol-id", kind: .init(rawValue: "enum"),
+            pathComponents: ["AnotherDirectory", "MyEnum"])
         let symbols: [SymbolGraph.Symbol] = [someSymbol, anotherSymbol]
-        
+
         // Create a catalog with doc extension files with the same filename for each symbol.
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    symbols: symbols
-                )),
-                
-                Folder(name: "SomeDirectory", content: [
-                    TextFile(name: "MyEnum.md", utf8Content:
-                        """
-                        # ``SomeDirectory/MyEnum``
-                        
-                        A documentation extension for my enum.
-                        """
-                    )
-                ]),
-                
-                Folder(name: "AnotherDirectory", content: [
-                    TextFile(name: "MyEnum.md", utf8Content:
-                        """
-                        # ``AnotherDirectory/MyEnum``
-                        
-                        A documentation extension for an unrelated enum.
-                        """
-                    )
-                ]),
-                
-                // An unrelated article that happens to have the same filename
-                TextFile(name: "MyEnum.md", utf8Content:
-                    """
-                    # MyEnum
-                    
-                    Here is a regular article about MyEnum.
-                    """
-                )
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            symbols: symbols
+                        )),
+
+                    Folder(
+                        name: "SomeDirectory",
+                        content: [
+                            TextFile(
+                                name: "MyEnum.md",
+                                utf8Content:
+                                    """
+                                    # ``SomeDirectory/MyEnum``
+
+                                    A documentation extension for my enum.
+                                    """
+                            )
+                        ]),
+
+                    Folder(
+                        name: "AnotherDirectory",
+                        content: [
+                            TextFile(
+                                name: "MyEnum.md",
+                                utf8Content:
+                                    """
+                                    # ``AnotherDirectory/MyEnum``
+
+                                    A documentation extension for an unrelated enum.
+                                    """
+                            )
+                        ]),
+
+                    // An unrelated article that happens to have the same filename
+                    TextFile(
+                        name: "MyEnum.md",
+                        utf8Content:
+                            """
+                            # MyEnum
+
+                            Here is a regular article about MyEnum.
+                            """
+                    ),
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
 
         // Since documentation extensions' filenames have no impact on the URL of pages, we should not see warnings enforcing unique filenames for them.
-        let problemWithDuplicateReference = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
+        let problemWithDuplicateReference = context.problems.filter {
+            $0.diagnostic.identifier == "org.swift.docc.DuplicateReference"
+        }
         XCTAssertEqual(problemWithDuplicateReference.count, 0)
-        
+
         // Ensure the content from both documentation extensions was used.
         let someEnumNode = try XCTUnwrap(context.documentationCache["someEnumSymbol-id"])
         let someEnumSymbol = try XCTUnwrap(someEnumNode.semantic as? Symbol)
-        XCTAssertEqual(someEnumSymbol.abstract?.plainText, "A documentation extension for my enum.", "The abstract should be from the symbol's documentation extension.")
-        
+        XCTAssertEqual(
+            someEnumSymbol.abstract?.plainText, "A documentation extension for my enum.",
+            "The abstract should be from the symbol's documentation extension.")
+
         let anotherEnumNode = try XCTUnwrap(context.documentationCache["anotherEnumSymbol-id"])
         let anotherEnumSymbol = try XCTUnwrap(anotherEnumNode.semantic as? Symbol)
-        XCTAssertEqual(anotherEnumSymbol.abstract?.plainText, "A documentation extension for an unrelated enum.", "The abstract should be from the symbol's documentation extension.")
+        XCTAssertEqual(
+            anotherEnumSymbol.abstract?.plainText,
+            "A documentation extension for an unrelated enum.",
+            "The abstract should be from the symbol's documentation extension.")
     }
 
     func testGraphChecks() throws {
         var configuration = DocumentationContext.Configuration()
         configuration.topicAnalysisConfiguration.additionalChecks.append(
             { (context, reference) -> [Problem] in
-                [Problem(diagnostic: Diagnostic(source: reference.url, severity: DiagnosticSeverity.error, range: nil, identifier: "com.tests.testGraphChecks", summary: "test error"), possibleSolutions: [])]
+                [
+                    Problem(
+                        diagnostic: Diagnostic(
+                            source: reference.url, severity: DiagnosticSeverity.error, range: nil,
+                            identifier: "com.tests.testGraphChecks", summary: "test error"),
+                        possibleSolutions: [])
+                ]
             }
         )
-        
-        let catalog = Folder(name: "unit-test.docc", content: [
-            TextFile(name: "Root.md", utf8Content: """
-            # Some root page
-            """)
-        ])
+
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                TextFile(
+                    name: "Root.md",
+                    utf8Content: """
+                        # Some root page
+                        """)
+            ])
         let (_, context) = try loadBundle(catalog: catalog, configuration: configuration)
-        
+
         /// Checks if the custom check added problems to the context.
         let testProblems = context.problems.filter({ (problem) -> Bool in
             return problem.diagnostic.identifier == "com.tests.testGraphChecks"
         })
         XCTAssertTrue(!testProblems.isEmpty)
     }
-    
+
     func testSupportedAssetTypes() throws {
         for ext in ["jpg", "jpeg", "png", "JPG", "PNG", "PnG", "jPg", "svg", "gif"] {
             XCTAssertTrue(DocumentationContext.isFileExtension(ext, supported: .image))
@@ -803,459 +927,613 @@ class DocumentationContextTests: XCTestCase {
             XCTAssertFalse(DocumentationContext.isFileExtension(ext, supported: .video))
         }
     }
-    
+
     func testIgnoresUnknownMarkupFiles() throws {
-        let testCatalog = Folder(name: "TestIgnoresUnknownMarkupFiles.docc", content: [
-            InfoPlist(displayName: "TestIgnoresUnknownMarkupFiles", identifier: "com.example.documentation"),
-            Folder(name: "Resources", content: [
-                TextFile(name: "Article1.tutorial", utf8Content: "@Article"),
-                TextFile(name: "Article2.md", utf8Content: "notvalid"),
+        let testCatalog = Folder(
+            name: "TestIgnoresUnknownMarkupFiles.docc",
+            content: [
+                InfoPlist(
+                    displayName: "TestIgnoresUnknownMarkupFiles",
+                    identifier: "com.example.documentation"),
+                Folder(
+                    name: "Resources",
+                    content: [
+                        TextFile(name: "Article1.tutorial", utf8Content: "@Article"),
+                        TextFile(name: "Article2.md", utf8Content: "notvalid"),
+                    ]),
             ])
-        ])
-        
+
         let (_, context) = try loadBundle(catalog: testCatalog)
-        
-        XCTAssertEqual(context.knownPages.map { $0.path }, ["/tutorials/TestIgnoresUnknownMarkupFiles/Article1"])
-        XCTAssertTrue(context.problems.map { $0.diagnostic.identifier }.contains("org.swift.docc.Article.Title.NotFound"))
+
+        XCTAssertEqual(
+            context.knownPages.map { $0.path },
+            ["/tutorials/TestIgnoresUnknownMarkupFiles/Article1"])
+        XCTAssertTrue(
+            context.problems.map { $0.diagnostic.identifier }.contains(
+                "org.swift.docc.Article.Title.NotFound"))
     }
-    
+
     func testLoadsSymbolData() throws {
-        let testCatalog = Folder(name: "TestIgnoresUnknownMarkupFiles.docc", content: [
-            InfoPlist(displayName: "TestIgnoresUnknownMarkupFiles", identifier: "com.example.documentation"),
-            Folder(name: "Resources", content: [
-                CopyOfFile(original: Bundle.module.url(
-                    forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-                    .appendingPathComponent("documentation")
-                    .appendingPathComponent("myprotocol.md")),
-            ]),
-            Folder(name: "Symbols", content: [
-                CopyOfFile(original: Bundle.module.url(
-                    forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-                    .appendingPathComponent("mykit-iOS.symbols.json")),
+        let testCatalog = Folder(
+            name: "TestIgnoresUnknownMarkupFiles.docc",
+            content: [
+                InfoPlist(
+                    displayName: "TestIgnoresUnknownMarkupFiles",
+                    identifier: "com.example.documentation"),
+                Folder(
+                    name: "Resources",
+                    content: [
+                        CopyOfFile(
+                            original: Bundle.module.url(
+                                forResource: "LegacyBundle_DoNotUseInNewTests",
+                                withExtension: "docc", subdirectory: "Test Bundles")!
+                                .appendingPathComponent("documentation")
+                                .appendingPathComponent("myprotocol.md"))
+                    ]),
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        CopyOfFile(
+                            original: Bundle.module.url(
+                                forResource: "LegacyBundle_DoNotUseInNewTests",
+                                withExtension: "docc", subdirectory: "Test Bundles")!
+                                .appendingPathComponent("mykit-iOS.symbols.json"))
+                    ]),
             ])
-        ])
-        
+
         let (_, context) = try loadBundle(catalog: testCatalog)
-        
+
         // Symbols are loaded
         XCTAssertFalse(context.documentationCache.isEmpty)
-        
+
         // MyClass is loaded
         guard let myClass = context.documentationCache["s:5MyKit0A5ClassC"] else {
             XCTFail("`MyClass` not found in symbol graph")
             return
         }
-        
+
         //
         // Test the MyClass documentation node
         //
         let markupModel = DocumentationMarkup(markup: myClass.markup)
-        
+
         XCTAssertEqual(myClass.name.description, "MyClass")
-        XCTAssertEqual(myClass.reference.absoluteString, "doc://com.example.documentation/documentation/MyKit/MyClass")
+        XCTAssertEqual(
+            myClass.reference.absoluteString,
+            "doc://com.example.documentation/documentation/MyKit/MyClass")
         XCTAssertNil(markupModel.abstractSection)
         XCTAssertNil(markupModel.discussionSection)
         XCTAssertNil(markupModel.seeAlsoSection)
         XCTAssertEqual(myClass.kind, DocumentationNode.Kind.class)
         XCTAssertEqual(myClass.sourceLanguage, SourceLanguage.swift)
-        
+
         // Verify topics are empty
         XCTAssertNil(markupModel.topicsSection)
         XCTAssertNil(markupModel.seeAlsoSection)
-        
+
         XCTAssertTrue(myClass.semantic is Symbol)
         guard let myClassSymbol = myClass.semantic as? Symbol else { return }
-        
+
         //
         // Test the MyClass Symbol
         //
 
         // The two types are equatable but XCTAssertEqual doesn't catch that.
         XCTAssertTrue(myClassSymbol.kind.identifier == SymbolGraph.Symbol.KindIdentifier.class)
-        XCTAssertNotNil(myClassSymbol.availability?.availability.first(where: { (availability) -> Bool in
-            if let domain = availability.domain, let introduced = availability.introducedVersion, domain.rawValue == "macOS", introduced.major == 10, introduced.minor == 15 {
-                return true
-            }
-            return false
-        }))
-        
-        XCTAssertEqual(Array(myClassSymbol.declaration.keys), [[PlatformName(operatingSystemName: "ios")]])
-        XCTAssertEqual(myClassSymbol.declaration[[PlatformName(operatingSystemName: "ios")]]?.declarationFragments.map { $0.spelling }.joined(), "class MyClass")
-        XCTAssertEqual(myClassSymbol.moduleReference.absoluteString, "doc://com.example.documentation/documentation/MyKit")
-        XCTAssertTrue(myClassSymbol.relationships.groups.contains { group -> Bool in
-            return group.kind == .conformsTo && Array(group.destinations.map({ $0.url?.absoluteString })) == ["doc://com.example.documentation/documentation/MyKit/MyProtocol"]
-        })
+        XCTAssertNotNil(
+            myClassSymbol.availability?.availability.first(where: { (availability) -> Bool in
+                if let domain = availability.domain,
+                    let introduced = availability.introducedVersion, domain.rawValue == "macOS",
+                    introduced.major == 10, introduced.minor == 15
+                {
+                    return true
+                }
+                return false
+            }))
+
+        XCTAssertEqual(
+            Array(myClassSymbol.declaration.keys), [[PlatformName(operatingSystemName: "ios")]])
+        XCTAssertEqual(
+            myClassSymbol.declaration[[PlatformName(operatingSystemName: "ios")]]?
+                .declarationFragments.map { $0.spelling }.joined(), "class MyClass")
+        XCTAssertEqual(
+            myClassSymbol.moduleReference.absoluteString,
+            "doc://com.example.documentation/documentation/MyKit")
+        XCTAssertTrue(
+            myClassSymbol.relationships.groups.contains { group -> Bool in
+                return group.kind == .conformsTo
+                    && Array(group.destinations.map({ $0.url?.absoluteString })) == [
+                        "doc://com.example.documentation/documentation/MyKit/MyProtocol"
+                    ]
+            })
         XCTAssertEqual(myClassSymbol.platformName, PlatformName(operatingSystemName: "ios"))
         XCTAssertEqual(myClassSymbol.roleHeading, "Class")
         XCTAssertEqual(myClassSymbol.title, "MyClass")
-        
+
         //
         // Test MyClass' children
         //
-        
+
         let functionChildrenRefs = context.children(of: myClass.reference)
-        
+
         // Find a match with the specific path as `functionChildrenRefs` order is random.
-        guard let childReference = functionChildrenRefs.first(where: { $0.reference.path == "/documentation/MyKit/MyClass/myFunction()" })?.reference else {
+        guard
+            let childReference = functionChildrenRefs.first(where: {
+                $0.reference.path == "/documentation/MyKit/MyClass/myFunction()"
+            })?.reference
+        else {
             XCTFail("No children found of MyClass")
             return
         }
-        
+
         guard let parent = context.parents(of: childReference).first else {
             XCTFail("No parent found for myFunction()")
             return
         }
         XCTAssertTrue(parent.path.hasSuffix("MyKit/MyClass"))
-        
+
         //
         // Test sidecar documentation
         //
-        
+
         // MyProtocol is loaded
         guard let myProtocol = context.documentationCache["s:5MyKit0A5ProtocolP"],
-            let myProtocolSymbol = myProtocol.semantic as? Symbol else {
+            let myProtocolSymbol = myProtocol.semantic as? Symbol
+        else {
             XCTFail("`MyProtocol` not found in symbol graph")
             return
         }
-        
+
         XCTAssertEqual(myProtocolSymbol.title, "MyProtocol")
-        XCTAssertEqual(myProtocolSymbol.abstractSection?.content.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n"),
-                       """
-                       Text "An abstract of a protocol using a "
-                       InlineCode `String`
-                       Text " id value."
-                       """)
+        XCTAssertEqual(
+            myProtocolSymbol.abstractSection?.content.map {
+                $0.detachedFromParent.debugDescription()
+            }.joined(separator: "\n"),
+            """
+            Text "An abstract of a protocol using a "
+            InlineCode `String`
+            Text " id value."
+            """)
 
+        XCTAssertEqual(
+            myProtocolSymbol.discussion?.content.map { $0.detachedFromParent.debugDescription() }
+                .joined(separator: "\n\n"),
+            """
+            Heading level: 2
+            └─ Text "Discussion"
 
-        XCTAssertEqual(myProtocolSymbol.discussion?.content.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n\n"),
-                        """
-                        Heading level: 2
-                        └─ Text "Discussion"
+            Paragraph
+            └─ Text "Further discussion."
 
-                        Paragraph
-                        └─ Text "Further discussion."
+            Paragraph
+            ├─ Text "Exercise links to symbols: relative "
+            ├─ SymbolLink destination: doc://com.example.documentation/documentation/MyKit/MyClass
+            ├─ Text " and absolute "
+            ├─ SymbolLink destination: doc://com.example.documentation/documentation/MyKit/MyClass
+            └─ Text "."
 
-                        Paragraph
-                        ├─ Text "Exercise links to symbols: relative "
-                        ├─ SymbolLink destination: doc://com.example.documentation/documentation/MyKit/MyClass
-                        ├─ Text " and absolute "
-                        ├─ SymbolLink destination: doc://com.example.documentation/documentation/MyKit/MyClass
-                        └─ Text "."
+            Paragraph
+            ├─ Text "Exercise unresolved symbols: unresolved "
+            ├─ SymbolLink destination: MyUnresolvedSymbol
+            └─ Text "."
 
-                        Paragraph
-                        ├─ Text "Exercise unresolved symbols: unresolved "
-                        ├─ SymbolLink destination: MyUnresolvedSymbol
-                        └─ Text "."
+            Paragraph
+            ├─ Text "Exercise known unresolvable symbols: know unresolvable "
+            ├─ SymbolLink destination: NSCodable
+            └─ Text "."
 
-                        Paragraph
-                        ├─ Text "Exercise known unresolvable symbols: know unresolvable "
-                        ├─ SymbolLink destination: NSCodable
-                        └─ Text "."
+            Paragraph
+            ├─ Text "Exercise external references: "
+            └─ Link destination: "doc://com.test.external/ExternalPage"
+               └─ Text "doc://com.test.external/ExternalPage"
 
-                        Paragraph
-                        ├─ Text "Exercise external references: "
-                        └─ Link destination: "doc://com.test.external/ExternalPage"
-                           └─ Text "doc://com.test.external/ExternalPage"
+            OrderedList
+            ├─ ListItem
+            │  └─ Paragraph
+            │     └─ Text "One ordered"
+            ├─ ListItem
+            │  └─ Paragraph
+            │     └─ Text "Two ordered"
+            └─ ListItem
+               └─ Paragraph
+                  └─ Text "Three ordered"
 
-                        OrderedList
-                        ├─ ListItem
-                        │  └─ Paragraph
-                        │     └─ Text "One ordered"
-                        ├─ ListItem
-                        │  └─ Paragraph
-                        │     └─ Text "Two ordered"
-                        └─ ListItem
-                           └─ Paragraph
-                              └─ Text "Three ordered"
+            UnorderedList
+            ├─ ListItem
+            │  └─ Paragraph
+            │     └─ Text "One unordered"
+            ├─ ListItem
+            │  └─ Paragraph
+            │     └─ Text "Two unordered"
+            └─ ListItem
+               └─ Paragraph
+                  └─ Text "Three unordered"
 
-                        UnorderedList
-                        ├─ ListItem
-                        │  └─ Paragraph
-                        │     └─ Text "One unordered"
-                        ├─ ListItem
-                        │  └─ Paragraph
-                        │     └─ Text "Two unordered"
-                        └─ ListItem
-                           └─ Paragraph
-                              └─ Text "Three unordered"
+            OrderedList startIndex: 2
+            ├─ ListItem
+            │  └─ Paragraph
+            │     └─ Text "Two ordered with custom start"
+            ├─ ListItem
+            │  └─ Paragraph
+            │     └─ Text "Three ordered with custom start"
+            └─ ListItem
+               └─ Paragraph
+                  └─ Text "Four ordered with custom start"
+            """)
 
-                        OrderedList startIndex: 2
-                        ├─ ListItem
-                        │  └─ Paragraph
-                        │     └─ Text "Two ordered with custom start"
-                        ├─ ListItem
-                        │  └─ Paragraph
-                        │     └─ Text "Three ordered with custom start"
-                        └─ ListItem
-                           └─ Paragraph
-                              └─ Text "Four ordered with custom start"
-                        """)
+        XCTAssertEqual(
+            myProtocolSymbol.declaration.values.first?.declarationFragments.map({ $0.spelling }),
+            ["protocol", " ", "MyProtocol", " : ", "Hashable"])
+        XCTAssertEqual(
+            myProtocolSymbol.declaration.values.first?.declarationFragments.map({
+                $0.preciseIdentifier
+            }), [nil, nil, nil, nil, "p:hPP"])
 
-        XCTAssertEqual(myProtocolSymbol.declaration.values.first?.declarationFragments.map({ $0.spelling }), ["protocol", " ", "MyProtocol", " : ", "Hashable"])
-        XCTAssertEqual(myProtocolSymbol.declaration.values.first?.declarationFragments.map({ $0.preciseIdentifier }), [nil, nil, nil, nil, "p:hPP"])
-
-        XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.heading?.detachedFromParent.debugDescription(),
-                        """
-                        Heading level: 3
-                        └─ Text "Task Group Exercising Symbol Links"
-                        """)
+        XCTAssertEqual(
+            myProtocolSymbol.topics?.taskGroups.first?.heading?.detachedFromParent
+                .debugDescription(),
+            """
+            Heading level: 3
+            └─ Text "Task Group Exercising Symbol Links"
+            """)
         XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.links.count, 3)
-        XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.links[0].destination, "doc://com.example.documentation/documentation/MyKit/MyClass")
-        XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.links[1].destination, "doc://com.example.documentation/documentation/MyKit/MyClass")
-        XCTAssertEqual(myProtocolSymbol.topics?.taskGroups.first?.links[2].destination, "doc://com.example.documentation/documentation/MyKit/MyClass")
+        XCTAssertEqual(
+            myProtocolSymbol.topics?.taskGroups.first?.links[0].destination,
+            "doc://com.example.documentation/documentation/MyKit/MyClass")
+        XCTAssertEqual(
+            myProtocolSymbol.topics?.taskGroups.first?.links[1].destination,
+            "doc://com.example.documentation/documentation/MyKit/MyClass")
+        XCTAssertEqual(
+            myProtocolSymbol.topics?.taskGroups.first?.links[2].destination,
+            "doc://com.example.documentation/documentation/MyKit/MyClass")
 
-        XCTAssertEqual(myProtocolSymbol.seeAlso?.taskGroups.first?.heading?.detachedFromParent.debugDescription(),
-        """
-        Heading level: 3
-        └─ Text "Related Documentation"
-        """)
+        XCTAssertEqual(
+            myProtocolSymbol.seeAlso?.taskGroups.first?.heading?.detachedFromParent
+                .debugDescription(),
+            """
+            Heading level: 3
+            └─ Text "Related Documentation"
+            """)
         XCTAssertEqual(myProtocolSymbol.seeAlso?.taskGroups.first?.links.count, 5)
-        XCTAssertEqual(myProtocolSymbol.seeAlso?.taskGroups.first?.links.first?.destination, "doc://com.example.documentation/documentation/MyKit/MyClass")
+        XCTAssertEqual(
+            myProtocolSymbol.seeAlso?.taskGroups.first?.links.first?.destination,
+            "doc://com.example.documentation/documentation/MyKit/MyClass")
 
-        XCTAssertEqual(myProtocolSymbol.returnsSection?.content.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n"),
-                       """
-                       Paragraph
-                       ├─ Text "A "
-                       ├─ InlineCode `String`
-                       └─ Text " id value."
-                       """)
+        XCTAssertEqual(
+            myProtocolSymbol.returnsSection?.content.map {
+                $0.detachedFromParent.debugDescription()
+            }.joined(separator: "\n"),
+            """
+            Paragraph
+            ├─ Text "A "
+            ├─ InlineCode `String`
+            └─ Text " id value."
+            """)
 
-        XCTAssertEqual(myProtocolSymbol.parametersSection?.parameters.first?.contents.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n"),
-                       """
-                       Paragraph
-                       └─ Text "A name of the item to find."
-                       """)
+        XCTAssertEqual(
+            myProtocolSymbol.parametersSection?.parameters.first?.contents.map {
+                $0.detachedFromParent.debugDescription()
+            }.joined(separator: "\n"),
+            """
+            Paragraph
+            └─ Text "A name of the item to find."
+            """)
 
         //
         // Test doc comments are parsed correctly
         //
-        
-        guard let functionSymbol = try context.entity(with: childReference).semantic as? Symbol else {
+
+        guard let functionSymbol = try context.entity(with: childReference).semantic as? Symbol
+        else {
             XCTFail("myFunction() not resolved")
             return
         }
-        
-        XCTAssertEqual(functionSymbol.abstractSection?.content.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n"),
-                       """
-                       Text "A cool API to call."
-                       """)
+
+        XCTAssertEqual(
+            functionSymbol.abstractSection?.content.map { $0.detachedFromParent.debugDescription() }
+                .joined(separator: "\n"),
+            """
+            Text "A cool API to call."
+            """)
         XCTAssertEqual(functionSymbol.discussion?.content.isEmpty, true)
         guard let parameter = functionSymbol.parametersSection?.parameters.first else {
             XCTFail("myFunction() parameter not found")
             return
         }
         XCTAssertEqual(parameter.name, "name")
-        XCTAssertEqual(parameter.contents.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n"),
-                       """
-                       Paragraph
-                       └─ Text "A parameter"
-                       """)
-        XCTAssertEqual(functionSymbol.returnsSection?.content.map { $0.detachedFromParent.debugDescription() }.joined(separator: "\n"),
-                       """
-                       Paragraph
-                       └─ Text "Return value"
-                       """)
+        XCTAssertEqual(
+            parameter.contents.map { $0.detachedFromParent.debugDescription() }.joined(
+                separator: "\n"),
+            """
+            Paragraph
+            └─ Text "A parameter"
+            """)
+        XCTAssertEqual(
+            functionSymbol.returnsSection?.content.map { $0.detachedFromParent.debugDescription() }
+                .joined(separator: "\n"),
+            """
+            Paragraph
+            └─ Text "Return value"
+            """)
     }
-    
-    func testMergesMultipleSymbolDeclarations() throws {
-        let graphContentiOS = try String(contentsOf: Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-            .appendingPathComponent("mykit-iOS.symbols.json"))
 
-        let graphContentmacOS = graphContentiOS
+    func testMergesMultipleSymbolDeclarations() throws {
+        let graphContentiOS = try String(
+            contentsOf: Bundle.module.url(
+                forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc",
+                subdirectory: "Test Bundles")!
+                .appendingPathComponent("mykit-iOS.symbols.json"))
+
+        let graphContentmacOS =
+            graphContentiOS
             .replacingOccurrences(of: "\"name\" : \"ios\"", with: "\"name\" : \"macosx\"")
 
-        let graphContenttvOS = graphContentiOS
+        let graphContenttvOS =
+            graphContentiOS
             .replacingOccurrences(of: "\"name\" : \"ios\"", with: "\"name\" : \"tvos\"")
-            .replacingOccurrences(of: "\"spelling\" : \"MyClass\"", with: "\"spelling\" : \"MyClassTV\"")
-        
-        let testCatalog = Folder(name: "TestIgnoresUnknownMarkupFiles.docc", content: [
-            InfoPlist(displayName: "TestIgnoresUnknownMarkupFiles", identifier: "com.example.documentation"),
-            Folder(name: "Symbols", content: [
-                TextFile(name: "mykit-iOS.symbols.json", utf8Content: graphContentiOS),
-                TextFile(name: "mykit-macOS.symbols.json", utf8Content: graphContentmacOS),
-                TextFile(name: "mykit-tvOS.symbols.json", utf8Content: graphContenttvOS),
-            ]),
-        ])
-        
+            .replacingOccurrences(
+                of: "\"spelling\" : \"MyClass\"", with: "\"spelling\" : \"MyClassTV\"")
+
+        let testCatalog = Folder(
+            name: "TestIgnoresUnknownMarkupFiles.docc",
+            content: [
+                InfoPlist(
+                    displayName: "TestIgnoresUnknownMarkupFiles",
+                    identifier: "com.example.documentation"),
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        TextFile(name: "mykit-iOS.symbols.json", utf8Content: graphContentiOS),
+                        TextFile(name: "mykit-macOS.symbols.json", utf8Content: graphContentmacOS),
+                        TextFile(name: "mykit-tvOS.symbols.json", utf8Content: graphContenttvOS),
+                    ]),
+            ])
+
         let (_, context) = try loadBundle(catalog: testCatalog)
-        
+
         // MyClass is loaded
         guard let myClass = context.documentationCache["s:5MyKit0A5ClassC"],
-            let myClassSymbol = myClass.semantic as? Symbol else {
+            let myClassSymbol = myClass.semantic as? Symbol
+        else {
             XCTFail("`MyClass` not found in symbol graph")
             return
         }
-        
+
         // Test that the declarations are grouped correctly
         XCTAssertNotNil(myClassSymbol.declaration[[PlatformName(operatingSystemName: "tvos")]])
-        
+
         // The order of the platforms is not guaranteed.
-        XCTAssertNotNil(myClassSymbol.declaration[[PlatformName(operatingSystemName: "ios"), PlatformName(operatingSystemName: "macos")]] ?? myClassSymbol.declaration[[PlatformName(operatingSystemName: "macos"), PlatformName(operatingSystemName: "ios")]])
+        XCTAssertNotNil(
+            myClassSymbol.declaration[[
+                PlatformName(operatingSystemName: "ios"),
+                PlatformName(operatingSystemName: "macos"),
+            ]]
+                ?? myClassSymbol.declaration[[
+                    PlatformName(operatingSystemName: "macos"),
+                    PlatformName(operatingSystemName: "ios"),
+                ]])
     }
-    
+
     func testMergedMultipleSymbolDeclarationsIncludesPlatformSpecificSymbols() throws {
         let iOSGraphURL = Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
+            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc",
+            subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json")
         let graphContentiOS = try String(contentsOf: iOSGraphURL)
 
         var graph = try JSONDecoder().decode(SymbolGraph.self, from: Data(contentsOf: iOSGraphURL))
         // Remove the original MyClass symbol
         let myFunctionSymbolPreciseIdentifier = "s:5MyKit0A5ClassC10myFunctionyyF"
-        guard let myFunctionSymbol = graph.symbols.removeValue(forKey: myFunctionSymbolPreciseIdentifier) else {
+        guard
+            let myFunctionSymbol = graph.symbols.removeValue(
+                forKey: myFunctionSymbolPreciseIdentifier)
+        else {
             XCTFail("`myFunction` not found in iOS symbol graph")
             return
         }
-        
+
         // Add a modified PlatformSpecificFunctionSymbolPreciseIdentifier symbol
         var myPlatformSpecificFunctionSymbol = myFunctionSymbol
         let myPlatformSpecificFunctionName = "myPlatformSpecificFunction"
         myPlatformSpecificFunctionSymbol.names.title = myPlatformSpecificFunctionName
-        myPlatformSpecificFunctionSymbol.identifier.precise = "s:5MyKit0A\(myPlatformSpecificFunctionName.count)\(myPlatformSpecificFunctionName)C"
-        
-        graph.symbols[myPlatformSpecificFunctionSymbol.identifier.precise] = myPlatformSpecificFunctionSymbol
-        
+        myPlatformSpecificFunctionSymbol.identifier.precise =
+            "s:5MyKit0A\(myPlatformSpecificFunctionName.count)\(myPlatformSpecificFunctionName)C"
+
+        graph.symbols[myPlatformSpecificFunctionSymbol.identifier.precise] =
+            myPlatformSpecificFunctionSymbol
+
         // Change the graph platform
         graph.module = SymbolGraph.Module(
             name: graph.module.name,
-            platform: .init(architecture: "x86_64", vendor: "apple", operatingSystem: .init(name: "macos")),
+            platform: .init(
+                architecture: "x86_64", vendor: "apple", operatingSystem: .init(name: "macos")),
             version: .init(major: 10, minor: 15, patch: 0)
         )
-        
+
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
         let newGraphContent = try String(data: encoder.encode(graph), encoding: .utf8)!
-        
-        let testCatalog = Folder(name: "TestIgnoresUnknownMarkupFiles.docc", content: [
-            InfoPlist(displayName: "TestIgnoresUnknownMarkupFiles", identifier: "com.example.documentation"),
-            Folder(name: "Symbols", content: [
-                TextFile(name: "mykit-iOS.symbols.json", utf8Content: graphContentiOS),
-                TextFile(name: "mykit-macOS.symbols.json", utf8Content: newGraphContent),
+
+        let testCatalog = Folder(
+            name: "TestIgnoresUnknownMarkupFiles.docc",
+            content: [
+                InfoPlist(
+                    displayName: "TestIgnoresUnknownMarkupFiles",
+                    identifier: "com.example.documentation"),
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        TextFile(name: "mykit-iOS.symbols.json", utf8Content: graphContentiOS),
+                        TextFile(name: "mykit-macOS.symbols.json", utf8Content: newGraphContent),
+                    ]),
             ])
-        ])
-        
+
         let (_, context) = try loadBundle(catalog: testCatalog)
-        
+
         // MyFunction is loaded
-        XCTAssertNotNil(context.documentationCache[myFunctionSymbolPreciseIdentifier], "myFunction which only exist on iOS should be found in the graph")
-        XCTAssertNotNil(context.documentationCache[myPlatformSpecificFunctionSymbol.identifier.precise], "The new platform specific function should be found in the graph")
-        
+        XCTAssertNotNil(
+            context.documentationCache[myFunctionSymbolPreciseIdentifier],
+            "myFunction which only exist on iOS should be found in the graph")
+        XCTAssertNotNil(
+            context.documentationCache[myPlatformSpecificFunctionSymbol.identifier.precise],
+            "The new platform specific function should be found in the graph")
+
         XCTAssertEqual(
             context.documentationCache.count,
-            graph.symbols.count + 1 /* for the module */ + 1 /* for the new platform specific function */,
+            graph.symbols.count + 1 /* for the module */
+                + 1 /* for the new platform specific function */,
             "Together the two graphs contain one symbol more than they do individually"
         )
     }
-    
+
     func testResolvesSymbolsBetweenSymbolGraphs() throws {
-        let testCatalog = Folder(name: "CrossGraphResolving.docc", content: [
-            InfoPlist(displayName: "CrossGraphResolving", identifier: "com.example.documentation"),
-            Folder(name: "Resources", content: [
-            ]),
-            Folder(name: "Symbols", content: [
-                CopyOfFile(original: Bundle.module.url(
-                    forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-                    .appendingPathComponent("mykit-iOS.symbols.json")),
-                CopyOfFile(original: Bundle.module.url(
-                    forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-                    .appendingPathComponent("sidekit.symbols.json")),
+        let testCatalog = Folder(
+            name: "CrossGraphResolving.docc",
+            content: [
+                InfoPlist(
+                    displayName: "CrossGraphResolving", identifier: "com.example.documentation"),
+                Folder(name: "Resources", content: []),
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        CopyOfFile(
+                            original: Bundle.module.url(
+                                forResource: "LegacyBundle_DoNotUseInNewTests",
+                                withExtension: "docc", subdirectory: "Test Bundles")!
+                                .appendingPathComponent("mykit-iOS.symbols.json")),
+                        CopyOfFile(
+                            original: Bundle.module.url(
+                                forResource: "LegacyBundle_DoNotUseInNewTests",
+                                withExtension: "docc", subdirectory: "Test Bundles")!
+                                .appendingPathComponent("sidekit.symbols.json")),
+                    ]),
             ])
-        ])
-        
+
         let (_, context) = try loadBundle(catalog: testCatalog)
-        
+
         // SideClass is loaded
         guard let sideClass = context.documentationCache["s:7SideKit0A5ClassC"],
-            let sideClassSymbol = sideClass.semantic as? Symbol else {
+            let sideClassSymbol = sideClass.semantic as? Symbol
+        else {
             XCTFail("`SideClass` not found in symbol graph")
             return
         }
-        
+
         // Test that the relationship has been resolved correctly
-        XCTAssertNotNil(sideClassSymbol.relationships.groups.first { (group) -> Bool in
-            return group.kind == .conformsTo && group.destinations.map({ $0.url?.absoluteString }) == ["doc://com.example.documentation/documentation/MyKit/MyProtocol"]
-        })
+        XCTAssertNotNil(
+            sideClassSymbol.relationships.groups.first { (group) -> Bool in
+                return group.kind == .conformsTo
+                    && group.destinations.map({ $0.url?.absoluteString }) == [
+                        "doc://com.example.documentation/documentation/MyKit/MyProtocol"
+                    ]
+            })
     }
 
     func testLoadsDeclarationWithNoOS() throws {
-        var graphContentiOS = try String(contentsOf: Bundle.module.url(
-            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-            .appendingPathComponent("mykit-iOS.symbols.json"))
-        
+        var graphContentiOS = try String(
+            contentsOf: Bundle.module.url(
+                forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc",
+                subdirectory: "Test Bundles")!
+                .appendingPathComponent("mykit-iOS.symbols.json"))
+
         // "remove" the operating system information
-        graphContentiOS = graphContentiOS.replacingOccurrences(of: "\"operatingSystem\"", with: "\"ignored\"")
-        
-        let testCatalog = Folder(name: "NoOSDeclaration.docc", content: [
-            InfoPlist(displayName: "NoOSDeclaration", identifier: "com.example.documentation"),
-            Folder(name: "Resources", content: []),
-            Folder(name: "Symbols", content: [
-                TextFile(name: "mykit-iOS.symbols.json", utf8Content: graphContentiOS),
+        graphContentiOS = graphContentiOS.replacingOccurrences(
+            of: "\"operatingSystem\"", with: "\"ignored\"")
+
+        let testCatalog = Folder(
+            name: "NoOSDeclaration.docc",
+            content: [
+                InfoPlist(displayName: "NoOSDeclaration", identifier: "com.example.documentation"),
+                Folder(name: "Resources", content: []),
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        TextFile(name: "mykit-iOS.symbols.json", utf8Content: graphContentiOS)
+                    ]),
             ])
-        ])
-        
+
         let (_, context) = try loadBundle(catalog: testCatalog)
-        
+
         // MyClass is loaded
         guard let myClass = context.documentationCache["s:5MyKit0A5ClassC"],
-            let myClassSymbol = myClass.semantic as? Symbol else {
+            let myClassSymbol = myClass.semantic as? Symbol
+        else {
             XCTFail("`MyClass` not found in symbol graph")
             return
         }
-        
+
         // Test that the declarations are grouped correctly
         XCTAssertNotNil(myClassSymbol.declaration[[nil]])
     }
-    
+
     func testDetectsDuplicateSymbolArticles() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
-                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
-            ])),
-            
-            TextFile(name: "first.md", utf8Content: """
-            # ``SomeClass``
-            
-            The first documentation extension for this class
-            """),
-            
-            TextFile(name: "second.md", utf8Content: """
-            # ``/ModuleName/SomeClass``
-            
-            The second documentation extension for this class
-            """),
-        ])
-        
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "ModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
+                        ])),
+
+                TextFile(
+                    name: "first.md",
+                    utf8Content: """
+                        # ``SomeClass``
+
+                        The first documentation extension for this class
+                        """),
+
+                TextFile(
+                    name: "second.md",
+                    utf8Content: """
+                        # ``/ModuleName/SomeClass``
+
+                        The second documentation extension for this class
+                        """),
+            ])
+
         let (bundle, context) = try loadBundle(catalog: catalog)
 
-        let duplicateExtensionProblems = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateMarkdownTitleSymbolReferences" }
+        let duplicateExtensionProblems = context.problems.filter {
+            $0.diagnostic.identifier == "org.swift.docc.DuplicateMarkdownTitleSymbolReferences"
+        }
         let diagnostic = try XCTUnwrap(duplicateExtensionProblems.first).diagnostic
         let source = try XCTUnwrap(diagnostic.source)
-            
+
         // Verify that both files are mentioned in the diagnostic and its note.
         let mentionedMarkupURLs = Set(diagnostic.notes.map(\.source) + [source])
-        
+
         let missingMarkupURLs = Set(bundle.markupURLs).subtracting(mentionedMarkupURLs)
-        
-        XCTAssert(missingMarkupURLs.isEmpty, "\(missingMarkupURLs.map(\.lastPathComponent).sorted()) isn't mentioned in the diagnostic.")
+
+        XCTAssert(
+            missingMarkupURLs.isEmpty,
+            "\(missingMarkupURLs.map(\.lastPathComponent).sorted()) isn't mentioned in the diagnostic."
+        )
     }
-    
+
     func testCanResolveArticleFromTutorial() throws {
         struct TestData {
             let symbolGraphNames: [String]
-            
+
             var symbolGraphFiles: [File] {
                 return symbolGraphNames.map { name in
-                    CopyOfFile(original: Bundle.module.url(forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-                        .appendingPathComponent(name + ".symbols.json"))
+                    CopyOfFile(
+                        original: Bundle.module.url(
+                            forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc",
+                            subdirectory: "Test Bundles")!
+                            .appendingPathComponent(name + ".symbols.json"))
                 }
             }
-                
+
             var expectsToResolveArticleReference: Bool {
                 return symbolGraphNames.count == 1
             }
         }
-        
+
         // Verify that the article can be resolved when there's a single module but not otherwise.
         let combinationsToTest = [
             TestData(symbolGraphNames: []),
@@ -1263,425 +1541,566 @@ class DocumentationContextTests: XCTestCase {
             TestData(symbolGraphNames: ["sidekit"]),
             TestData(symbolGraphNames: ["mykit-iOS", "sidekit"]),
         ]
-        
+
         for testData in combinationsToTest {
-            let testCatalog = Folder(name: "TestCanResolveArticleFromTutorial.docc", content: [
-                InfoPlist(displayName: "TestCanResolveArticleFromTutorial", identifier: "com.example.documentation"),
-                
-                TextFile(name: "extra-article.md", utf8Content: """
-                # Extra article
-                
-                This is an extra article that will be automatically curated.
-                """),
-                    
-                TextFile(name: "TestOverview.tutorial", utf8Content: """
-                @Tutorials(name: "Technology X") {
-                   @Intro(title: "Technology X") {
-                      Reference the extra article in tutorial content: <doc:extra-article>
-                   }
-                }
-                """),
-            ] + testData.symbolGraphFiles)
-            
+            let testCatalog = Folder(
+                name: "TestCanResolveArticleFromTutorial.docc",
+                content: [
+                    InfoPlist(
+                        displayName: "TestCanResolveArticleFromTutorial",
+                        identifier: "com.example.documentation"),
+
+                    TextFile(
+                        name: "extra-article.md",
+                        utf8Content: """
+                            # Extra article
+
+                            This is an extra article that will be automatically curated.
+                            """),
+
+                    TextFile(
+                        name: "TestOverview.tutorial",
+                        utf8Content: """
+                            @Tutorials(name: "Technology X") {
+                               @Intro(title: "Technology X") {
+                                  Reference the extra article in tutorial content: <doc:extra-article>
+                               }
+                            }
+                            """),
+                ] + testData.symbolGraphFiles)
+
             let (bundle, context) = try loadBundle(catalog: testCatalog)
             let renderContext = RenderContext(documentationContext: context, bundle: bundle)
-            
-            let identifier = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
+
+            let identifier = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
             let node = try context.entity(with: identifier)
-            
-            let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
+
+            let converter = DocumentationContextConverter(
+                bundle: bundle, context: context, renderContext: renderContext)
             let renderNode = try XCTUnwrap(converter.renderNode(for: node))
-            
+
             XCTAssertEqual(
                 !testData.expectsToResolveArticleReference,
-                context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }),
+                context.problems.contains(where: {
+                    $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference"
+                }),
                 "Expected to \(testData.expectsToResolveArticleReference ? "resolve" : "not resolve") article reference from tutorial content when there are \(testData.symbolGraphNames.count) modules."
             )
             XCTAssertEqual(
                 testData.expectsToResolveArticleReference,
-                renderNode.references.keys.contains("doc://com.example.documentation/documentation/TestCanResolveArticleFromTutorial/extra-article"),
+                renderNode.references.keys.contains(
+                    "doc://com.example.documentation/documentation/TestCanResolveArticleFromTutorial/extra-article"
+                ),
                 "Expected to \(testData.expectsToResolveArticleReference ? "find" : "not find") article among the tutorial's references when there are \(testData.symbolGraphNames.count) modules."
             )
         }
     }
-    
+
     func testCuratesSymbolsAndArticlesCorrectly() throws {
         let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Sort the edges for each node to get consistent results, no matter the order that the symbols were processed.
         for (source, targets) in context.topicGraph.edges {
-            context.topicGraph.edges[source] = targets.sorted(by: { $0.absoluteString < $1.absoluteString })
+            context.topicGraph.edges[source] = targets.sorted(by: {
+                $0.absoluteString < $1.absoluteString
+            })
         }
-        
-let expected = """
- doc://org.swift.docc.example/documentation/FillIntroduced
- ├ doc://org.swift.docc.example/documentation/FillIntroduced/iOSMacOSOnly()
- ├ doc://org.swift.docc.example/documentation/FillIntroduced/iOSOnlyDeprecated()
- ├ doc://org.swift.docc.example/documentation/FillIntroduced/iOSOnlyIntroduced()
- ├ doc://org.swift.docc.example/documentation/FillIntroduced/macCatalystOnlyDeprecated()
- ├ doc://org.swift.docc.example/documentation/FillIntroduced/macCatalystOnlyIntroduced()
- ├ doc://org.swift.docc.example/documentation/FillIntroduced/macOSOnlyDeprecated()
- ╰ doc://org.swift.docc.example/documentation/FillIntroduced/macOSOnlyIntroduced()
- doc://org.swift.docc.example/documentation/MyKit
- ├ doc://org.swift.docc.example/documentation/MyKit/MyClass
- │ ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-33vaw
- │ ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-3743d
- │ ╰ doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()
- ├ doc://org.swift.docc.example/documentation/MyKit/MyProtocol
- │ ╰ doc://org.swift.docc.example/documentation/MyKit/MyClass
- │   ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-33vaw
- │   ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-3743d
- │   ╰ doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()
- ├ doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)
- ├ doc://org.swift.docc.example/documentation/SideKit/UncuratedClass/angle
- ├ doc://org.swift.docc.example/documentation/Test-Bundle/Default-Code-Listing-Syntax
- ├ doc://org.swift.docc.example/documentation/Test-Bundle/article
- │ ├ doc://org.swift.docc.example/documentation/Test-Bundle/article2
- │ ├ doc://org.swift.docc.example/documentation/Test-Bundle/article3
- │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial
- │   ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB
- │   ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Duplicate
- │   ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection
- ╰ doc://org.swift.docc.example/documentation/Test-Bundle/article2
- doc://org.swift.docc.example/documentation/SideKit
- ├ doc://org.swift.docc.example/documentation/SideKit/SideClass
- │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/Element
- │ │ ╰ doc://org.swift.docc.example/documentation/SideKit/SideClass/Element/Protocol-Implementations
- │ │   ╰ doc://org.swift.docc.example/documentation/SideKit/SideClass/Element/inherited()
- │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/Value(_:)
- │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/init()
- │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/myFunction()
- │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/path
- │ ╰ doc://org.swift.docc.example/documentation/SideKit/SideClass/url
- ├ doc://org.swift.docc.example/documentation/SideKit/SideProtocol
- │ ╰ doc://org.swift.docc.example/documentation/SideKit/SideProtocol/func()
- │   ╰ doc://org.swift.docc.example/documentation/SideKit/SideProtocol/func()-2dxqn
- ╰ doc://org.swift.docc.example/documentation/SideKit/UncuratedClass
- doc://org.swift.docc.example/tutorials/TestOverview
- ╰ doc://org.swift.docc.example/tutorials/TestOverview/$volume
-   ╰ doc://org.swift.docc.example/tutorials/TestOverview/Chapter-1
-     ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial
-     │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB
-     │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Duplicate
-     │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection
-     ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2
-     │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2#Create-a-New-AR-Project
-     ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle
-     │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle#A-Section
-     │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle#This-is-an-H2
-     │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle#This-is-an-H3
-     ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TutorialMediaWithSpaces
-       ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TutorialMediaWithSpaces#Create-a-New-AR-Project
-"""
+
+        let expected = """
+             doc://org.swift.docc.example/documentation/FillIntroduced
+             ├ doc://org.swift.docc.example/documentation/FillIntroduced/iOSMacOSOnly()
+             ├ doc://org.swift.docc.example/documentation/FillIntroduced/iOSOnlyDeprecated()
+             ├ doc://org.swift.docc.example/documentation/FillIntroduced/iOSOnlyIntroduced()
+             ├ doc://org.swift.docc.example/documentation/FillIntroduced/macCatalystOnlyDeprecated()
+             ├ doc://org.swift.docc.example/documentation/FillIntroduced/macCatalystOnlyIntroduced()
+             ├ doc://org.swift.docc.example/documentation/FillIntroduced/macOSOnlyDeprecated()
+             ╰ doc://org.swift.docc.example/documentation/FillIntroduced/macOSOnlyIntroduced()
+             doc://org.swift.docc.example/documentation/MyKit
+             ├ doc://org.swift.docc.example/documentation/MyKit/MyClass
+             │ ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-33vaw
+             │ ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-3743d
+             │ ╰ doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()
+             ├ doc://org.swift.docc.example/documentation/MyKit/MyProtocol
+             │ ╰ doc://org.swift.docc.example/documentation/MyKit/MyClass
+             │   ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-33vaw
+             │   ├ doc://org.swift.docc.example/documentation/MyKit/MyClass/init()-3743d
+             │   ╰ doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()
+             ├ doc://org.swift.docc.example/documentation/MyKit/globalFunction(_:considering:)
+             ├ doc://org.swift.docc.example/documentation/SideKit/UncuratedClass/angle
+             ├ doc://org.swift.docc.example/documentation/Test-Bundle/Default-Code-Listing-Syntax
+             ├ doc://org.swift.docc.example/documentation/Test-Bundle/article
+             │ ├ doc://org.swift.docc.example/documentation/Test-Bundle/article2
+             │ ├ doc://org.swift.docc.example/documentation/Test-Bundle/article3
+             │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial
+             │   ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB
+             │   ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Duplicate
+             │   ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection
+             ╰ doc://org.swift.docc.example/documentation/Test-Bundle/article2
+             doc://org.swift.docc.example/documentation/SideKit
+             ├ doc://org.swift.docc.example/documentation/SideKit/SideClass
+             │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/Element
+             │ │ ╰ doc://org.swift.docc.example/documentation/SideKit/SideClass/Element/Protocol-Implementations
+             │ │   ╰ doc://org.swift.docc.example/documentation/SideKit/SideClass/Element/inherited()
+             │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/Value(_:)
+             │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/init()
+             │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/myFunction()
+             │ ├ doc://org.swift.docc.example/documentation/SideKit/SideClass/path
+             │ ╰ doc://org.swift.docc.example/documentation/SideKit/SideClass/url
+             ├ doc://org.swift.docc.example/documentation/SideKit/SideProtocol
+             │ ╰ doc://org.swift.docc.example/documentation/SideKit/SideProtocol/func()
+             │   ╰ doc://org.swift.docc.example/documentation/SideKit/SideProtocol/func()-2dxqn
+             ╰ doc://org.swift.docc.example/documentation/SideKit/UncuratedClass
+             doc://org.swift.docc.example/tutorials/TestOverview
+             ╰ doc://org.swift.docc.example/tutorials/TestOverview/$volume
+               ╰ doc://org.swift.docc.example/tutorials/TestOverview/Chapter-1
+                 ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial
+                 │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Create-a-New-AR-Project-%F0%9F%92%BB
+                 │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Duplicate
+                 │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Initiate-ARKit-Plane-Detection
+                 ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2
+                 │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial2#Create-a-New-AR-Project
+                 ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle
+                 │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle#A-Section
+                 │ ├ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle#This-is-an-H2
+                 │ ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorialArticle#This-is-an-H3
+                 ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TutorialMediaWithSpaces
+                   ╰ doc://org.swift.docc.example/tutorials/Test-Bundle/TutorialMediaWithSpaces#Create-a-New-AR-Project
+            """
 
         assertEqualDumps(context.dumpGraph(), expected)
-        
+
         // Test correct symbol hierarchy in context
-        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
-                       [["doc://org.swift.docc.example/documentation/MyKit"], ["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyProtocol"]])
-        
-        XCTAssertEqual(context.finitePaths(to: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/init()-33vaw", sourceLanguage: .swift)).map { $0.map {$0.absoluteString} },
-                       [["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyClass"], ["doc://org.swift.docc.example/documentation/MyKit", "doc://org.swift.docc.example/documentation/MyKit/MyProtocol", "doc://org.swift.docc.example/documentation/MyKit/MyClass"]])
+        XCTAssertEqual(
+            context.finitePaths(
+                to: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass",
+                    sourceLanguage: .swift)
+            ).map { $0.map { $0.absoluteString } },
+            [
+                ["doc://org.swift.docc.example/documentation/MyKit"],
+                [
+                    "doc://org.swift.docc.example/documentation/MyKit",
+                    "doc://org.swift.docc.example/documentation/MyKit/MyProtocol",
+                ],
+            ])
+
+        XCTAssertEqual(
+            context.finitePaths(
+                to: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/MyKit/MyClass/init()-33vaw", sourceLanguage: .swift)
+            ).map { $0.map { $0.absoluteString } },
+            [
+                [
+                    "doc://org.swift.docc.example/documentation/MyKit",
+                    "doc://org.swift.docc.example/documentation/MyKit/MyClass",
+                ],
+                [
+                    "doc://org.swift.docc.example/documentation/MyKit",
+                    "doc://org.swift.docc.example/documentation/MyKit/MyProtocol",
+                    "doc://org.swift.docc.example/documentation/MyKit/MyClass",
+                ],
+            ])
     }
-    
-    func createNode(in context: DocumentationContext, bundle: DocumentationBundle, parent: ResolvedTopicReference, name: String) throws -> (DocumentationNode, TopicGraph.Node) {
+
+    func createNode(
+        in context: DocumentationContext, bundle: DocumentationBundle,
+        parent: ResolvedTopicReference, name: String
+    ) throws -> (DocumentationNode, TopicGraph.Node) {
         let reference = parent.appendingPath(name)
-        let node = DocumentationNode(reference: reference, kind: .article, sourceLanguage: .swift, name: .conceptual(title: name), markup: Document(parsing: "# \(name)"), semantic: nil)
-        let tgNode = TopicGraph.Node(reference: reference, kind: .article, source: .external, title: name)
-        
+        let node = DocumentationNode(
+            reference: reference, kind: .article, sourceLanguage: .swift,
+            name: .conceptual(title: name), markup: Document(parsing: "# \(name)"), semantic: nil)
+        let tgNode = TopicGraph.Node(
+            reference: reference, kind: .article, source: .external, title: name)
+
         context.documentationCache[reference] = node
         context.topicGraph.addNode(tgNode)
         let parentNode = try XCTUnwrap(context.topicGraph.nodeWithReference(parent))
         context.topicGraph.addEdge(from: parentNode, to: tgNode)
-        
+
         return (node, tgNode)
     }
-    
+
     func testSortingBreadcrumbsOfEqualDistanceToRoot() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName"))
-        ])
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(moduleName: "SomeModuleName"))
+            ])
         let (bundle, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
-        
+
         ///
         /// Create nodes in alphabetical order
         ///
 
         /// Create /documentation/MyKit/AAA & /documentation/MyKit/BBB
-        let (aaaNode, _) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "AAA")
-        let (_, bbbTgNode) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "BBB")
+        let (aaaNode, _) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "AAA")
+        let (_, bbbTgNode) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "BBB")
         /// Create /documentation/MyKit/AAA/CCC, curate also under BBB
-        let (cccNode, cccTgNode) = try createNode(in: context, bundle: bundle, parent: aaaNode.reference, name: "CCC")
+        let (cccNode, cccTgNode) = try createNode(
+            in: context, bundle: bundle, parent: aaaNode.reference, name: "CCC")
         context.topicGraph.addEdge(from: bbbTgNode, to: cccTgNode)
-        
+
         let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePath(to: cccNode.reference))
-        XCTAssertEqual(["/documentation/SomeModuleName", "/documentation/SomeModuleName/AAA"], canonicalPathCCC.map({ $0.path }))
-        
+        XCTAssertEqual(
+            ["/documentation/SomeModuleName", "/documentation/SomeModuleName/AAA"],
+            canonicalPathCCC.map({ $0.path }))
+
         ///
         /// Create nodes in non-alphabetical order
         ///
 
         /// Create /documentation/MyKit/DDD & /documentation/MyKit/EEE
-        let (_, dddTgNode) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "DDD")
-        let (eeeNode, _) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "EEE")
+        let (_, dddTgNode) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "DDD")
+        let (eeeNode, _) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "EEE")
         /// Create /documentation/MyKit/DDD/FFF, curate also under EEE
-        let (fffNode, fffTgNode) = try createNode(in: context, bundle: bundle, parent: eeeNode.reference, name: "FFF")
+        let (fffNode, fffTgNode) = try createNode(
+            in: context, bundle: bundle, parent: eeeNode.reference, name: "FFF")
         context.topicGraph.addEdge(from: dddTgNode, to: fffTgNode)
-        
+
         let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePath(to: fffNode.reference))
-        XCTAssertEqual(["/documentation/SomeModuleName", "/documentation/SomeModuleName/DDD"], canonicalPathFFF.map({ $0.path }))
+        XCTAssertEqual(
+            ["/documentation/SomeModuleName", "/documentation/SomeModuleName/DDD"],
+            canonicalPathFFF.map({ $0.path }))
     }
-    
+
     func testSortingBreadcrumbsOfDifferentDistancesToRoot() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName"))
-        ])
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(moduleName: "SomeModuleName"))
+            ])
         let (bundle, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         let moduleTopicNode = try XCTUnwrap(context.topicGraph.nodeWithReference(moduleReference))
-        
+
         ///
         /// Create nodes in order
         ///
 
         /// Create /documentation/MyKit/AAA & /documentation/MyKit/BBB
-        let (aaaNode, aaaTgNode) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "AAA")
-        let (_, bbbTgNode) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "BBB")
+        let (aaaNode, aaaTgNode) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "AAA")
+        let (_, bbbTgNode) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "BBB")
         /// Create /documentation/MyKit/AAA/CCC and also curate under /documentation/MyKit
-        let (cccNode, cccTgNode) = try createNode(in: context, bundle: bundle, parent: aaaNode.reference, name: "CCC")
+        let (cccNode, cccTgNode) = try createNode(
+            in: context, bundle: bundle, parent: aaaNode.reference, name: "CCC")
         context.topicGraph.addEdge(from: moduleTopicNode, to: cccTgNode)
         context.topicGraph.addEdge(from: aaaTgNode, to: cccTgNode)
         context.topicGraph.addEdge(from: bbbTgNode, to: cccTgNode)
-        
+
         let canonicalPathCCC = try XCTUnwrap(context.shortestFinitePath(to: cccNode.reference))
         XCTAssertEqual(["/documentation/SomeModuleName"], canonicalPathCCC.map({ $0.path }))
-        
+
         ///
         /// Create nodes not in order
         ///
 
         /// Create /documentation/MyKit/DDD & /documentation/MyKit/EEE
-        let (_, dddTgNode) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "DDD")
-        let (eeeNode, eeeTgNode) = try createNode(in: context, bundle: bundle, parent: moduleReference, name: "EEE")
+        let (_, dddTgNode) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "DDD")
+        let (eeeNode, eeeTgNode) = try createNode(
+            in: context, bundle: bundle, parent: moduleReference, name: "EEE")
         /// Create /documentation/MyKit/DDD/FFF, curate also under /documentation/MyKit
-        let (fffNode, fffTgNode) = try createNode(in: context, bundle: bundle, parent: eeeNode.reference, name: "FFF")
+        let (fffNode, fffTgNode) = try createNode(
+            in: context, bundle: bundle, parent: eeeNode.reference, name: "FFF")
         context.topicGraph.addEdge(from: eeeTgNode, to: fffTgNode)
         context.topicGraph.addEdge(from: dddTgNode, to: fffTgNode)
         context.topicGraph.addEdge(from: moduleTopicNode, to: fffTgNode)
-        
+
         let canonicalPathFFF = try XCTUnwrap(context.shortestFinitePath(to: fffNode.reference))
         XCTAssertEqual(["/documentation/SomeModuleName"], canonicalPathFFF.map({ $0.path }))
     }
 
     // Verify that a symbol that has no parents in the symbol graph is automatically curated under the module node.
     func testRootSymbolsAreCuratedInModule() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
-                makeSymbol(id: "some-class-id",    kind: .class,    pathComponents: ["SomeClass"]),
-            ])),
-        ])
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "SomeModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "some-class-id", kind: .class, pathComponents: ["SomeClass"])
+                        ]))
+            ])
         let (_, context) = try loadBundle(catalog: catalog)
-        
+
         // Verify the node is a child of the module node when the graph is loaded.
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         let classReference = moduleReference.appendingPath("SomeClass")
         let parents = context.parents(of: classReference)
         XCTAssertEqual(parents, [moduleReference])
     }
-    
+
     /// Tests whether tutorial curated multiple times gets the correct breadcrumbs and hierarchy.
     func testCurateTutorialMultipleTimes() throws {
         // Curate "TestTutorial" under MyKit as well as TechnologyX.
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            root in
             let myKitURL = root.appendingPathComponent("documentation/mykit.md")
-            let text = try String(contentsOf: myKitURL).replacingOccurrences(of: "## Topics", with: """
-            ## Topics
+            let text = try String(contentsOf: myKitURL).replacingOccurrences(
+                of: "## Topics",
+                with: """
+                    ## Topics
 
-            ### Tutorials
-             - <doc:/tutorials/Test-Bundle/TestTutorial>
-             - <doc:/tutorials/Test-Bundle/TestTutorial2>
-            """)
+                    ### Tutorials
+                     - <doc:/tutorials/Test-Bundle/TestTutorial>
+                     - <doc:/tutorials/Test-Bundle/TestTutorial2>
+                    """)
             try text.write(to: myKitURL, atomically: true, encoding: .utf8)
         }
-        
+
         // Get a node
-        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
-        
+        let node = try context.entity(
+            with: ResolvedTopicReference(
+                bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial",
+                sourceLanguage: .swift))
+
         // Get the breadcrumbs as paths
         let paths = context.finitePaths(to: node.reference).sorted { (path1, path2) -> Bool in
             return path1.count < path2.count
         }
         .map { return $0.map { $0.url.path } }
-        
+
         // Verify the tutorial has multiple paths
-        XCTAssertEqual(paths, [["/documentation/MyKit"], ["/documentation/MyKit", "/documentation/Test-Bundle/article"], ["/tutorials/TestOverview", "/tutorials/TestOverview/$volume", "/tutorials/TestOverview/Chapter-1"]])
+        XCTAssertEqual(
+            paths,
+            [
+                ["/documentation/MyKit"],
+                ["/documentation/MyKit", "/documentation/Test-Bundle/article"],
+                [
+                    "/tutorials/TestOverview", "/tutorials/TestOverview/$volume",
+                    "/tutorials/TestOverview/Chapter-1",
+                ],
+            ])
     }
 
     func testNonOverloadPaths() throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            root in
             let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
-            let text = try String(contentsOf: sideKitURL).replacingOccurrences(of: "\"symbols\" : [", with: """
-            "symbols" : [
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.enum.case",
-                "displayName" : "Enumeration Case"
-              },
-              "names" : { "title" : "test" },
-              "pathComponents" : [ "SideClass", "test" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testEC",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.var",
-                "displayName" : "Variable"
-              },
-              "names" : { "title" : "test" },
-              "pathComponents" : [ "SideClass", "test" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testV",
-                "interfaceLanguage": "swift"
-              }
-            },
-            """).replacingOccurrences(of: "\"relationships\" : [", with: """
-            "relationships" : [
-            {
-              "kind" : "memberOf",
-              "source" : "s:7SideKit0A5ClassC10testEC",
-              "target" : "s:7SideKit0A5ClassC"
-            },
-            {
-              "kind" : "memberOf",
-              "source" : "s:7SideKit0A5ClassC10testV",
-              "target" : "s:7SideKit0A5ClassC"
-            },
-            """)
+            let text = try String(contentsOf: sideKitURL).replacingOccurrences(
+                of: "\"symbols\" : [",
+                with: """
+                    "symbols" : [
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.enum.case",
+                        "displayName" : "Enumeration Case"
+                      },
+                      "names" : { "title" : "test" },
+                      "pathComponents" : [ "SideClass", "test" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testEC",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.var",
+                        "displayName" : "Variable"
+                      },
+                      "names" : { "title" : "test" },
+                      "pathComponents" : [ "SideClass", "test" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testV",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    """
+            ).replacingOccurrences(
+                of: "\"relationships\" : [",
+                with: """
+                    "relationships" : [
+                    {
+                      "kind" : "memberOf",
+                      "source" : "s:7SideKit0A5ClassC10testEC",
+                      "target" : "s:7SideKit0A5ClassC"
+                    },
+                    {
+                      "kind" : "memberOf",
+                      "source" : "s:7SideKit0A5ClassC10testV",
+                      "target" : "s:7SideKit0A5ClassC"
+                    },
+                    """)
             try text.write(to: sideKitURL, atomically: true, encoding: .utf8)
         }
-        
+
         // Verify the non-overload collisions were resolved
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.enum.case", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.var", sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/test-swift.enum.case",
+                    sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/test-swift.var", sourceLanguage: .swift)
+            ))
     }
-    
+
     func testModuleLanguageFallsBackToSwiftIfItHasNoSymbols() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName")),
-        ])
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(moduleName: "SomeModuleName"))
+            ])
         let (_, context) = try loadBundle(catalog: catalog)
-        
+
         XCTAssertEqual(
             context.soleRootModuleReference.map { context.sourceLanguages(for: $0) },
             [.swift],
             "Expected the module to have language 'Swift' since it has 0 symbols."
         )
     }
-    
+
     func testOverloadPlusNonOverloadCollisionPaths() throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            root in
             let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
-            let text = try String(contentsOf: sideKitURL).replacingOccurrences(of: "\"symbols\" : [", with: """
-            "symbols" : [
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.enum",
-                "displayName" : "Enumeration"
-              },
-              "names" : { "title" : "Test" },
-              "pathComponents" : [ "SideClass", "Test" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testE",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.var",
-                "displayName" : "Type Variable"
-              },
-              "names" : { "title" : "test" },
-              "pathComponents" : [ "SideClass", "test" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testSV",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.var",
-                "displayName" : "Type Variable"
-              },
-              "names" : { "title" : "tEst" },
-              "pathComponents" : [ "SideClass", "tEst" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10tEstV",
-                "interfaceLanguage": "swift"
-              }
-            },
-            """).replacingOccurrences(of: "\"relationships\" : [", with: """
-            "relationships" : [
-            {
-              "kind" : "memberOf",
-              "source" : "s:7SideKit0A5ClassC10testE",
-              "target" : "s:7SideKit0A5ClassC"
-            },
-            {
-              "kind" : "memberOf",
-              "source" : "s:7SideKit0A5ClassC10testSV",
-              "target" : "s:7SideKit0A5ClassC"
-            },
-            {
-              "kind" : "memberOf",
-              "source" : "s:7SideKit0A5ClassC10tEstV",
-              "target" : "s:7SideKit0A5ClassC"
-            },
-            """)
+            let text = try String(contentsOf: sideKitURL).replacingOccurrences(
+                of: "\"symbols\" : [",
+                with: """
+                    "symbols" : [
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.enum",
+                        "displayName" : "Enumeration"
+                      },
+                      "names" : { "title" : "Test" },
+                      "pathComponents" : [ "SideClass", "Test" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testE",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.var",
+                        "displayName" : "Type Variable"
+                      },
+                      "names" : { "title" : "test" },
+                      "pathComponents" : [ "SideClass", "test" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testSV",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.var",
+                        "displayName" : "Type Variable"
+                      },
+                      "names" : { "title" : "tEst" },
+                      "pathComponents" : [ "SideClass", "tEst" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10tEstV",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    """
+            ).replacingOccurrences(
+                of: "\"relationships\" : [",
+                with: """
+                    "relationships" : [
+                    {
+                      "kind" : "memberOf",
+                      "source" : "s:7SideKit0A5ClassC10testE",
+                      "target" : "s:7SideKit0A5ClassC"
+                    },
+                    {
+                      "kind" : "memberOf",
+                      "source" : "s:7SideKit0A5ClassC10testSV",
+                      "target" : "s:7SideKit0A5ClassC"
+                    },
+                    {
+                      "kind" : "memberOf",
+                      "source" : "s:7SideKit0A5ClassC10tEstV",
+                      "target" : "s:7SideKit0A5ClassC"
+                    },
+                    """)
             try text.write(to: sideKitURL, atomically: true, encoding: .utf8)
         }
-        
+
         // Verify the non-overload collisions were resolved
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/tEst-9053a", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-959hd", sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift
+                )))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/tEst-9053a", sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/test-959hd", sourceLanguage: .swift)))
     }
 
     func testUnknownSymbolKind() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
-                makeSymbol(id: "some-symbol-id",  kind: .init(identifier: "blip-blop"), pathComponents: ["SomeUnknownSymbol"]),
-            ])),
-        ])
-        
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "SomeModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "some-symbol-id", kind: .init(identifier: "blip-blop"),
+                                pathComponents: ["SomeUnknownSymbol"])
+                        ]))
+            ])
+
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
-        
+
         // Get the node, verify its kind is unknown
         let node = try context.entity(with: moduleReference.appendingPath("SomeUnknownSymbol"))
         XCTAssertEqual(node.kind, .unknown)
     }
-    
+
     func testCuratingSymbolsWithSpecialCharacters() throws {
         let (_, _, context) = try testBundleAndContext(copying: "InheritedOperators") { root in
             try """
             # ``Operators/MyNumber``
-            
+
             A documentation extension that curates symbols with characters not allowed in a resolved reference URL.
 
             ## Topics
-            
+
             ### Operator name only
-            
+
             - ``<(_:_:)``
             - ``>(_:_:)``
             - ``<=(_:_:)``
@@ -1691,9 +2110,9 @@ let expected = """
             - ``-=(_:_:)-7w3vn``
             - ``/(_:_:)``
             - ``/=(_:_:)``
-            
+
             ### Prefixes with containing type name
-            
+
             - ``MyNumber/<(_:_:)``
             - ``MyNumber/>(_:_:)``
             - ``MyNumber/<=(_:_:)``
@@ -1703,981 +2122,1298 @@ let expected = """
             - ``MyNumber/-=(_:_:)-7w3vn``
             - ``MyNumber//(_:_:)``
             - ``MyNumber//=(_:_:)``
-            """.write(to: root.appendingPathComponent("doc-extension.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: root.appendingPathComponent("doc-extension.md"), atomically: true,
+                encoding: .utf8)
         }
-        
-        let unresolvedTopicProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" })
-        XCTAssertEqual(unresolvedTopicProblems.map(\.diagnostic.summary), [], "All links should resolve without warnings")
+
+        let unresolvedTopicProblems = context.problems.filter({
+            $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference"
+        })
+        XCTAssertEqual(
+            unresolvedTopicProblems.map(\.diagnostic.summary), [],
+            "All links should resolve without warnings")
     }
-    
+
     func testOperatorReferences() throws {
         let (_, context) = try testBundleAndContext(named: "InheritedOperators")
-        
-        let pageIdentifiersAndNames = Dictionary(uniqueKeysWithValues: try context.knownPages.map { reference in
-            (key: reference.path, value: try context.entity(with: reference).name.description)
-        })
-        
+
+        let pageIdentifiersAndNames = Dictionary(
+            uniqueKeysWithValues: try context.knownPages.map { reference in
+                (key: reference.path, value: try context.entity(with: reference).name.description)
+            })
+
         // Operators where all characters in the operator name are also allowed in URL paths
-        XCTAssertEqual("!=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/!=(_:_:)"])
-        XCTAssertEqual("*(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/*(_:_:)"])
-        XCTAssertEqual("*=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/*=(_:_:)"])
-        XCTAssertEqual("+(_:)",     pageIdentifiersAndNames["/documentation/Operators/MyNumber/+(_:)"])
-        XCTAssertEqual("+(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/+(_:_:)"])
-        XCTAssertEqual("+=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/+=(_:_:)"])
-        XCTAssertEqual("-(_:)",     pageIdentifiersAndNames["/documentation/Operators/MyNumber/-(_:)"])
-        XCTAssertEqual("-(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/-(_:_:)"])
-        XCTAssertEqual("-=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/-=(_:_:)"])
-        XCTAssertEqual("...(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:_:)"])
-        XCTAssertEqual("..<(_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/.._(_:)"])
-        XCTAssertEqual("..<(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/.._(_:_:)"])
+        XCTAssertEqual(
+            "!=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/!=(_:_:)"])
+        XCTAssertEqual(
+            "*(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/*(_:_:)"])
+        XCTAssertEqual(
+            "*=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/*=(_:_:)"])
+        XCTAssertEqual("+(_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/+(_:)"])
+        XCTAssertEqual(
+            "+(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/+(_:_:)"])
+        XCTAssertEqual(
+            "+=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/+=(_:_:)"])
+        XCTAssertEqual("-(_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/-(_:)"])
+        XCTAssertEqual(
+            "-(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/-(_:_:)"])
+        XCTAssertEqual(
+            "-=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/-=(_:_:)"])
+        XCTAssertEqual(
+            "...(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:_:)"])
+        XCTAssertEqual(
+            "..<(_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/.._(_:)"])
+        XCTAssertEqual(
+            "..<(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/.._(_:_:)"])
         // Operators with the same name have disambiguation in their paths
-        XCTAssertEqual("...(_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:)-28faz"])
-        XCTAssertEqual("...(_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:)-8ooeh"])
-        
+        XCTAssertEqual(
+            "...(_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:)-28faz"])
+        XCTAssertEqual(
+            "...(_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/...(_:)-8ooeh"])
+
         // Characters that are not allowed in URL paths are replaced with "_" (adding disambiguation if the replacement introduces conflicts)
-        XCTAssertEqual("<(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-736gk"])
-        XCTAssertEqual("<=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-9uewk"])
-        XCTAssertEqual(">(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-21jxf"])
-        XCTAssertEqual(">=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-70j0d"])
-        
+        XCTAssertEqual(
+            "<(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-736gk"])
+        XCTAssertEqual(
+            "<=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-9uewk"])
+        XCTAssertEqual(
+            ">(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-21jxf"])
+        XCTAssertEqual(
+            ">=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)-70j0d"])
+
         // "/" is a separator in URL paths so it's replaced with with "_" (adding disambiguation if the replacement introduces conflicts)
-        XCTAssertEqual("/(_:_:)",   pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-7am4"])
-        XCTAssertEqual("/=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)"])
+        XCTAssertEqual(
+            "/(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/_(_:_:)-7am4"])
+        XCTAssertEqual(
+            "/=(_:_:)", pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)"])
     }
-    
+
     func testFileNamesWithDifferentPunctuation() throws {
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                TextFile(name: "Hello-world.md", utf8Content: """
-                # Dash
-                
-                No whitespace in the file name
-                """),
-                
-                TextFile(name: "Hello world.md", utf8Content: """
-                # Only space
-                
-                This has the same reference as "Hello-world.md" and will raise a warning.
-                """),
-                
-                TextFile(name: "Hello  world.md", utf8Content: """
-                # Multiple spaces
-                
-                Each space is replaced with a dash in the reference, so this has a unique reference.
-                """),
-                
-                TextFile(name: "Hello, world!.md", utf8Content: """
-                # Space and punctuation
-                
-                The punctuation is not removed from the reference, so this has a unique reference.
-                """),
-                
-                TextFile(name: "Hello. world?.md", utf8Content: """
-                # Space and different punctuation
-                
-                The punctuation is not removed from the reference, so this has a unique reference.
-                """),
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    TextFile(
+                        name: "Hello-world.md",
+                        utf8Content: """
+                            # Dash
+
+                            No whitespace in the file name
+                            """),
+
+                    TextFile(
+                        name: "Hello world.md",
+                        utf8Content: """
+                            # Only space
+
+                            This has the same reference as "Hello-world.md" and will raise a warning.
+                            """),
+
+                    TextFile(
+                        name: "Hello  world.md",
+                        utf8Content: """
+                            # Multiple spaces
+
+                            Each space is replaced with a dash in the reference, so this has a unique reference.
+                            """),
+
+                    TextFile(
+                        name: "Hello, world!.md",
+                        utf8Content: """
+                            # Space and punctuation
+
+                            The punctuation is not removed from the reference, so this has a unique reference.
+                            """),
+
+                    TextFile(
+                        name: "Hello. world?.md",
+                        utf8Content: """
+                            # Space and different punctuation
+
+                            The punctuation is not removed from the reference, so this has a unique reference.
+                            """),
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
 
-        XCTAssertEqual(context.problems.map(\.diagnostic.summary), ["Redeclaration of 'Hello world.md'; this file will be skipped"])
-        
-        XCTAssertEqual(context.knownPages.map(\.absoluteString).sorted(), [
-            "doc://unit-test/documentation/unit-test",
-            "doc://unit-test/documentation/unit-test/Hello,-world!",
-            "doc://unit-test/documentation/unit-test/Hello--world",
-            "doc://unit-test/documentation/unit-test/Hello-world",
-            "doc://unit-test/documentation/unit-test/Hello.-world-",
-        ])
+        XCTAssertEqual(
+            context.problems.map(\.diagnostic.summary),
+            ["Redeclaration of 'Hello world.md'; this file will be skipped"])
+
+        XCTAssertEqual(
+            context.knownPages.map(\.absoluteString).sorted(),
+            [
+                "doc://unit-test/documentation/unit-test",
+                "doc://unit-test/documentation/unit-test/Hello,-world!",
+                "doc://unit-test/documentation/unit-test/Hello--world",
+                "doc://unit-test/documentation/unit-test/Hello-world",
+                "doc://unit-test/documentation/unit-test/Hello.-world-",
+            ])
     }
-    
+
     func testSpecialCharactersInLinks() throws {
-        let catalog = Folder(name: "special-characters.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(
-                moduleName: "SomeModuleName",
-                symbols: [
-                    makeSymbol(id: "some-class-id", kind: .class, pathComponents: ["SomeClass"]),
-                    makeSymbol(id: "some-function-id", kind: .func, pathComponents: ["SomeClass", "someFunction🙂()"]),
-                ],
-                relationships: [
-                    .init(source: "some-function-id", target: "some-class-id", kind: .memberOf, targetFallback: nil)
-                ])
-            ),
-            
-            TextFile(name: "article-with-emoji-in-heading.md", utf8Content: """
-            # Article with emoji in heading
-            
-            Abstract
-            
-            ### Hello 🌍
-            """),
-            
-            TextFile(name: "article-with-😃-in-filename.md", utf8Content: """
-            # Article with 😃 emoji in its filename
-            
-            Abstract
-            
-            ### Hello world
-            """),
-            
-            TextFile(name: "Article: with - various! whitespace & punctuation. in, filename.md", utf8Content: """
-            # Article with various whitespace and punctuation in its filename
-            
-            Abstract
-            
-            ### Hello world
-            """),
-            
-            TextFile(name: "SomeModuleName.md", utf8Content: """
-            # ``SomeModuleName``
-            
-            Test linking to articles, symbols, and headings with special characters;
-            
-            - ``SomeClass/someFunction🙂()``
-            - <doc:article-with-emoji-in-heading#Hello-🌍>
-            - <doc:article-with-😃-in-filename>
-            - <doc:article-with-😃-in-filename#Hello-world>
-            - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename>
-            - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename#Hello-world>
-            
-            Now test the same links in topic curation.
-            
-            ## Topics
-            
-            Only curate the pages. Headings don't support curation.
-            
-            - ``SomeClass/someFunction🙂()``
-            - <doc:article-with-😃-in-filename>
-            - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename>
-            """),
-        ])
+        let catalog = Folder(
+            name: "special-characters.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "SomeModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "some-class-id", kind: .class, pathComponents: ["SomeClass"]),
+                            makeSymbol(
+                                id: "some-function-id", kind: .func,
+                                pathComponents: ["SomeClass", "someFunction🙂()"]),
+                        ],
+                        relationships: [
+                            .init(
+                                source: "some-function-id", target: "some-class-id",
+                                kind: .memberOf, targetFallback: nil)
+                        ])
+                ),
+
+                TextFile(
+                    name: "article-with-emoji-in-heading.md",
+                    utf8Content: """
+                        # Article with emoji in heading
+
+                        Abstract
+
+                        ### Hello 🌍
+                        """),
+
+                TextFile(
+                    name: "article-with-😃-in-filename.md",
+                    utf8Content: """
+                        # Article with 😃 emoji in its filename
+
+                        Abstract
+
+                        ### Hello world
+                        """),
+
+                TextFile(
+                    name: "Article: with - various! whitespace & punctuation. in, filename.md",
+                    utf8Content: """
+                        # Article with various whitespace and punctuation in its filename
+
+                        Abstract
+
+                        ### Hello world
+                        """),
+
+                TextFile(
+                    name: "SomeModuleName.md",
+                    utf8Content: """
+                        # ``SomeModuleName``
+
+                        Test linking to articles, symbols, and headings with special characters;
+
+                        - ``SomeClass/someFunction🙂()``
+                        - <doc:article-with-emoji-in-heading#Hello-🌍>
+                        - <doc:article-with-😃-in-filename>
+                        - <doc:article-with-😃-in-filename#Hello-world>
+                        - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename>
+                        - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename#Hello-world>
+
+                        Now test the same links in topic curation.
+
+                        ## Topics
+
+                        Only curate the pages. Headings don't support curation.
+
+                        - ``SomeClass/someFunction🙂()``
+                        - <doc:article-with-😃-in-filename>
+                        - <doc:Article:-with-various!-whitespace-&-punctuation.-in,-filename>
+                        """),
+            ])
         let bundleURL = try catalog.write(inside: createTemporaryDirectory())
         let (_, bundle, context) = try loadBundle(from: bundleURL)
 
         let problems = context.problems
-        XCTAssertEqual(problems.count, 0, "Unexpected problems: \(problems.map(\.diagnostic.summary).sorted())")
-        
+        XCTAssertEqual(
+            problems.count, 0, "Unexpected problems: \(problems.map(\.diagnostic.summary).sorted())"
+        )
+
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         let entity = try context.entity(with: moduleReference)
-        
+
         let moduleSymbol = try XCTUnwrap(entity.semantic as? Symbol)
         let topicSection = try XCTUnwrap(moduleSymbol.topics?.taskGroups.first)
 
         // Verify that all the links in the topic section resolved
-        XCTAssertEqual(topicSection.links.map(\.destination), [
-            "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()",
-            "doc://special-characters/documentation/special-characters/article-with---in-filename",
-            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename",
-        ])
-        
+        XCTAssertEqual(
+            topicSection.links.map(\.destination),
+            [
+                "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()",
+                "doc://special-characters/documentation/special-characters/article-with---in-filename",
+                "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename",
+            ])
+
         // Verify that all resolved link exist in the context.
         for reference in topicSection.links {
             XCTAssertNotNil(reference.destination)
-            XCTAssert(context.knownPages.contains(where: { $0.absoluteString == reference.destination })
-                   || context.nodeAnchorSections.keys.contains(where: { $0.absoluteString == reference.destination })
+            XCTAssert(
+                context.knownPages.contains(where: { $0.absoluteString == reference.destination })
+                    || context.nodeAnchorSections.keys.contains(where: {
+                        $0.absoluteString == reference.destination
+                    })
             )
         }
-        
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: moduleReference)
+
+        var translator = RenderNodeTranslator(
+            context: context, bundle: bundle, identifier: moduleReference)
         let renderNode = translator.visit(moduleSymbol) as! RenderNode
-        
+
         // Verify that the resolved links rendered as links
         XCTAssertEqual(renderNode.topicSections.first?.identifiers.count, 3)
-        XCTAssertEqual(renderNode.topicSections.first?.identifiers, [
-            "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()",
-            "doc://special-characters/documentation/special-characters/article-with---in-filename",
-            "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename",
-        ])
-        
-        
-        let contentSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
-        let lists: [RenderBlockContent.UnorderedList] = contentSection.content.compactMap({ (content: RenderBlockContent) -> RenderBlockContent.UnorderedList? in
+        XCTAssertEqual(
+            renderNode.topicSections.first?.identifiers,
+            [
+                "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()",
+                "doc://special-characters/documentation/special-characters/article-with---in-filename",
+                "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename",
+            ])
+
+        let contentSection = try XCTUnwrap(
+            renderNode.primaryContentSections.first as? ContentRenderSection)
+        let lists: [RenderBlockContent.UnorderedList] = contentSection.content.compactMap({
+            (content: RenderBlockContent) -> RenderBlockContent.UnorderedList? in
             if case let .unorderedList(list) = content {
                 return list
             } else {
                 return nil
             }
         })
-        
+
         XCTAssertEqual(lists.count, 1)
         let list = try XCTUnwrap(lists.first)
         XCTAssertEqual(list.items.count, 6, "Unexpected list items: \(list.items.map(\.content))")
-        
-        func withContentAsReference(_ listItem: RenderBlockContent.ListItem?, verify: (RenderReferenceIdentifier, Bool, String?, [RenderInlineContent]?) -> Void) {
+
+        func withContentAsReference(
+            _ listItem: RenderBlockContent.ListItem?,
+            verify: (RenderReferenceIdentifier, Bool, String?, [RenderInlineContent]?) -> Void
+        ) {
             guard let listItem else {
                 XCTFail("Missing list item")
                 return
             }
             if case let .paragraph(paragraph) = listItem.content.first,
-               case let .reference(identifier, isActive, overridingTitle, overridingTitleInlineContent) = paragraph.inlineContent.first {
+                case let .reference(
+                    identifier, isActive, overridingTitle, overridingTitleInlineContent) = paragraph
+                    .inlineContent.first
+            {
                 verify(identifier, isActive, overridingTitle, overridingTitleInlineContent)
             } else {
                 XCTFail("Unexpected list item kind: \(listItem.content)")
             }
         }
-        
+
         // First
-        withContentAsReference(list.items.first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()")
+        withContentAsReference(list.items.first) {
+            identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(
+                identifier.identifier,
+                "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()")
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-        withContentAsReference(list.items.dropFirst().first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/article-with-emoji-in-heading#Hello-%F0%9F%8C%8D")
+        withContentAsReference(list.items.dropFirst().first) {
+            identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(
+                identifier.identifier,
+                "doc://special-characters/documentation/special-characters/article-with-emoji-in-heading#Hello-%F0%9F%8C%8D"
+            )
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-        withContentAsReference(list.items.dropFirst(2).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/article-with---in-filename")
+        withContentAsReference(list.items.dropFirst(2).first) {
+            identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(
+                identifier.identifier,
+                "doc://special-characters/documentation/special-characters/article-with---in-filename"
+            )
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-        withContentAsReference(list.items.dropFirst(3).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world")
+        withContentAsReference(list.items.dropFirst(3).first) {
+            identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(
+                identifier.identifier,
+                "doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world"
+            )
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-        withContentAsReference(list.items.dropFirst(4).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename")
+        withContentAsReference(list.items.dropFirst(4).first) {
+            identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(
+                identifier.identifier,
+                "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename"
+            )
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-        withContentAsReference(list.items.dropFirst(5).first) { identifier, isActive, overridingTitle, overridingTitleInlineContent in
-            XCTAssertEqual(identifier.identifier, "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename#Hello-world")
+        withContentAsReference(list.items.dropFirst(5).first) {
+            identifier, isActive, overridingTitle, overridingTitleInlineContent in
+            XCTAssertEqual(
+                identifier.identifier,
+                "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename#Hello-world"
+            )
             XCTAssertEqual(isActive, true)
             XCTAssertEqual(overridingTitle, nil)
             XCTAssertEqual(overridingTitleInlineContent, nil)
         }
-    
+
         // Verify that the topic render references have titles with special characters when the original content contained special characters
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()"] as? TopicRenderReference)?.title,
+            (renderNode.references[
+                "doc://special-characters/documentation/SomeModuleName/SomeClass/someFunction_()"]
+                as? TopicRenderReference)?.title,
             "someFunction🙂()"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/article-with-emoji-in-heading#Hello-%F0%9F%8C%8D"] as? TopicRenderReference)?.title,
+            (renderNode.references[
+                "doc://special-characters/documentation/special-characters/article-with-emoji-in-heading#Hello-%F0%9F%8C%8D"
+            ] as? TopicRenderReference)?.title,
             "Hello 🌍"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/article-with---in-filename"] as? TopicRenderReference)?.title,
+            (renderNode.references[
+                "doc://special-characters/documentation/special-characters/article-with---in-filename"
+            ] as? TopicRenderReference)?.title,
             "Article with 😃 emoji in its filename"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world"] as? TopicRenderReference)?.title,
+            (renderNode.references[
+                "doc://special-characters/documentation/special-characters/article-with---in-filename#Hello-world"
+            ] as? TopicRenderReference)?.title,
             "Hello world"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename"] as? TopicRenderReference)?.title,
+            (renderNode.references[
+                "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename"
+            ] as? TopicRenderReference)?.title,
             "Article with various whitespace and punctuation in its filename"
         )
         XCTAssertEqual(
-            (renderNode.references["doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename#Hello-world"] as? TopicRenderReference)?.title,
+            (renderNode.references[
+                "doc://special-characters/documentation/special-characters/Article:-with---various!-whitespace-&-punctuation.-in,-filename#Hello-world"
+            ] as? TopicRenderReference)?.title,
             "Hello world"
         )
     }
-    
+
     func testNonOverloadCollisionFromExtension() throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: ["mykit-iOS.symbols.json"]) { root in
+        let (_, _, context) = try testBundleAndContext(
+            copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: ["mykit-iOS.symbols.json"]
+        ) { root in
             let sideKitURL = root.appendingPathComponent("something@SideKit.symbols.json")
             let text = """
-            {
-              "metadata": { "formatVersion" : { "major" : 1 }, "generator" : "app/1.0" },
-              "relationships" : [ ],
-              "module" : {
-                "name" : "Something",
-                "platform" : {
-                  "architecture" : "x86_64",
-                  "vendor" : "apple",
-                  "operatingSystem" : {
-                    "name" : "ios",
-                    "version" : {
-                      "major" : 10,
-                      "minor" : 15,
-                      "patch" : 0
-                    }
-                  }
-                }
-              },
-              "symbols" : [
-                  {
-                    "accessLevel" : "public",
-                    "kind" : {
-                      "identifier" : "swift.var",
-                      "displayName" : "Variable"
-                    },
-                    "names" : {
-                      "title" : "sideClass"
-                    },
-                    "pathComponents": [
-                      "sideClass"
-                    ],
-                    "identifier" : {
-                      "precise" : "s:5SideKit0A5SideClassVV",
-                      "interfaceLanguage": "swift"
-                    },
-                    "declarationFragments" : [
-                      {
-                        "kind" : "text",
-                        "spelling" : "var sideClass: String"
-                      }
-                    ]
-                 }
-              ]
-            }
-            """
-            try text.write(to: sideKitURL, atomically: true, encoding: .utf8)
-        }
-        
-        let symbolGraphProblems = context.problems
-            .filter { $0.diagnostic.source?.lastPathComponent.hasSuffix(".symbols.json") ?? false }
-            .filter { $0.diagnostic.severity != .information }
-        XCTAssert(symbolGraphProblems.isEmpty, "There shouldn't be any errors or warnings in the symbol graphs")
-        
-        // Verify the non-overload collisions form different symbol graph files were resolved
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass-swift.class", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass-swift.class/path", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/sideClass-swift.var", sourceLanguage: .swift)))
-    }
-
-    func testUnresolvedSidecarDiagnostics() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                moduleName: "ModuleName",
-                symbols: [
-                    makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["SymbolName"]),
-                ]
-            )),
-            
-            TextFile(name: "Extension.md", utf8Content: """
-            # ``/ModuleName/UnknownSymbol``
-            
-            This symbol doesn't exist in the symbol graph.        
-            """),
-            
-            TextFile(name: "SameExtension.md", utf8Content: """
-            # ``/ModuleName/UnknownSymbol``
-            
-            This symbol doesn't exist in the symbol graph.        
-            """),
-        ])
-        
-        let (bundle, context) = try loadBundle(catalog: catalog)
-        
-        let unmatchedSidecarProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.SymbolUnmatched" }))
-        XCTAssertNotNil(unmatchedSidecarProblem)
-        
-        // Verify the diagnostics have the sidecar source URL
-        let source = try XCTUnwrap(unmatchedSidecarProblem.diagnostic.source)
-        
-        let unmatchedSidecarDiagnostic = unmatchedSidecarProblem.diagnostic
-        XCTAssertTrue(bundle.markupURLs.contains(source.standardizedFileURL), "One of the files should be the diagnostic source")
-        XCTAssertEqual(unmatchedSidecarDiagnostic.range, SourceLocation(line: 1, column: 3, source: unmatchedSidecarProblem.diagnostic.source)..<SourceLocation(line: 1, column: 32, source: unmatchedSidecarProblem.diagnostic.source))
-        
-        XCTAssertEqual(unmatchedSidecarDiagnostic.summary, "No symbol matched '/ModuleName/UnknownSymbol'. 'UnknownSymbol' doesn't exist at '/ModuleName'.")
-        XCTAssertEqual(unmatchedSidecarDiagnostic.severity, .warning)
-    }
-    
-    func testExtendingSymbolWithSpaceInName() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                moduleName: "ModuleName",
-                symbols: [
-                    makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol Name"]),
-                ]
-            )),
-            
-            TextFile(name: "Extension.md", utf8Content: """
-            # ``Symbol Name``
-            
-            Extend a symbol with a space in its name.
-            """),
-            
-            TextFile(name: "Article.md", utf8Content: """
-            # Article
-            
-            Link in content to a symbol with a space in its name: ``Symbol Name``.
-            """),
-        ])
-        
-        let (bundle, context) = try loadBundle(catalog: catalog)
-        
-        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
-        
-        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/Symbol_Name", sourceLanguage: .swift)
-        let node = try context.entity(with: reference)
-        
-        XCTAssertEqual((node.semantic as? Symbol)?.abstract?.plainText, "Extend a symbol with a space in its name.")
-    }
-
-    func testDeprecationSummaryWithLocalLink() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                moduleName: "ModuleName",
-                symbols: ["Old", "New"].map {
-                    makeSymbol(id: "\($0.lowercased())-symbol-id", kind: .class, pathComponents: ["\($0)Symbol"])
-                }
-            )),
-            
-            TextFile(name: "Extension.md", utf8Content: """
-            # ``OldSymbol``
-            
-            @DeprecationSummary {
-              Use ``NewSymbol`` instead.
-            }
-            
-            Deprecate a symbol and link to its replacement in the deprecation message.
-            """),
-            
-            TextFile(name: "Article.md", utf8Content: """
-            # Article
-            
-            @DeprecationSummary {
-              Use ``NewSymbol`` instead.
-            }
-            
-            Link to external content in an article deprecation message.
-            """),
-        ])
-        
-        let (bundle, context) = try loadBundle(catalog: catalog)
-        
-        XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
-        
-        do {
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/OldSymbol", sourceLanguage: .swift)
-            let node = try context.entity(with: reference)
-            
-            let deprecatedSection = try XCTUnwrap((node.semantic as? Symbol)?.deprecatedSummary)
-            XCTAssertEqual(deprecatedSection.content.count, 1)
-            XCTAssertEqual(deprecatedSection.content.first?.format().trimmingCharacters(in: .whitespaces), "Use ``doc://unit-test/documentation/ModuleName/NewSymbol`` instead.", "The link should have been resolved")
-        }
-        
-        do {
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
-            let node = try context.entity(with: reference)
-            
-            let deprecatedSection = try XCTUnwrap((node.semantic as? Article)?.deprecationSummary)
-            XCTAssertEqual(deprecatedSection.count, 1)
-            XCTAssertEqual(deprecatedSection.first?.format().trimmingCharacters(in: .whitespaces), "Use ``doc://unit-test/documentation/ModuleName/NewSymbol`` instead.", "The link should have been resolved")
-        }
-    }
-    
-    func testUncuratedArticleDiagnostics() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            // This setup only happens if the developer manually mixes symbol inputs from different builds
-            JSONFile(name: "FirstModuleName.symbols.json", content: makeSymbolGraph(moduleName: "FirstModuleName")),
-            JSONFile(name: "SecondModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SecondModuleName")),
-            
-            // Add an article without curating it anywhere
-            // This will be uncurated because there's more than one module.
-            TextFile(name: "Article.md", utf8Content: """
-            # Article
-            
-            This article won't be curated anywhere.
-            """),
-        ])
-        
-        let (bundle, context) = try loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: .information))
-        XCTAssertNil(context.soleRootModuleReference)
-        
-        let curationDiagnostics = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.ArticleUncurated" }).map(\.diagnostic)
-        let sidecarDiagnostic = try XCTUnwrap(curationDiagnostics.first(where: { $0.source?.standardizedFileURL == bundle.markupURLs.first?.standardizedFileURL }))
-        XCTAssertNil(sidecarDiagnostic.range)
-        XCTAssertEqual(sidecarDiagnostic.summary, "You haven't curated 'doc://unit-test/documentation/unit-test/Article'")
-        XCTAssertEqual(sidecarDiagnostic.severity, .information)
-    }
-    
-    func testUpdatesReferencesForChildrenOfCollisions() throws {
-        // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
-            let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
-            var text = try String(contentsOf: sideKitURL)
-            
-            text = text.replacingOccurrences(of: "\"relationships\" : [", with: """
-            "relationships" : [
-            {
-              "source" : "s:7SideKit0A5ClassC10testSV",
-              "target" : "s:7SideKit0A5ClassC",
-              "kind" : "memberOf"
-            },
-            {
-              "source" : "s:7SideKit0A5ClassC10testE",
-              "target" : "s:7SideKit0A5ClassC",
-              "kind" : "memberOf"
-            },
-            {
-              "source" : "s:7SideKit0A5ClassC10tEstP",
-              "target" : "s:7SideKit0A5ClassC10testE",
-              "kind" : "memberOf"
-            },
-            {
-              "source" : "s:7SideKit0A5ClassC10testEE",
-              "target" : "s:7SideKit0A5ClassC10testE",
-              "kind" : "memberOf"
-            },
-            {
-              "source" : "s:7SideKit0A5ClassC10tEstPP",
-              "target" : "s:7SideKit0A5ClassC10testEE",
-              "kind" : "memberOf"
-            },
-            {
-              "source" : "s:7SideKit0A5ClassC10testnEE",
-              "target" : "s:7SideKit0A5ClassC10testE",
-              "kind" : "memberOf"
-            },
-            """)
-            
-            text = text.replacingOccurrences(of: "\"symbols\" : [", with: """
-            "symbols" : [
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.enum",
-                "displayName" : "Enumeration"
-              },
-              "names" : { "title" : "Test" },
-              "pathComponents" : [ "SideClass", "Test" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testE",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.variable",
-                "displayName" : "Type Variable"
-              },
-              "names" : { "title" : "test" },
-              "pathComponents" : [ "SideClass", "test" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testSV",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.variable",
-                "displayName" : "Type Variable"
-              },
-              "names" : { "title" : "path" },
-              "pathComponents" : [ "SideClass", "Test", "path" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10tEstP",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.enum",
-                "displayName" : "Enumeration"
-              },
-              "names" : { "title" : "NestedEnum" },
-              "pathComponents" : [ "SideClass", "Test", "NestedEnum" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testEE",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.property",
-                "displayName" : "Instance Property"
-              },
-              "names" : { "title" : "nestedEnum" },
-              "pathComponents" : [ "SideClass", "Test", "nestedEnum" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10testnEE",
-                "interfaceLanguage": "swift"
-              }
-            },
-            {
-              "accessLevel" : "public",
-              "kind" : {
-                "identifier" : "swift.variable",
-                "displayName" : "Type Variable"
-              },
-              "names" : { "title" : "path" },
-              "pathComponents" : [ "SideClass", "Test", "NestedEnum", "path" ],
-              "identifier" : {
-                "precise" : "s:7SideKit0A5ClassC10tEstPP",
-                "interfaceLanguage": "swift"
-              }
-            },
-            """)
-            try text.write(to: sideKitURL, atomically: true, encoding: .utf8)
-        }
-
-        // Test that collision symbol reference was updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift)))
-        
-        // Test that collision symbol child reference was updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/path", sourceLanguage: .swift)))
-
-        // Test that nested collisions were updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum", sourceLanguage: .swift)))
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property", sourceLanguage: .swift)))
-        
-        // Test that child of nested collision is updated
-        XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path", sourceLanguage: .swift)))
-        
-        // Verify that the symbol index has been updated with the rewritten collision-corrected symbol paths
-        XCTAssertEqual(context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10testnEE")?.path, "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property")
-        XCTAssertEqual(context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10testEE")?.path, "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum")
-        XCTAssertEqual(context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10tEstPP")?.path, "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path")
-        
-        XCTAssertEqual(context.documentationCache.reference(symbolID: "s:5MyKit0A5MyProtocol0Afunc()")?.path, "/documentation/SideKit/SideProtocol/func()")
-        XCTAssertEqual(context.documentationCache.reference(symbolID: "s:5MyKit0A5MyProtocol0Afunc()DefaultImp")?.path, "/documentation/SideKit/SideProtocol/func()-2dxqn")
-    }
-
-    func testResolvingArticleLinkBeforeCuratingIt() throws {
-        var newArticle1URL: URL!
-        
-        // Add an article without curating it anywhere
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
-            /// Curate MyKit -> new-article1
-            let myKitURL = root.appendingPathComponent("documentation").appendingPathComponent("mykit.md")
-            try """
-                # ``MyKit``
-                
-                ## Topics
-                ### New articles
-                - <doc:new-article1>
-                - <doc:new-article2>
-                """
-                .write(to: myKitURL, atomically: true, encoding: .utf8)
-            /// Curate new-article1 -> new-article2
-            newArticle1URL = root.appendingPathComponent("documentation").appendingPathComponent("new-article1.md")
-            try """
-                # New Article 1
-                Abstracts can't have links.
-
-                Paragraph with a link to <doc:new-article2>
-                """
-                .write(to: newArticle1URL, atomically: true, encoding: .utf8)
-            
-            /// Add new-article2
-            let newArticle2URL = root.appendingPathComponent("documentation").appendingPathComponent("new-article2.md")
-            try """
-                # New Article 2
-                Placeholder abstract.
-                """
-                .write(to: newArticle2URL, atomically: true, encoding: .utf8)
-        }
-        
-        // Verify that there are no problems for new-article1.md (where we resolve the link to new-article2 before it's curated)
-        XCTAssertEqual(context.problems.filter { $0.diagnostic.source?.path.hasSuffix(newArticle1URL.lastPathComponent) == true }.count, 0)
-    }
-
-    func testPrefersNonSymbolsInDocLink() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
-            // This bundle has a top-level struct named "Wrapper". Adding an article named "Wrapper.md" introduces a possibility for a link collision
-            try """
-            # An article
-            
-            This is an article with the same name as a top-level symbol
-            """.write(to: url.appendingPathComponent("Wrapper.md"), atomically: true, encoding: .utf8)
-            
-            // Also change the display name so that the article container has the same name as the module.
-            try InfoPlist(displayName: "Something", identifier: "com.example.Something").write(inside: url)
-            
-            // Use a doc-link to curate the article.
-            try """
-            # ``Something``
-            
-            Curate the article and the symbol top-level.
-            
-            ## Topics
-            
-            - <doc:Wrapper>
-            """.write(to: url.appendingPathComponent("Something.md"), atomically: true, encoding: .utf8)
-        }
-        
-        let moduleReference = try XCTUnwrap(context.rootModules.first)
-        let moduleNode = try context.entity(with: moduleReference)
-        
-        let renderContext = RenderContext(documentationContext: context, bundle: bundle)
-        let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
-        
-        let renderNode = try XCTUnwrap(converter.renderNode(for: moduleNode))
-        let curatedTopic = try XCTUnwrap(renderNode.topicSections.first?.identifiers.first)
-        
-        let topicReference = try XCTUnwrap(renderNode.references[curatedTopic] as? TopicRenderReference)
-        XCTAssertEqual(topicReference.title, "An article")
-        
-        // This test also reproduce https://github.com/swiftlang/swift-docc/issues/593
-        // When that's fixed this test should also use a symbol link to curate the top-level symbol and verify that
-        // the symbol link resolves to the symbol.
-    }
-    
-    // Modules that are being extended should not have their own symbol in the current bundle's graph.
-    func testNoSymbolForTertiarySymbolGraphModules() throws {
-        // Add an article without curating it anywhere
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
-            /// Create an extension only symbol graph.
-            let tertiaryURL = root.appendingPathComponent("Tertiary@MyKit.symbols.json")
-            try """
                 {
-                  "metadata": {
-                    "formatVersion": { "major": 48, "minor": 1516, "patch": 2342 },
-                    "generator": "Apple Swift version 5.3-dev (LLVM f7753df930, Swift a3cf3737d4)"
-                  },
-                  "module": {
-                    "name": "Tertiary",
-                    "platform": {
-                      "architecture": "x86_64",
-                      "vendor": "apple",
-                      "operatingSystem": {
-                        "name": "macosx",
-                        "minimumVersion": { "major": 10, "minor": 10, "patch": 0
+                  "metadata": { "formatVersion" : { "major" : 1 }, "generator" : "app/1.0" },
+                  "relationships" : [ ],
+                  "module" : {
+                    "name" : "Something",
+                    "platform" : {
+                      "architecture" : "x86_64",
+                      "vendor" : "apple",
+                      "operatingSystem" : {
+                        "name" : "ios",
+                        "version" : {
+                          "major" : 10,
+                          "minor" : 15,
+                          "patch" : 0
                         }
                       }
                     }
                   },
-                  "symbols": [],
-                  "relationships": []
+                  "symbols" : [
+                      {
+                        "accessLevel" : "public",
+                        "kind" : {
+                          "identifier" : "swift.var",
+                          "displayName" : "Variable"
+                        },
+                        "names" : {
+                          "title" : "sideClass"
+                        },
+                        "pathComponents": [
+                          "sideClass"
+                        ],
+                        "identifier" : {
+                          "precise" : "s:5SideKit0A5SideClassVV",
+                          "interfaceLanguage": "swift"
+                        },
+                        "declarationFragments" : [
+                          {
+                            "kind" : "text",
+                            "spelling" : "var sideClass: String"
+                          }
+                        ]
+                     }
+                  ]
                 }
                 """
-                .write(to: tertiaryURL, atomically: true, encoding: .utf8)
+            try text.write(to: sideKitURL, atomically: true, encoding: .utf8)
+        }
+
+        let symbolGraphProblems = context.problems
+            .filter { $0.diagnostic.source?.lastPathComponent.hasSuffix(".symbols.json") ?? false }
+            .filter { $0.diagnostic.severity != .information }
+        XCTAssert(
+            symbolGraphProblems.isEmpty,
+            "There shouldn't be any errors or warnings in the symbol graphs")
+
+        // Verify the non-overload collisions form different symbol graph files were resolved
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass-swift.class", sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass-swift.class/path",
+                    sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/sideClass-swift.var", sourceLanguage: .swift)))
+    }
+
+    func testUnresolvedSidecarDiagnostics() throws {
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "ModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "symbol-id", kind: .class, pathComponents: ["SymbolName"])
+                        ]
+                    )),
+
+                TextFile(
+                    name: "Extension.md",
+                    utf8Content: """
+                        # ``/ModuleName/UnknownSymbol``
+
+                        This symbol doesn't exist in the symbol graph.        
+                        """),
+
+                TextFile(
+                    name: "SameExtension.md",
+                    utf8Content: """
+                        # ``/ModuleName/UnknownSymbol``
+
+                        This symbol doesn't exist in the symbol graph.        
+                        """),
+            ])
+
+        let (bundle, context) = try loadBundle(catalog: catalog)
+
+        let unmatchedSidecarProblem = try XCTUnwrap(
+            context.problems.first(where: {
+                $0.diagnostic.identifier == "org.swift.docc.SymbolUnmatched"
+            }))
+        XCTAssertNotNil(unmatchedSidecarProblem)
+
+        // Verify the diagnostics have the sidecar source URL
+        let source = try XCTUnwrap(unmatchedSidecarProblem.diagnostic.source)
+
+        let unmatchedSidecarDiagnostic = unmatchedSidecarProblem.diagnostic
+        XCTAssertTrue(
+            bundle.markupURLs.contains(source.standardizedFileURL),
+            "One of the files should be the diagnostic source")
+        XCTAssertEqual(
+            unmatchedSidecarDiagnostic.range,
+            SourceLocation(
+                line: 1, column: 3, source: unmatchedSidecarProblem.diagnostic.source)..<SourceLocation(
+                    line: 1, column: 32, source: unmatchedSidecarProblem.diagnostic.source))
+
+        XCTAssertEqual(
+            unmatchedSidecarDiagnostic.summary,
+            "No symbol matched '/ModuleName/UnknownSymbol'. 'UnknownSymbol' doesn't exist at '/ModuleName'."
+        )
+        XCTAssertEqual(unmatchedSidecarDiagnostic.severity, .warning)
+    }
+
+    func testExtendingSymbolWithSpaceInName() throws {
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "ModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "symbol-id", kind: .class, pathComponents: ["Symbol Name"])
+                        ]
+                    )),
+
+                TextFile(
+                    name: "Extension.md",
+                    utf8Content: """
+                        # ``Symbol Name``
+
+                        Extend a symbol with a space in its name.
+                        """),
+
+                TextFile(
+                    name: "Article.md",
+                    utf8Content: """
+                        # Article
+
+                        Link in content to a symbol with a space in its name: ``Symbol Name``.
+                        """),
+            ])
+
+        let (bundle, context) = try loadBundle(catalog: catalog)
+
+        XCTAssert(
+            context.problems.isEmpty,
+            "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))"
+        )
+
+        let reference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/ModuleName/Symbol_Name",
+            sourceLanguage: .swift)
+        let node = try context.entity(with: reference)
+
+        XCTAssertEqual(
+            (node.semantic as? Symbol)?.abstract?.plainText,
+            "Extend a symbol with a space in its name.")
+    }
+
+    func testDeprecationSummaryWithLocalLink() throws {
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "ModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: ["Old", "New"].map {
+                            makeSymbol(
+                                id: "\($0.lowercased())-symbol-id", kind: .class,
+                                pathComponents: ["\($0)Symbol"])
+                        }
+                    )),
+
+                TextFile(
+                    name: "Extension.md",
+                    utf8Content: """
+                        # ``OldSymbol``
+
+                        @DeprecationSummary {
+                          Use ``NewSymbol`` instead.
+                        }
+
+                        Deprecate a symbol and link to its replacement in the deprecation message.
+                        """),
+
+                TextFile(
+                    name: "Article.md",
+                    utf8Content: """
+                        # Article
+
+                        @DeprecationSummary {
+                          Use ``NewSymbol`` instead.
+                        }
+
+                        Link to external content in an article deprecation message.
+                        """),
+            ])
+
+        let (bundle, context) = try loadBundle(catalog: catalog)
+
+        XCTAssert(
+            context.problems.isEmpty,
+            "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))"
+        )
+
+        do {
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/ModuleName/OldSymbol",
+                sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+
+            let deprecatedSection = try XCTUnwrap((node.semantic as? Symbol)?.deprecatedSummary)
+            XCTAssertEqual(deprecatedSection.content.count, 1)
+            XCTAssertEqual(
+                deprecatedSection.content.first?.format().trimmingCharacters(in: .whitespaces),
+                "Use ``doc://unit-test/documentation/ModuleName/NewSymbol`` instead.",
+                "The link should have been resolved")
+        }
+
+        do {
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/unit-test/Article",
+                sourceLanguage: .swift)
+            let node = try context.entity(with: reference)
+
+            let deprecatedSection = try XCTUnwrap((node.semantic as? Article)?.deprecationSummary)
+            XCTAssertEqual(deprecatedSection.count, 1)
+            XCTAssertEqual(
+                deprecatedSection.first?.format().trimmingCharacters(in: .whitespaces),
+                "Use ``doc://unit-test/documentation/ModuleName/NewSymbol`` instead.",
+                "The link should have been resolved")
+        }
+    }
+
+    func testUncuratedArticleDiagnostics() throws {
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                // This setup only happens if the developer manually mixes symbol inputs from different builds
+                JSONFile(
+                    name: "FirstModuleName.symbols.json",
+                    content: makeSymbolGraph(moduleName: "FirstModuleName")),
+                JSONFile(
+                    name: "SecondModuleName.symbols.json",
+                    content: makeSymbolGraph(moduleName: "SecondModuleName")),
+
+                // Add an article without curating it anywhere
+                // This will be uncurated because there's more than one module.
+                TextFile(
+                    name: "Article.md",
+                    utf8Content: """
+                        # Article
+
+                        This article won't be curated anywhere.
+                        """),
+            ])
+
+        let (bundle, context) = try loadBundle(
+            catalog: catalog, diagnosticEngine: .init(filterLevel: .information))
+        XCTAssertNil(context.soleRootModuleReference)
+
+        let curationDiagnostics = context.problems.filter({
+            $0.diagnostic.identifier == "org.swift.docc.ArticleUncurated"
+        }).map(\.diagnostic)
+        let sidecarDiagnostic = try XCTUnwrap(
+            curationDiagnostics.first(where: {
+                $0.source?.standardizedFileURL == bundle.markupURLs.first?.standardizedFileURL
+            }))
+        XCTAssertNil(sidecarDiagnostic.range)
+        XCTAssertEqual(
+            sidecarDiagnostic.summary,
+            "You haven't curated 'doc://unit-test/documentation/unit-test/Article'")
+        XCTAssertEqual(sidecarDiagnostic.severity, .information)
+    }
+
+    func testUpdatesReferencesForChildrenOfCollisions() throws {
+        // Add some symbol collisions to graph
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            root in
+            let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
+            var text = try String(contentsOf: sideKitURL)
+
+            text = text.replacingOccurrences(
+                of: "\"relationships\" : [",
+                with: """
+                    "relationships" : [
+                    {
+                      "source" : "s:7SideKit0A5ClassC10testSV",
+                      "target" : "s:7SideKit0A5ClassC",
+                      "kind" : "memberOf"
+                    },
+                    {
+                      "source" : "s:7SideKit0A5ClassC10testE",
+                      "target" : "s:7SideKit0A5ClassC",
+                      "kind" : "memberOf"
+                    },
+                    {
+                      "source" : "s:7SideKit0A5ClassC10tEstP",
+                      "target" : "s:7SideKit0A5ClassC10testE",
+                      "kind" : "memberOf"
+                    },
+                    {
+                      "source" : "s:7SideKit0A5ClassC10testEE",
+                      "target" : "s:7SideKit0A5ClassC10testE",
+                      "kind" : "memberOf"
+                    },
+                    {
+                      "source" : "s:7SideKit0A5ClassC10tEstPP",
+                      "target" : "s:7SideKit0A5ClassC10testEE",
+                      "kind" : "memberOf"
+                    },
+                    {
+                      "source" : "s:7SideKit0A5ClassC10testnEE",
+                      "target" : "s:7SideKit0A5ClassC10testE",
+                      "kind" : "memberOf"
+                    },
+                    """)
+
+            text = text.replacingOccurrences(
+                of: "\"symbols\" : [",
+                with: """
+                    "symbols" : [
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.enum",
+                        "displayName" : "Enumeration"
+                      },
+                      "names" : { "title" : "Test" },
+                      "pathComponents" : [ "SideClass", "Test" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testE",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.variable",
+                        "displayName" : "Type Variable"
+                      },
+                      "names" : { "title" : "test" },
+                      "pathComponents" : [ "SideClass", "test" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testSV",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.variable",
+                        "displayName" : "Type Variable"
+                      },
+                      "names" : { "title" : "path" },
+                      "pathComponents" : [ "SideClass", "Test", "path" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10tEstP",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.enum",
+                        "displayName" : "Enumeration"
+                      },
+                      "names" : { "title" : "NestedEnum" },
+                      "pathComponents" : [ "SideClass", "Test", "NestedEnum" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testEE",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.property",
+                        "displayName" : "Instance Property"
+                      },
+                      "names" : { "title" : "nestedEnum" },
+                      "pathComponents" : [ "SideClass", "Test", "nestedEnum" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10testnEE",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    {
+                      "accessLevel" : "public",
+                      "kind" : {
+                        "identifier" : "swift.variable",
+                        "displayName" : "Type Variable"
+                      },
+                      "names" : { "title" : "path" },
+                      "pathComponents" : [ "SideClass", "Test", "NestedEnum", "path" ],
+                      "identifier" : {
+                        "precise" : "s:7SideKit0A5ClassC10tEstPP",
+                        "interfaceLanguage": "swift"
+                      }
+                    },
+                    """)
+            try text.write(to: sideKitURL, atomically: true, encoding: .utf8)
+        }
+
+        // Test that collision symbol reference was updated
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/Test-swift.enum", sourceLanguage: .swift
+                )))
+
+        // Test that collision symbol child reference was updated
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/Test-swift.enum/path",
+                    sourceLanguage: .swift)))
+
+        // Test that nested collisions were updated
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path: "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum",
+                    sourceLanguage: .swift)))
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path:
+                        "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property",
+                    sourceLanguage: .swift)))
+
+        // Test that child of nested collision is updated
+        XCTAssertNoThrow(
+            try context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example",
+                    path:
+                        "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path",
+                    sourceLanguage: .swift)))
+
+        // Verify that the symbol index has been updated with the rewritten collision-corrected symbol paths
+        XCTAssertEqual(
+            context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10testnEE")?.path,
+            "/documentation/SideKit/SideClass/Test-swift.enum/nestedEnum-swift.property")
+        XCTAssertEqual(
+            context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10testEE")?.path,
+            "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum")
+        XCTAssertEqual(
+            context.documentationCache.reference(symbolID: "s:7SideKit0A5ClassC10tEstPP")?.path,
+            "/documentation/SideKit/SideClass/Test-swift.enum/NestedEnum-swift.enum/path")
+
+        XCTAssertEqual(
+            context.documentationCache.reference(symbolID: "s:5MyKit0A5MyProtocol0Afunc()")?.path,
+            "/documentation/SideKit/SideProtocol/func()")
+        XCTAssertEqual(
+            context.documentationCache.reference(
+                symbolID: "s:5MyKit0A5MyProtocol0Afunc()DefaultImp")?.path,
+            "/documentation/SideKit/SideProtocol/func()-2dxqn")
+    }
+
+    func testResolvingArticleLinkBeforeCuratingIt() throws {
+        var newArticle1URL: URL!
+
+        // Add an article without curating it anywhere
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            root in
+            /// Curate MyKit -> new-article1
+            let myKitURL = root.appendingPathComponent("documentation").appendingPathComponent(
+                "mykit.md")
+            try """
+            # ``MyKit``
+
+            ## Topics
+            ### New articles
+            - <doc:new-article1>
+            - <doc:new-article2>
+            """
+            .write(to: myKitURL, atomically: true, encoding: .utf8)
+            /// Curate new-article1 -> new-article2
+            newArticle1URL = root.appendingPathComponent("documentation").appendingPathComponent(
+                "new-article1.md")
+            try """
+            # New Article 1
+            Abstracts can't have links.
+
+            Paragraph with a link to <doc:new-article2>
+            """
+            .write(to: newArticle1URL, atomically: true, encoding: .utf8)
+
+            /// Add new-article2
+            let newArticle2URL = root.appendingPathComponent("documentation")
+                .appendingPathComponent("new-article2.md")
+            try """
+            # New Article 2
+            Placeholder abstract.
+            """
+            .write(to: newArticle2URL, atomically: true, encoding: .utf8)
+        }
+
+        // Verify that there are no problems for new-article1.md (where we resolve the link to new-article2 before it's curated)
+        XCTAssertEqual(
+            context.problems.filter {
+                $0.diagnostic.source?.path.hasSuffix(newArticle1URL.lastPathComponent) == true
+            }.count, 0)
+    }
+
+    func testPrefersNonSymbolsInDocLink() throws {
+        let (_, bundle, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule")
+        { url in
+            // This bundle has a top-level struct named "Wrapper". Adding an article named "Wrapper.md" introduces a possibility for a link collision
+            try """
+            # An article
+
+            This is an article with the same name as a top-level symbol
+            """.write(
+                to: url.appendingPathComponent("Wrapper.md"), atomically: true, encoding: .utf8)
+
+            // Also change the display name so that the article container has the same name as the module.
+            try InfoPlist(displayName: "Something", identifier: "com.example.Something").write(
+                inside: url)
+
+            // Use a doc-link to curate the article.
+            try """
+            # ``Something``
+
+            Curate the article and the symbol top-level.
+
+            ## Topics
+
+            - <doc:Wrapper>
+            """.write(
+                to: url.appendingPathComponent("Something.md"), atomically: true, encoding: .utf8)
+        }
+
+        let moduleReference = try XCTUnwrap(context.rootModules.first)
+        let moduleNode = try context.entity(with: moduleReference)
+
+        let renderContext = RenderContext(documentationContext: context, bundle: bundle)
+        let converter = DocumentationContextConverter(
+            bundle: bundle, context: context, renderContext: renderContext)
+
+        let renderNode = try XCTUnwrap(converter.renderNode(for: moduleNode))
+        let curatedTopic = try XCTUnwrap(renderNode.topicSections.first?.identifiers.first)
+
+        let topicReference = try XCTUnwrap(
+            renderNode.references[curatedTopic] as? TopicRenderReference)
+        XCTAssertEqual(topicReference.title, "An article")
+
+        // This test also reproduce https://github.com/swiftlang/swift-docc/issues/593
+        // When that's fixed this test should also use a symbol link to curate the top-level symbol and verify that
+        // the symbol link resolves to the symbol.
+    }
+
+    // Modules that are being extended should not have their own symbol in the current bundle's graph.
+    func testNoSymbolForTertiarySymbolGraphModules() throws {
+        // Add an article without curating it anywhere
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            root in
+            /// Create an extension only symbol graph.
+            let tertiaryURL = root.appendingPathComponent("Tertiary@MyKit.symbols.json")
+            try """
+            {
+              "metadata": {
+                "formatVersion": { "major": 48, "minor": 1516, "patch": 2342 },
+                "generator": "Apple Swift version 5.3-dev (LLVM f7753df930, Swift a3cf3737d4)"
+              },
+              "module": {
+                "name": "Tertiary",
+                "platform": {
+                  "architecture": "x86_64",
+                  "vendor": "apple",
+                  "operatingSystem": {
+                    "name": "macosx",
+                    "minimumVersion": { "major": 10, "minor": 10, "patch": 0
+                    }
+                  }
+                }
+              },
+              "symbols": [],
+              "relationships": []
+            }
+            """
+            .write(to: tertiaryURL, atomically: true, encoding: .utf8)
         }
 
         // Verify that the Tertiary framework has no symbol in the graph
-        XCTAssertNotNil(try? context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)))
-        XCTAssertNil(try? context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Tertiary", sourceLanguage: .swift)))
+        XCTAssertNotNil(
+            try? context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example", path: "/documentation/MyKit",
+                    sourceLanguage: .swift)))
+        XCTAssertNil(
+            try? context.entity(
+                with: ResolvedTopicReference(
+                    bundleID: "org.swift.docc.example", path: "/documentation/Tertiary",
+                    sourceLanguage: .swift)))
     }
-    
+
     func testDeclarationTokenKinds() throws {
         let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
-        
-        let myFunc = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
-        
+
+        let myFunc = try context.entity(
+            with: ResolvedTopicReference(
+                bundleID: "org.swift.docc.example",
+                path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
+
         // Symbol graph declaration tokens, including more esoteric kinds like internalParam, externalParam, and unknown kinds.
-        let tokens = (myFunc.symbol!.mixins[SymbolGraph.Symbol.DeclarationFragments.mixinKey] as? SymbolGraph.Symbol.DeclarationFragments)?
+        let tokens =
+            (myFunc.symbol!.mixins[SymbolGraph.Symbol.DeclarationFragments.mixinKey]
+            as? SymbolGraph.Symbol.DeclarationFragments)?
             .declarationFragments
             .map({ fragment -> String in
                 return fragment.kind.rawValue
             })
-        XCTAssertEqual(tokens, ["keyword", "text", "identifier", "text", "externalParam", "text", "internalParam", "unhandledTokenKind", "text"])
-        
+        XCTAssertEqual(
+            tokens,
+            [
+                "keyword", "text", "identifier", "text", "externalParam", "text", "internalParam",
+                "unhandledTokenKind", "text",
+            ])
+
         // Render declaration and compare token kinds with symbol graph
         let symbol = myFunc.semantic as! Symbol
-        var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: myFunc.reference)
+        var translator = RenderNodeTranslator(
+            context: context, bundle: bundle, identifier: myFunc.reference)
         let renderNode = translator.visitSymbol(symbol) as! RenderNode
-        
+
         let declarationTokens = renderNode.primaryContentSections.mapFirst { section -> [String]? in
             guard section.kind == .declarations,
                 let declarations = section as? DeclarationsRenderSection,
                 let declaration = declarations.declarations.first
-                else { return nil }
+            else { return nil }
             return declaration.tokens.map({ token in return token.kind.rawValue })
         }
-        
+
         // Verify the unhandled token kind is defaulting to "text"
-        XCTAssertEqual(declarationTokens, tokens?.map({ return $0 == "unhandledTokenKind" ? "text" : $0 }))
+        XCTAssertEqual(
+            declarationTokens, tokens?.map({ return $0 == "unhandledTokenKind" ? "text" : $0 }))
     }
-    
+
     // Test reference resolving in symbol graph docs
     func testReferenceResolvingDiagnosticsInSourceDocs() throws {
         for (source, expectedDiagnosticSource) in [
             ("file:///path/to/file.swift", "file:///path/to/file.swift"),
             // Test the scenario where the symbol graph file contains invalid URLs (rdar://77335208).
-            ("file:///path with spaces/to/file.swift", "file:///path%20with%20spaces/to/file.swift"),
+            (
+                "file:///path with spaces/to/file.swift",
+                "file:///path%20with%20spaces/to/file.swift"
+            ),
         ] {
             // Create an empty bundle
             let targetURL = try createTemporaryDirectory(named: "test.docc")
-            
+
             // Copy test Info.plist
-            try FileManager.default.copyItem(at: Bundle.module.url(
-                forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-                                                .appendingPathComponent("Info.plist"),
-                                             to: targetURL.appendingPathComponent("Info.plist")
+            try FileManager.default.copyItem(
+                at: Bundle.module.url(
+                    forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc",
+                    subdirectory: "Test Bundles")!
+                    .appendingPathComponent("Info.plist"),
+                to: targetURL.appendingPathComponent("Info.plist")
             )
-            
+
             // Create symbol graph
             let referencesURL = targetURL.appendingPathComponent("references.symbols.json")
             let text = """
-            {
-              "metadata": { "formatVersion" : { "major" : 1 }, "generator" : "app/1.0" },
-              "module" : {
-                "name" : "References",
-                "platform" : {
-                  "architecture" : "x86_64",
-                  "vendor" : "apple",
-                  "operatingSystem" : { "name" : "ios", "version" : { "major" : 48, "minor" : 1516, "patch" : 2342 } }
-                }
-              },
-              "relationships" : [
-                
-              ],
-              "symbols" : [
-                   {
-                     "accessLevel" : "public",
-                     "kind" : { "identifier" : "swift.class", "displayName" : "Class" },
-                     "names" : { "title" : "RefClass" },
-                     "pathComponents": [ "RefClass" ],
-                     "identifier" : {
-                       "precise" : "RefClass",
-                       "interfaceLanguage": "swift"
-                     },
-                     "docComment" : {
-                       "lines" : [
-                         {
-                             "range": {
-                               "start": { "line": 16, "character": 8 },
-                               "end": { "line": 16, "character": 56 }
-                             },
-                             "text" : "Resolvable: ``refVariable``, ``References``, ``References/refVariable``. Unresolvable: ``Foundation/URL``."
-                         }
-                       ]
-                    },
-                    "location": {
-                      "uri": "\(source)",
-                      "position": { "line": 10, "character": 10 }
+                {
+                  "metadata": { "formatVersion" : { "major" : 1 }, "generator" : "app/1.0" },
+                  "module" : {
+                    "name" : "References",
+                    "platform" : {
+                      "architecture" : "x86_64",
+                      "vendor" : "apple",
+                      "operatingSystem" : { "name" : "ios", "version" : { "major" : 48, "minor" : 1516, "patch" : 2342 } }
                     }
                   },
-            
-                  {
-                    "accessLevel" : "public",
-                    "kind" : { "identifier" : "swift.var", "displayName" : "Variable" },
-                    "names" : { "title" : "refVariable" },
-                    "pathComponents": [ "refVariable" ],
-                    "identifier" : {
-                      "precise" : "refVariable",
-                      "interfaceLanguage": "swift"
-                    },
-                    "docComment" : {
-                      "lines" : [
-                        {
-                            "range": {
-                              "start": { "line": 16, "character": 8 },
-                              "end": { "line": 16, "character": 56 }
-                            },
-                            "text" : "Resolvable: ``refVariable``, ``References``, ``References/refVariable``, ``RefClass``"
+                  "relationships" : [
+                    
+                  ],
+                  "symbols" : [
+                       {
+                         "accessLevel" : "public",
+                         "kind" : { "identifier" : "swift.class", "displayName" : "Class" },
+                         "names" : { "title" : "RefClass" },
+                         "pathComponents": [ "RefClass" ],
+                         "identifier" : {
+                           "precise" : "RefClass",
+                           "interfaceLanguage": "swift"
+                         },
+                         "docComment" : {
+                           "lines" : [
+                             {
+                                 "range": {
+                                   "start": { "line": 16, "character": 8 },
+                                   "end": { "line": 16, "character": 56 }
+                                 },
+                                 "text" : "Resolvable: ``refVariable``, ``References``, ``References/refVariable``. Unresolvable: ``Foundation/URL``."
+                             }
+                           ]
                         },
-                        {
-                          "range": {
-                            "start": { "line": 17, "character": 8 },
-                            "end": { "line": 17, "character": 56 }
-                          },
-                          "text" : "Unresolvable: ``refVariable123``, ``References1``, ``References1/refVariable``, ``RefClass/refVariable``"
+                        "location": {
+                          "uri": "\(source)",
+                          "position": { "line": 10, "character": 10 }
                         }
-                      ]
-                    },
-                    "location": {
-                      "uri": "\(source)",
-                      "position": { "line": 20, "character": 10 }
-                    }
-                 }
-              ]
-            }
-            """
+                      },
+
+                      {
+                        "accessLevel" : "public",
+                        "kind" : { "identifier" : "swift.var", "displayName" : "Variable" },
+                        "names" : { "title" : "refVariable" },
+                        "pathComponents": [ "refVariable" ],
+                        "identifier" : {
+                          "precise" : "refVariable",
+                          "interfaceLanguage": "swift"
+                        },
+                        "docComment" : {
+                          "lines" : [
+                            {
+                                "range": {
+                                  "start": { "line": 16, "character": 8 },
+                                  "end": { "line": 16, "character": 56 }
+                                },
+                                "text" : "Resolvable: ``refVariable``, ``References``, ``References/refVariable``, ``RefClass``"
+                            },
+                            {
+                              "range": {
+                                "start": { "line": 17, "character": 8 },
+                                "end": { "line": 17, "character": 56 }
+                              },
+                              "text" : "Unresolvable: ``refVariable123``, ``References1``, ``References1/refVariable``, ``RefClass/refVariable``"
+                            }
+                          ]
+                        },
+                        "location": {
+                          "uri": "\(source)",
+                          "position": { "line": 20, "character": 10 }
+                        }
+                     }
+                  ]
+                }
+                """
             try text.write(to: referencesURL, atomically: true, encoding: .utf8)
-            
+
             // Load the bundle & reference resolve symbol graph docs
             let (_, _, context) = try loadBundle(from: targetURL)
-            
+
             guard context.problems.count == 5 else {
-                XCTFail("Expected 5 problems during reference resolving; got \(context.problems.count)")
+                XCTFail(
+                    "Expected 5 problems during reference resolving; got \(context.problems.count)")
                 return
             }
-            
+
             // All problems should be unresolved references
-            XCTAssertTrue(context.problems.allSatisfy({ $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
-            
-            XCTAssert(context.problems.allSatisfy { $0.diagnostic.source?.absoluteString == expectedDiagnosticSource })
-            
+            XCTAssertTrue(
+                context.problems.allSatisfy({
+                    $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference"
+                }))
+
+            XCTAssert(
+                context.problems.allSatisfy {
+                    $0.diagnostic.source?.absoluteString == expectedDiagnosticSource
+                })
+
             // Verify the expected source ranges
             XCTAssertEqual(
-                context.problems.map { "\($0.diagnostic.range!.lowerBound.line):\($0.diagnostic.range!.lowerBound.column)" }.sorted(),
+                context.problems.map {
+                    "\($0.diagnostic.range!.lowerBound.line):\($0.diagnostic.range!.lowerBound.column)"
+                }.sorted(),
                 ["17:98", "18:100", "18:25", "18:45", "18:62"].sorted()
             )
         }
     }
-    
+
     func testNavigatorTitle() throws {
         let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         func renderNodeForPath(path: String) throws -> (DocumentationNode, RenderNode) {
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: path, sourceLanguage: .swift)
             let node = try context.entity(with: reference)
 
             let symbol = node.semantic as! Symbol
-            var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
+            var translator = RenderNodeTranslator(
+                context: context, bundle: bundle, identifier: reference)
             let renderNode = translator.visitSymbol(symbol) as! RenderNode
 
             return (node, renderNode)
         }
-        
+
         do {
             let (node, renderNode) = try renderNodeForPath(path: "/documentation/MyKit/MyClass")
 
             // Testing the model is parsing both subHeading and navigator keys correctly
-            XCTAssertEqual((node.semantic as? Symbol)?.subHeading?.map { $0.spelling }, ["class", " ", "MyClass"])
-            XCTAssertEqual((node.semantic as? Symbol)?.navigator?.map { $0.spelling }, ["MyClassNavigator"])
-            
+            XCTAssertEqual(
+                (node.semantic as? Symbol)?.subHeading?.map { $0.spelling },
+                ["class", " ", "MyClass"])
+            XCTAssertEqual(
+                (node.semantic as? Symbol)?.navigator?.map { $0.spelling }, ["MyClassNavigator"])
+
             // Testing correct rendering of the metadata keys
-            XCTAssertEqual(renderNode.metadata.fragments?.map { $0.text }, ["class", " ", "MyClass"])
-            XCTAssertEqual(renderNode.metadata.navigatorTitle?.map { $0.text }, ["MyClassNavigator"])
+            XCTAssertEqual(
+                renderNode.metadata.fragments?.map { $0.text }, ["class", " ", "MyClass"])
+            XCTAssertEqual(
+                renderNode.metadata.navigatorTitle?.map { $0.text }, ["MyClassNavigator"])
         }
-        
+
         do {
             let (_, renderNode) = try renderNodeForPath(path: "/documentation/MyKit")
 
-            guard let renderReference = renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass"] as? TopicRenderReference else {
+            guard
+                let renderReference = renderNode.references[
+                    "doc://org.swift.docc.example/documentation/MyKit/MyClass"]
+                    as? TopicRenderReference
+            else {
                 XCTFail("MyClass render reference not found")
                 return
             }
-            
+
             // Testing correct rendering of the render reference keys
             XCTAssertEqual(renderReference.fragments?.map { $0.text }, ["class", " ", "MyClass"])
             XCTAssertEqual(renderReference.navigatorTitle?.map { $0.text }, ["MyClassNavigator"])
         }
     }
-    
+
     func testCrossSymbolGraphPathCollisions() throws {
         // Create temp folder
         let tempURL = try createTemporaryDirectory()
 
         // Create test bundle
-        let catalogURL = try Folder(name: "collisions.docc", content: [
-            InfoPlist(displayName: "Collisions", identifier: "com.test.collisions"),
-            CopyOfFile(original: Bundle.module.url(
+        let catalogURL = try Folder(
+            name: "collisions.docc",
+            content: [
+                InfoPlist(displayName: "Collisions", identifier: "com.test.collisions"),
+                CopyOfFile(
+                    original: Bundle.module.url(
                         forResource: "Collisions-iOS.symbols", withExtension: "json",
                         subdirectory: "Test Resources")!),
-            CopyOfFile(original: Bundle.module.url(
+                CopyOfFile(
+                    original: Bundle.module.url(
                         forResource: "Collisions-macOS.symbols", withExtension: "json",
                         subdirectory: "Test Resources")!),
-        ]).write(inside: tempURL)
-        
+            ]
+        ).write(inside: tempURL)
+
         // Load test bundle
         let (_, _, context) = try loadBundle(from: catalogURL)
-        
+
         let referenceForPath: (String) -> ResolvedTopicReference = { path in
-            return ResolvedTopicReference(bundleID: "com.test.collisions", path: "/documentation" + path, sourceLanguage: .swift)
+            return ResolvedTopicReference(
+                bundleID: "com.test.collisions", path: "/documentation" + path,
+                sourceLanguage: .swift)
         }
-        
+
         // Verify that:
         // 1. Symbol collisions from different graphs "Collisions-iOS.symbols.json" and "Collisions-macOS.symbols.json"
         // were detected and resolved
-        XCTAssertNotNil(try context.entity(with: referenceForPath("/Collisions/SharedStruct/testFunc(_:)-73bpa")))
-        XCTAssertNotNil(try context.entity(with: referenceForPath("/Collisions/SharedStruct/testFunc(_:)-734tu")))
+        XCTAssertNotNil(
+            try context.entity(
+                with: referenceForPath("/Collisions/SharedStruct/testFunc(_:)-73bpa")))
+        XCTAssertNotNil(
+            try context.entity(
+                with: referenceForPath("/Collisions/SharedStruct/testFunc(_:)-734tu")))
 
         // 2. The same symbol from different graphs was not detected as a collision
         XCTAssertNotNil(try context.entity(with: referenceForPath("/Collisions/SharedStruct")))
 
         // 3. The symbols from all graphs are merged into the topic graph
-        XCTAssertNotNil(try context.entity(with: referenceForPath("/Collisions/SharedStruct/iOSVar")))
+        XCTAssertNotNil(
+            try context.entity(with: referenceForPath("/Collisions/SharedStruct/iOSVar")))
     }
-    
+
     func testLinkToSymbolWithoutPage() throws {
         let inheritedDefaultImplementationsSGF = Bundle.module.url(
             forResource: "InheritedDefaultImplementations.symbols",
@@ -2689,70 +3425,89 @@ let expected = """
             withExtension: "json",
             subdirectory: "Test Resources"
         )!
-        
+
         let testBundle = try Folder(
             name: "unit-test.docc",
             content: [
                 CopyOfFile(original: inheritedDefaultImplementationsSGF),
                 CopyOfFile(original: inheritedDefaultImplementationsAtSwiftSGF),
-                TextFile(name: "doc-extension.md", utf8Content: """
-                # ``FirstTarget``
-                
-                Link to a default implementation symbol that doesn't have a page in this build.
-                
-                - ``Comparable/localDefaultImplementation()``
-                """)
+                TextFile(
+                    name: "doc-extension.md",
+                    utf8Content: """
+                        # ``FirstTarget``
+
+                        Link to a default implementation symbol that doesn't have a page in this build.
+
+                        - ``Comparable/localDefaultImplementation()``
+                        """),
             ]
         ).write(inside: createTemporaryDirectory())
-        
+
         let (_, _, context) = try loadBundle(from: testBundle)
-        
-        let problem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
-        XCTAssertEqual(problem.diagnostic.summary, "'FirstTarget/Comparable/localDefaultImplementation()' has no page and isn't available for linking.")
+
+        let problem = try XCTUnwrap(
+            context.problems.first(where: {
+                $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference"
+            }))
+        XCTAssertEqual(
+            problem.diagnostic.summary,
+            "'FirstTarget/Comparable/localDefaultImplementation()' has no page and isn't available for linking."
+        )
     }
-    
+
     func testContextCachesReferences() throws {
         let bundleID: DocumentationBundle.Identifier = #function
         // Verify there is no pool bucket for the bundle we're about to test
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
-        
-        let (_, _, _) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { rootURL in
-            let infoPlistURL = rootURL.appendingPathComponent("Info.plist", isDirectory: false)
-            try! String(contentsOf: infoPlistURL)
-                .replacingOccurrences(of: "org.swift.docc.example", with: bundleID.rawValue)
-                .write(to: infoPlistURL, atomically: true, encoding: .utf8)
-        })
+
+        let (_, _, _) = try testBundleAndContext(
+            copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [],
+            configureBundle: { rootURL in
+                let infoPlistURL = rootURL.appendingPathComponent("Info.plist", isDirectory: false)
+                try! String(contentsOf: infoPlistURL)
+                    .replacingOccurrences(of: "org.swift.docc.example", with: bundleID.rawValue)
+                    .write(to: infoPlistURL, atomically: true, encoding: .utf8)
+            })
 
         // Verify there is a pool bucket for the bundle we've loaded
         XCTAssertNotNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
-        
-        let beforeCount = try XCTUnwrap(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
-        
+
+        let beforeCount = try XCTUnwrap(
+            ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
+
         // Verify a given identifier exists in the pool by creating it and verifying it wasn't added to the pool
-        _ = ResolvedTopicReference(bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
-        
+        _ = ResolvedTopicReference(
+            bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
+
         // Verify create the reference above did not add to the cache
-        XCTAssertEqual(beforeCount, ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
-        
+        XCTAssertEqual(
+            beforeCount, ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
+
         // Create a new reference for the same bundle that was not loaded with the context
-        _ = ResolvedTopicReference(bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial/\(#function)", sourceLanguage: .swift)
-        
+        _ = ResolvedTopicReference(
+            bundleID: bundleID, path: "/tutorials/Test-Bundle/TestTutorial/\(#function)",
+            sourceLanguage: .swift)
+
         // Verify creating a new reference added to the ones loaded with the context
-        XCTAssertNotEqual(beforeCount, ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
-        
+        XCTAssertNotEqual(
+            beforeCount, ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
+
         ResolvedTopicReference.purgePool(for: bundleID)
     }
-    
+
     func testAbstractAfterMetadataDirective() throws {
         let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
-        
+
         // Get the SideKit/SideClass/init() node and verify it has an abstract and no discussion.
         // We're verifying that the metadata directive between the title and the abstract didn't cause
         // the content to overflow into the discussion.
-        let node = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/init()", sourceLanguage: .swift))
+        let node = try context.entity(
+            with: ResolvedTopicReference(
+                bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/init()",
+                sourceLanguage: .swift))
         let markupModel = DocumentationMarkup(markup: node.markup)
         XCTAssertNotNil(markupModel.abstractSection)
-        
+
         // FIXME: A Discussion section is incorrectly getting created because of a comment. Comments shouldn't be
         // considered as content and hence not create a Discussion section. (rdar://79719308)
         // XCTAssertNil(markupModel.discussionSection)
@@ -2761,69 +3516,88 @@ let expected = """
     /// rdar://69242313
     func testLinkResolutionDoesNotSkipSymbolGraph() throws {
         let tempURL = try createTemporaryDirectory()
-        
-        let bundleURL = try Folder(name: "Missing.docc", content: [
-            InfoPlist(displayName: "MissingDocs", identifier: "com.test.missing-docs"),
-            CopyOfFile(original: Bundle.module.url(
+
+        let bundleURL = try Folder(
+            name: "Missing.docc",
+            content: [
+                InfoPlist(displayName: "MissingDocs", identifier: "com.test.missing-docs"),
+                CopyOfFile(
+                    original: Bundle.module.url(
                         forResource: "MissingDocs.symbols", withExtension: "json",
                         subdirectory: "Test Resources")!),
-        ]).write(inside: tempURL)
-        
+            ]
+        ).write(inside: tempURL)
+
         let (_, _, context) = try XCTUnwrap(loadBundle(from: bundleURL))
-        
+
         // MissingDocs contains a struct that has a link to a non-existent type.
         // If there are no problems, that indicates that symbol graph link
         // resolution was skipped.
         XCTAssertEqual(context.problems.count, 1)
     }
-    
+
     func testCreatingAnArticleNode() throws {
         // Create documentation node from markup
-        let reference = ResolvedTopicReference(bundleID: "com.testbundle", path: "/documentation/NewArticle", fragment: nil, sourceLanguage: .swift)
-        
+        let reference = ResolvedTopicReference(
+            bundleID: "com.testbundle", path: "/documentation/NewArticle", fragment: nil,
+            sourceLanguage: .swift)
+
         let source = """
-        # New Article
-        Article Abstract.
-        """
+            # New Article
+            Article Abstract.
+            """
         // Assert we can create a documentation node from markup
-        let markupArticle = Article(markup: Document(parsing: source), metadata: nil, redirects: nil, options: [:])
+        let markupArticle = Article(
+            markup: Document(parsing: source), metadata: nil, redirects: nil, options: [:])
         XCTAssertNoThrow(try DocumentationNode(reference: reference, article: markupArticle))
-        
+
         // Assert we cannot create new nodes from semantic article data
-        let semanticArticle = Article(title: Heading(level: 1, [Text("New Article")]), abstractSection: nil, discussion: nil, topics: nil, seeAlso: nil, deprecationSummary: nil, metadata: nil, redirects: nil)
+        let semanticArticle = Article(
+            title: Heading(level: 1, [Text("New Article")]), abstractSection: nil, discussion: nil,
+            topics: nil, seeAlso: nil, deprecationSummary: nil, metadata: nil, redirects: nil)
         XCTAssertThrowsError(try DocumentationNode(reference: reference, article: semanticArticle))
     }
-    
+
     func testTaskGroupsPersistInitialRangesFromMarkup() throws {
         let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Verify task group ranges are persisted for symbol docs
-        let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
-        let symbol = try XCTUnwrap((try? context.entity(with: symbolReference))?.semantic as? Symbol)
+        let symbolReference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let symbol = try XCTUnwrap(
+            (try? context.entity(with: symbolReference))?.semantic as? Symbol)
         let symbolTopics = try XCTUnwrap(symbol.topics)
         symbolTopics.originalLinkRangesByGroup.forEach { group in
             XCTAssertTrue(group.allSatisfy({ $0 != nil }))
         }
-        
+
         // Verify task group ranges are persisted for articles
-        let articleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
-        let article = try XCTUnwrap((try? context.entity(with: articleReference))?.semantic as? Article)
+        let articleReference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift)
+        let article = try XCTUnwrap(
+            (try? context.entity(with: articleReference))?.semantic as? Article)
         let articleTopics = try XCTUnwrap(article.topics)
         articleTopics.originalLinkRangesByGroup.forEach { group in
             XCTAssertTrue(group.allSatisfy({ $0 != nil }))
         }
     }
-    
+
     func testTaskGroupsOverwriteInitialRanges() throws {
-        let newTopics = TopicsSection(content: [], originalLinkRangesByGroup: [[
-            SourceLocation(line: 9, column: 41, source: URL(fileURLWithPath: "/howardst/747.md"))..<SourceLocation(line: 9, column: 42, source: URL(fileURLWithPath: "/howardst/747.md")),
-        ]])
-        
+        let newTopics = TopicsSection(
+            content: [],
+            originalLinkRangesByGroup: [
+                [
+                    SourceLocation(
+                        line: 9, column: 41, source: URL(fileURLWithPath: "/howardst/747.md"))..<SourceLocation(
+                            line: 9, column: 42, source: URL(fileURLWithPath: "/howardst/747.md"))
+                ]
+            ])
+
         guard let range = try XCTUnwrap(newTopics.originalLinkRangesByGroup.first?.first) else {
             XCTFail("Did not find original range")
             return
         }
-        
+
         XCTAssertEqual(range.lowerBound.line, 9)
         XCTAssertEqual(range.lowerBound.column, 41)
         XCTAssertEqual(range.lowerBound.source?.path, "/howardst/747.md")
@@ -2832,22 +3606,26 @@ let expected = """
     /// Tests that diagnostics raised during link resolution for symbols have the correct source URLs
     /// - Bug: rdar://63288817
     func testDiagnosticsForSymbolsHaveCorrectSource() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") {
+            url in
             let extensionFile = """
-            # ``SideKit/SideClass/myFunction()``
+                # ``SideKit/SideClass/myFunction()``
 
-            myFunction abstract
+                myFunction abstract
 
-            ## Overview
+                ## Overview
 
-            This is unresolvable: <doc:Does-Not-Exist>.
+                This is unresolvable: <doc:Does-Not-Exist>.
 
-            """
-            let fileURL = url.appendingPathComponent("documentation").appendingPathComponent("myFunction.md")
+                """
+            let fileURL = url.appendingPathComponent("documentation").appendingPathComponent(
+                "myFunction.md")
             try extensionFile.write(to: fileURL, atomically: true, encoding: .utf8)
         }
         let problems = context.diagnosticEngine.problems
-        let linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("myFunction.md") == true }
+        let linkResolutionProblems = problems.filter {
+            $0.diagnostic.source?.relativePath.hasSuffix("myFunction.md") == true
+        }
         XCTAssertEqual(linkResolutionProblems.count, 1)
         let problem = try XCTUnwrap(linkResolutionProblems.first)
         XCTAssertEqual(problem.diagnostic.range?.lowerBound.line, 7)
@@ -2855,9 +3633,11 @@ let expected = """
         XCTAssertEqual(problem.diagnostic.range?.upperBound.line, 7)
         XCTAssertEqual(problem.diagnostic.range?.upperBound.column, 42)
 
-        let functionNode = try XCTUnwrap(context.documentationCache["s:7SideKit0A5ClassC10myFunctionyyF"])
+        let functionNode = try XCTUnwrap(
+            context.documentationCache["s:7SideKit0A5ClassC10myFunctionyyF"])
         XCTAssertEqual(functionNode.docChunks.count, 2)
-        let docCommentChunks = functionNode.docChunks.compactMap { chunk -> DocumentationNode.DocumentationChunk? in
+        let docCommentChunks = functionNode.docChunks.compactMap {
+            chunk -> DocumentationNode.DocumentationChunk? in
             switch chunk.source {
             case .sourceCode: return chunk
             default: return nil
@@ -2865,7 +3645,8 @@ let expected = """
         }
         XCTAssertEqual(docCommentChunks.count, 1)
 
-        let extensionFileChunks = functionNode.docChunks.compactMap { chunk -> DocumentationNode.DocumentationChunk? in
+        let extensionFileChunks = functionNode.docChunks.compactMap {
+            chunk -> DocumentationNode.DocumentationChunk? in
             switch chunk.source {
             case .documentationExtension: return chunk
             default: return nil
@@ -2877,79 +3658,96 @@ let expected = """
     func testLinkResolutionDiagnosticsEmittedForTechnologyPages() throws {
         let tempURL = try createTemporaryDirectory()
 
-        let bundleURL = try Folder(name: "module-links.docc", content: [
-            InfoPlist(displayName: "Test", identifier: "com.test.docc"),
-            CopyOfFile(original: Bundle.module.url(
-                forResource: "LegacyBundle_DoNotUseInNewTests",
-                withExtension: "docc",
-                subdirectory: "Test Bundles"
-            )!.appendingPathComponent("sidekit.symbols.json")),
-            TextFile(name: "sidekit.md", utf8Content: """
-                # ``SideKit``
+        let bundleURL = try Folder(
+            name: "module-links.docc",
+            content: [
+                InfoPlist(displayName: "Test", identifier: "com.test.docc"),
+                CopyOfFile(
+                    original: Bundle.module.url(
+                        forResource: "LegacyBundle_DoNotUseInNewTests",
+                        withExtension: "docc",
+                        subdirectory: "Test Bundles"
+                    )!.appendingPathComponent("sidekit.symbols.json")),
+                TextFile(
+                    name: "sidekit.md",
+                    utf8Content: """
+                        # ``SideKit``
 
-                SideKit module root symbol
+                        SideKit module root symbol
 
-                ## Overview
+                        ## Overview
 
-                This link can't be resolved: <doc:Does-Not-Exist>
+                        This link can't be resolved: <doc:Does-Not-Exist>
 
-                ## Topics
+                        ## Topics
 
-                ### Basics
+                        ### Basics
 
-                - ``SideClass``
-                - ``SideProtocol``
-                """),
-        ]).write(inside: tempURL)
+                        - ``SideClass``
+                        - ``SideProtocol``
+                        """),
+            ]
+        ).write(inside: tempURL)
 
         let (_, _, context) = try loadBundle(from: bundleURL)
         let problems = context.diagnosticEngine.problems
-        let linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("sidekit.md") == true }
+        let linkResolutionProblems = problems.filter {
+            $0.diagnostic.source?.relativePath.hasSuffix("sidekit.md") == true
+        }
         XCTAssertEqual(linkResolutionProblems.count, 1)
-        XCTAssertEqual(linkResolutionProblems.first?.diagnostic.identifier, "org.swift.docc.unresolvedTopicReference")
+        XCTAssertEqual(
+            linkResolutionProblems.first?.diagnostic.identifier,
+            "org.swift.docc.unresolvedTopicReference")
     }
-    
+
     func testLinkDiagnosticsInSynthesizedTechnologyRoots() throws {
         // Verify that when synthesizing a technology root, links are resolved in the roots content.
         // Also, if an article is promoted to a root, verify that any existing metadata is preserved.
-        
+
         func makeMetadata(root: Bool, color: Bool) -> String {
             guard root || color else {
                 return ""
             }
             return """
-            @Metadata {
-              \(root  ? "@TechnologyRoot"    : "")
-              \(color ? "@PageColor(orange)" : "")
-            }
-            """
+                @Metadata {
+                  \(root  ? "@TechnologyRoot"    : "")
+                  \(color ? "@PageColor(orange)" : "")
+                }
+                """
         }
-        
+
         // Only a single article
         for withExplicitTechnologyRoot in [true, false] {
             for withPageColor in [true, false] {
                 let catalog =
-                    Folder(name: "unit-test.docc", content: [
-                        TextFile(name: "Root.md", utf8Content: """
-                    # My root page
-                    
-                    \(makeMetadata(root: withExplicitTechnologyRoot, color: withPageColor))
-                    
-                    This implicit technology root links to pages and on-page elements that don't exist.
-                    
-                    - ``NotFoundSymbol``
-                    - <doc:NotFoundArticle>
-                    - <doc:#NotFoundHeading>
-                    """),
-                    ])
+                    Folder(
+                        name: "unit-test.docc",
+                        content: [
+                            TextFile(
+                                name: "Root.md",
+                                utf8Content: """
+                                    # My root page
+
+                                    \(makeMetadata(root: withExplicitTechnologyRoot, color: withPageColor))
+
+                                    This implicit technology root links to pages and on-page elements that don't exist.
+
+                                    - ``NotFoundSymbol``
+                                    - <doc:NotFoundArticle>
+                                    - <doc:#NotFoundHeading>
+                                    """)
+                        ])
                 let (_, context) = try loadBundle(catalog: catalog)
-                
-                XCTAssertEqual(context.problems.map(\.diagnostic.summary), [
-                    "'NotFoundSymbol' doesn't exist at '/Root'",
-                    "'NotFoundArticle' doesn't exist at '/Root'",
-                    "'NotFoundHeading' doesn't exist at '/Root'",
-                ], withExplicitTechnologyRoot ? "with @TechnologyRoot" : "with synthesized root")
-                
+
+                XCTAssertEqual(
+                    context.problems.map(\.diagnostic.summary),
+                    [
+                        "'NotFoundSymbol' doesn't exist at '/Root'",
+                        "'NotFoundArticle' doesn't exist at '/Root'",
+                        "'NotFoundHeading' doesn't exist at '/Root'",
+                    ], withExplicitTechnologyRoot ? "with @TechnologyRoot" : "with synthesized root"
+                )
+
                 let rootReference = try XCTUnwrap(context.soleRootModuleReference)
                 let rootPage = try context.entity(with: rootReference)
                 XCTAssertNotNil(rootPage.metadata?.technologyRoot)
@@ -2960,41 +3758,50 @@ let expected = """
                 }
             }
         }
-        
+
         // Article that match the bundle's name
         for withExplicitTechnologyRoot in [true, false] {
             for withPageColor in [true, false] {
                 let catalog =
-                    Folder(name: "CatalogName.docc", content: [
-                        TextFile(name: "CatalogName.md", utf8Content: """
-                        # My root page
-                        
-                        \(makeMetadata(root: withExplicitTechnologyRoot, color: withPageColor))
-                        
-                        This implicit technology root links to pages and on-page elements that don't exist.
-                        
-                        - ``NotFoundSymbol``
-                        - <doc:NotFoundArticle>
-                        - <doc:#NotFoundHeading>
-                        """),
-                            
-                        TextFile(name: "OtherArticle.md", utf8Content: """
-                        # Another article
-                        
-                        This article links to the technology root.
-                        
-                        - <doc:CatalogName>
-                        """),
-                    ])
-                
+                    Folder(
+                        name: "CatalogName.docc",
+                        content: [
+                            TextFile(
+                                name: "CatalogName.md",
+                                utf8Content: """
+                                    # My root page
+
+                                    \(makeMetadata(root: withExplicitTechnologyRoot, color: withPageColor))
+
+                                    This implicit technology root links to pages and on-page elements that don't exist.
+
+                                    - ``NotFoundSymbol``
+                                    - <doc:NotFoundArticle>
+                                    - <doc:#NotFoundHeading>
+                                    """),
+
+                            TextFile(
+                                name: "OtherArticle.md",
+                                utf8Content: """
+                                    # Another article
+
+                                    This article links to the technology root.
+
+                                    - <doc:CatalogName>
+                                    """),
+                        ])
+
                 let (_, context) = try loadBundle(catalog: catalog)
-                
-                XCTAssertEqual(context.problems.map(\.diagnostic.summary), [
-                    "'NotFoundSymbol' doesn't exist at '/CatalogName'",
-                    "'NotFoundArticle' doesn't exist at '/CatalogName'",
-                    "'NotFoundHeading' doesn't exist at '/CatalogName'",
-                ], withExplicitTechnologyRoot ? "with @TechnologyRoot" : "with synthesized root")
-                
+
+                XCTAssertEqual(
+                    context.problems.map(\.diagnostic.summary),
+                    [
+                        "'NotFoundSymbol' doesn't exist at '/CatalogName'",
+                        "'NotFoundArticle' doesn't exist at '/CatalogName'",
+                        "'NotFoundHeading' doesn't exist at '/CatalogName'",
+                    ], withExplicitTechnologyRoot ? "with @TechnologyRoot" : "with synthesized root"
+                )
+
                 let rootReference = try XCTUnwrap(context.soleRootModuleReference)
                 let rootPage = try context.entity(with: rootReference)
                 XCTAssertNotNil(rootPage.metadata?.technologyRoot)
@@ -3005,423 +3812,569 @@ let expected = """
                 }
             }
         }
-        
+
         // Completely synthesized root
         let catalog =
-            Folder(name: "CatalogName.docc", content: [
-                TextFile(name: "First.md", utf8Content: """
-                    # One article
-                    
-                    This article links to pages and on-page elements that don't exist.
-                    
-                    - ``NotFoundSymbol``
-                    - <doc:#NotFoundHeading>
-                    
-                    It also links to the technology root.
-                    
-                    - <doc:CatalogName>
-                    """),
-                
-                TextFile(name: "Second.md", utf8Content: """
-                    # Another article
-                    
-                    This article links to a page that doesn't exist to the synthesized technology root.
-                    
-                    - <doc:NotFoundArticle>
-                    - <doc:CatalogName>
-                    """),
-            ])
-        
+            Folder(
+                name: "CatalogName.docc",
+                content: [
+                    TextFile(
+                        name: "First.md",
+                        utf8Content: """
+                            # One article
+
+                            This article links to pages and on-page elements that don't exist.
+
+                            - ``NotFoundSymbol``
+                            - <doc:#NotFoundHeading>
+
+                            It also links to the technology root.
+
+                            - <doc:CatalogName>
+                            """),
+
+                    TextFile(
+                        name: "Second.md",
+                        utf8Content: """
+                            # Another article
+
+                            This article links to a page that doesn't exist to the synthesized technology root.
+
+                            - <doc:NotFoundArticle>
+                            - <doc:CatalogName>
+                            """),
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
-        
-        XCTAssertEqual(context.problems.map(\.diagnostic.summary).sorted(), [
-            "'NotFoundArticle' doesn't exist at '/CatalogName/Second'",
-            "'NotFoundHeading' doesn't exist at '/CatalogName/First'",
-            "'NotFoundSymbol' doesn't exist at '/CatalogName/First'",
-        ])
-        
+
+        XCTAssertEqual(
+            context.problems.map(\.diagnostic.summary).sorted(),
+            [
+                "'NotFoundArticle' doesn't exist at '/CatalogName/Second'",
+                "'NotFoundHeading' doesn't exist at '/CatalogName/First'",
+                "'NotFoundSymbol' doesn't exist at '/CatalogName/First'",
+            ])
+
         let rootReference = try XCTUnwrap(context.soleRootModuleReference)
         let rootPage = try context.entity(with: rootReference)
         XCTAssertNotNil(rootPage.metadata?.technologyRoot)
     }
-    
+
     func testResolvingLinksToHeaders() throws {
         let tempURL = try createTemporaryDirectory()
 
-        let bundleURL = try Folder(name: "module-links.docc", content: [
-            InfoPlist(displayName: "Test", identifier: "com.test.docc"),
-            TextFile(name: "article.md", utf8Content: """
-                # Top Level Article
-                
-                @Metadata {
-                  @TechnologyRoot
-                }
-                
-                A top level article with various headers with special characters
-                
-                ## Overview
-                
-                All these header can be linked to
-                
-                ### Comma: first, second
-                
-                ### Apostrophe: first's second
-                
-                ### Prime: first′s second
-                
-                ### En dash: first–second
-                
-                ### Double hyphen: first--second
-                
-                ### Em dash: first—second
-                                                
-                ### Triple hyphen: first---second
-                
-                ### Emoji: 💻
-                
-                ## Topics
-                
-                ### Links to on-page headings
-                
-                - <doc:article#Comma:-first,-second>
-                - <doc:article#Comma:-first-second>
-                
-                - <doc:article#Apostrophe:-first's-second>
-                - <doc:article#Apostrophe:-firsts-second>
-                
-                - <doc:article#Prime:-first′s-second>
-                - <doc:article#Prime:-firsts-second>
-                
-                - <doc:article#En-dash:-first–second>
-                - <doc:article#En-dash:-first-second>
-                
-                - <doc:article#Double-hyphen:-first--second>
-                - <doc:article#Double-hyphen:-first-second>
-                
-                - <doc:article#Em-dash:-first-second>
-                - <doc:article#Em-dash:-first---second>
-                
-                - <doc:article#Triple-hyphen:-first---second>
-                - <doc:article#Triple-hyphen:-first-second>
-                
-                - <doc:article#Emoji:-💻>
-                - <doc:article#Emoji:-%F0%9F%92%BB>
-                
-                """),
-        ]).write(inside: tempURL)
+        let bundleURL = try Folder(
+            name: "module-links.docc",
+            content: [
+                InfoPlist(displayName: "Test", identifier: "com.test.docc"),
+                TextFile(
+                    name: "article.md",
+                    utf8Content: """
+                        # Top Level Article
+
+                        @Metadata {
+                          @TechnologyRoot
+                        }
+
+                        A top level article with various headers with special characters
+
+                        ## Overview
+
+                        All these header can be linked to
+
+                        ### Comma: first, second
+
+                        ### Apostrophe: first's second
+
+                        ### Prime: first′s second
+
+                        ### En dash: first–second
+
+                        ### Double hyphen: first--second
+
+                        ### Em dash: first—second
+                                                        
+                        ### Triple hyphen: first---second
+
+                        ### Emoji: 💻
+
+                        ## Topics
+
+                        ### Links to on-page headings
+
+                        - <doc:article#Comma:-first,-second>
+                        - <doc:article#Comma:-first-second>
+
+                        - <doc:article#Apostrophe:-first's-second>
+                        - <doc:article#Apostrophe:-firsts-second>
+
+                        - <doc:article#Prime:-first′s-second>
+                        - <doc:article#Prime:-firsts-second>
+
+                        - <doc:article#En-dash:-first–second>
+                        - <doc:article#En-dash:-first-second>
+
+                        - <doc:article#Double-hyphen:-first--second>
+                        - <doc:article#Double-hyphen:-first-second>
+
+                        - <doc:article#Em-dash:-first-second>
+                        - <doc:article#Em-dash:-first---second>
+
+                        - <doc:article#Triple-hyphen:-first---second>
+                        - <doc:article#Triple-hyphen:-first-second>
+
+                        - <doc:article#Emoji:-💻>
+                        - <doc:article#Emoji:-%F0%9F%92%BB>
+
+                        """),
+            ]
+        ).write(inside: tempURL)
 
         let (_, _, context) = try loadBundle(from: bundleURL)
-        
+
         let articleReference = try XCTUnwrap(context.knownPages.first)
         let node = try context.entity(with: articleReference)
         let article = try XCTUnwrap(node.semantic as? Article)
-        
+
         let taskGroup = try XCTUnwrap(article.topics?.taskGroups.first)
         XCTAssertEqual(taskGroup.heading?.plainText, "Links to on-page headings")
         XCTAssertEqual(taskGroup.links.count, 16)
-        
+
         XCTAssertEqual(node.anchorSections.first?.title, "Overview")
         for (index, anchor) in node.anchorSections.dropFirst().dropLast().enumerated() {
-            XCTAssertEqual(taskGroup.links.dropFirst(index * 2 + 0).first?.destination, anchor.reference.absoluteString)
-            XCTAssertEqual(taskGroup.links.dropFirst(index * 2 + 1).first?.destination, anchor.reference.absoluteString)
+            XCTAssertEqual(
+                taskGroup.links.dropFirst(index * 2 + 0).first?.destination,
+                anchor.reference.absoluteString)
+            XCTAssertEqual(
+                taskGroup.links.dropFirst(index * 2 + 1).first?.destination,
+                anchor.reference.absoluteString)
         }
-        
-        XCTAssertEqual(node.anchorSections.dropFirst().first?.reference.absoluteString, "doc://com.test.docc/documentation/article#Comma-first-second")
-        XCTAssertEqual(node.anchorSections.dropFirst(2).first?.reference.absoluteString, "doc://com.test.docc/documentation/article#Apostrophe-firsts-second")
-        XCTAssertEqual(node.anchorSections.dropFirst(3).first?.reference.absoluteString, "doc://com.test.docc/documentation/article#Prime-firsts-second")
-        
-        XCTAssertEqual(node.anchorSections.dropLast(3).last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Em-dash-first-second")
-        XCTAssertEqual(node.anchorSections.dropLast(2).last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Triple-hyphen-first-second")
-        XCTAssertEqual(node.anchorSections.dropLast().last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Emoji-%F0%9F%92%BB")
+
+        XCTAssertEqual(
+            node.anchorSections.dropFirst().first?.reference.absoluteString,
+            "doc://com.test.docc/documentation/article#Comma-first-second")
+        XCTAssertEqual(
+            node.anchorSections.dropFirst(2).first?.reference.absoluteString,
+            "doc://com.test.docc/documentation/article#Apostrophe-firsts-second")
+        XCTAssertEqual(
+            node.anchorSections.dropFirst(3).first?.reference.absoluteString,
+            "doc://com.test.docc/documentation/article#Prime-firsts-second")
+
+        XCTAssertEqual(
+            node.anchorSections.dropLast(3).last?.reference.absoluteString,
+            "doc://com.test.docc/documentation/article#Em-dash-first-second")
+        XCTAssertEqual(
+            node.anchorSections.dropLast(2).last?.reference.absoluteString,
+            "doc://com.test.docc/documentation/article#Triple-hyphen-first-second")
+        XCTAssertEqual(
+            node.anchorSections.dropLast().last?.reference.absoluteString,
+            "doc://com.test.docc/documentation/article#Emoji-%F0%9F%92%BB")
     }
 
     func testResolvingLinksToTopicSections() throws {
-        let (_, context) = try loadBundle(catalog:
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
-                
-                TextFile(name: "ModuleName.md", utf8Content: """
-                # ``ModuleName``
-                
-                A symbol with two topic section
-                
-                ## Topics
-                
-                ### One
-                
-                - <doc:First>
-                
-                ### Two
-                
-                - <doc:Second>
-                """),
-                
-                TextFile(name: "First.md", utf8Content: """
-                # The first article
-                
-                An article with a top-level topic section
-                
-                ## Topics
-                
-                - <doc:Third>
-                """),
-                
-                TextFile(name: "Second.md", utf8Content: """
-                # The second article
-                
-                An article with a named topic section
-                
-                ## Topics
-                
-                ### Some, topic - section!
-                
-                - <doc:Third>
-                """),
-                
-                TextFile(name: "Third.md", utf8Content: """
-                # The third article
-                
-                An article that links to the various topic sections
-                
-                - <doc:ModuleName#One>
-                - <doc:ModuleName#Two>
-                - <doc:First#Topics>
-                - <doc:Second#Some-topic-section>
-                - <doc:Third#Another-topic-section>
-                - <doc:#Another-topic-section>
-                
-                ## Topics
-                
-                ### Another topic section
-                
-                - <doc:Fourth>
-                """),
-                
-                TextFile(name: "Fourth.md", utf8Content: """
-                # The fourth article
-                
-                An article that only exists to be linked to
-                """),
-            ])
+        let (_, context) = try loadBundle(
+            catalog:
+                Folder(
+                    name: "unit-test.docc",
+                    content: [
+                        JSONFile(
+                            name: "ModuleName.symbols.json",
+                            content: makeSymbolGraph(moduleName: "ModuleName")),
+
+                        TextFile(
+                            name: "ModuleName.md",
+                            utf8Content: """
+                                # ``ModuleName``
+
+                                A symbol with two topic section
+
+                                ## Topics
+
+                                ### One
+
+                                - <doc:First>
+
+                                ### Two
+
+                                - <doc:Second>
+                                """),
+
+                        TextFile(
+                            name: "First.md",
+                            utf8Content: """
+                                # The first article
+
+                                An article with a top-level topic section
+
+                                ## Topics
+
+                                - <doc:Third>
+                                """),
+
+                        TextFile(
+                            name: "Second.md",
+                            utf8Content: """
+                                # The second article
+
+                                An article with a named topic section
+
+                                ## Topics
+
+                                ### Some, topic - section!
+
+                                - <doc:Third>
+                                """),
+
+                        TextFile(
+                            name: "Third.md",
+                            utf8Content: """
+                                # The third article
+
+                                An article that links to the various topic sections
+
+                                - <doc:ModuleName#One>
+                                - <doc:ModuleName#Two>
+                                - <doc:First#Topics>
+                                - <doc:Second#Some-topic-section>
+                                - <doc:Third#Another-topic-section>
+                                - <doc:#Another-topic-section>
+
+                                ## Topics
+
+                                ### Another topic section
+
+                                - <doc:Fourth>
+                                """),
+
+                        TextFile(
+                            name: "Fourth.md",
+                            utf8Content: """
+                                # The fourth article
+
+                                An article that only exists to be linked to
+                                """),
+                    ])
         )
-        
-        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).sorted())")
-        
-        let reference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "Third" }))
+
+        XCTAssert(
+            context.problems.isEmpty,
+            "Unexpected problems: \(context.problems.map(\.diagnostic.summary).sorted())")
+
+        let reference = try XCTUnwrap(
+            context.knownPages.first(where: { $0.lastPathComponent == "Third" }))
         let entity = try context.entity(with: reference)
-        
+
         struct LinkAggregator: MarkupWalker {
             var destinations: [String] = []
-            
-            mutating func visitLink(_ link: Link) -> () {
+
+            mutating func visitLink(_ link: Link) {
                 if let destination = link.destination {
                     destinations.append(destination)
                 }
             }
-            mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> () {
+            mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
                 if let destination = symbolLink.destination {
                     destinations.append(destination)
                 }
             }
         }
-        
+
         // Verify that the links are resolved in the in-memory model
-        
+
         var linkAggregator = LinkAggregator()
-        let list = try XCTUnwrap((entity.semantic as? Article)?.discussion?.content.first as? UnorderedList)
+        let list = try XCTUnwrap(
+            (entity.semantic as? Article)?.discussion?.content.first as? UnorderedList)
         linkAggregator.visit(list)
-        
-        XCTAssertEqual(linkAggregator.destinations, [
-            "doc://unit-test/documentation/ModuleName#One",
-            "doc://unit-test/documentation/ModuleName#Two",
-            "doc://unit-test/documentation/unit-test/First#Topics",
-            "doc://unit-test/documentation/unit-test/Second#Some-topic-section",
-            "doc://unit-test/documentation/unit-test/Third#Another-topic-section",
-            "doc://unit-test/documentation/unit-test/Third#Another-topic-section",
-        ])
-        
+
+        XCTAssertEqual(
+            linkAggregator.destinations,
+            [
+                "doc://unit-test/documentation/ModuleName#One",
+                "doc://unit-test/documentation/ModuleName#Two",
+                "doc://unit-test/documentation/unit-test/First#Topics",
+                "doc://unit-test/documentation/unit-test/Second#Some-topic-section",
+                "doc://unit-test/documentation/unit-test/Third#Another-topic-section",
+                "doc://unit-test/documentation/unit-test/Third#Another-topic-section",
+            ])
+
         // Verify that the links are resolved in the render model.
         let bundle = try XCTUnwrap(context.bundle)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let renderNode = converter.convert(entity)
-        
-        XCTAssertEqual(renderNode.topicSections.map(\.anchor), [
-            "Another-topic-section"
-        ])
-        
-        let firstReference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "First" }))
+
+        XCTAssertEqual(
+            renderNode.topicSections.map(\.anchor),
+            [
+                "Another-topic-section"
+            ])
+
+        let firstReference = try XCTUnwrap(
+            context.knownPages.first(where: { $0.lastPathComponent == "First" }))
         let firstRenderNode = try converter.convert(context.entity(with: firstReference))
-        XCTAssertEqual(firstRenderNode.topicSections.map(\.anchor), [
-            "Topics"
-        ])
-        
-        let secondReference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "Second" }))
+        XCTAssertEqual(
+            firstRenderNode.topicSections.map(\.anchor),
+            [
+                "Topics"
+            ])
+
+        let secondReference = try XCTUnwrap(
+            context.knownPages.first(where: { $0.lastPathComponent == "Second" }))
         let secondRenderNode = try converter.convert(context.entity(with: secondReference))
-        XCTAssertEqual(secondRenderNode.topicSections.map(\.anchor), [
-            "Some-topic-section"
-        ])
-        
-        let overviewSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
-        guard case .unorderedList(let unorderedList) = overviewSection.content.dropFirst().first else {
-            XCTFail("The first element of the Overview section (after the heading) should be an unordered list")
+        XCTAssertEqual(
+            secondRenderNode.topicSections.map(\.anchor),
+            [
+                "Some-topic-section"
+            ])
+
+        let overviewSection = try XCTUnwrap(
+            renderNode.primaryContentSections.first as? ContentRenderSection)
+        guard case .unorderedList(let unorderedList) = overviewSection.content.dropFirst().first
+        else {
+            XCTFail(
+                "The first element of the Overview section (after the heading) should be an unordered list"
+            )
             return
         }
-        
-        XCTAssertEqual(unorderedList.items.map(\.content.firstParagraph.first), [
-            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/ModuleName#One"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
-            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/ModuleName#Two"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
-            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/First#Topics"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
-            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/Second#Some-topic-section"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
-            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/Third#Another-topic-section"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
-            .reference(identifier: RenderReferenceIdentifier("doc://unit-test/documentation/unit-test/Third#Another-topic-section"), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
-        ])
+
+        XCTAssertEqual(
+            unorderedList.items.map(\.content.firstParagraph.first),
+            [
+                .reference(
+                    identifier: RenderReferenceIdentifier(
+                        "doc://unit-test/documentation/ModuleName#One"), isActive: true,
+                    overridingTitle: nil, overridingTitleInlineContent: nil),
+                .reference(
+                    identifier: RenderReferenceIdentifier(
+                        "doc://unit-test/documentation/ModuleName#Two"), isActive: true,
+                    overridingTitle: nil, overridingTitleInlineContent: nil),
+                .reference(
+                    identifier: RenderReferenceIdentifier(
+                        "doc://unit-test/documentation/unit-test/First#Topics"), isActive: true,
+                    overridingTitle: nil, overridingTitleInlineContent: nil),
+                .reference(
+                    identifier: RenderReferenceIdentifier(
+                        "doc://unit-test/documentation/unit-test/Second#Some-topic-section"),
+                    isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+                .reference(
+                    identifier: RenderReferenceIdentifier(
+                        "doc://unit-test/documentation/unit-test/Third#Another-topic-section"),
+                    isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+                .reference(
+                    identifier: RenderReferenceIdentifier(
+                        "doc://unit-test/documentation/unit-test/Third#Another-topic-section"),
+                    isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+            ])
     }
-    
+
     func testExtensionCanUseLanguageSpecificRelativeLinks() throws {
         // This test uses a symbol with different names in Swift and Objective-C, each with a member that's only available in that language.
         let symbolID = "some-symbol-id"
-        let (_, context) = try loadBundle(catalog:
-            Folder(name: "unit-test.docc", content: [
-                Folder(name: "swift", content: [
-                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                        moduleName: "ModuleName",
-                        symbols: [
-                            .init(
-                                identifier: .init(precise: symbolID, interfaceLanguage: SourceLanguage.swift.id),
-                                names: .init(title: "SwiftName", navigator: nil, subHeading: nil, prose: nil),
-                                pathComponents: ["SwiftName"],
-                                docComment: nil,
-                                accessLevel: .public,
-                                kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"),
-                                mixins: [:]
-                            ),
-                            .init(
-                                identifier: .init(precise: "swift-only-member-id", interfaceLanguage: SourceLanguage.swift.id),
-                                names: .init(title: "swiftOnlyMemberName", navigator: nil, subHeading: nil, prose: nil),
-                                pathComponents: ["SwiftName", "swiftOnlyMemberName"],
-                                docComment: nil,
-                                accessLevel: .public,
-                                kind: .init(parsedIdentifier: .property, displayName: "Kind Display Name"),
-                                mixins: [:]
-                            ),
-                        ], relationships: [
-                            .init(source: "swift-only-member-id", target: symbolID, kind: .memberOf, targetFallback: nil)
-                        ])
-                    ),
-                ]),
-                
-                Folder(name: "clang", content: [
-                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                        moduleName: "ModuleName",
-                        symbols: [
-                            .init(
-                                identifier: .init(precise: symbolID, interfaceLanguage: SourceLanguage.objectiveC.id),
-                                names: .init(title: "ObjectiveCName", navigator: nil, subHeading: nil, prose: nil),
-                                pathComponents: ["ObjectiveCName"],
-                                docComment: nil,
-                                accessLevel: .public,
-                                kind: .init(parsedIdentifier: .class, displayName: "Kind Display Name"),
-                                mixins: [:]
-                            ),
-                            .init(
-                                identifier: .init(precise: "objc-only-member-id", interfaceLanguage: SourceLanguage.objectiveC.id),
-                                names: .init(title: "objectiveCOnlyMemberName", navigator: nil, subHeading: nil, prose: nil),
-                                pathComponents: ["ObjectiveCName", "objectiveCOnlyMemberName"],
-                                docComment: nil,
-                                accessLevel: .public,
-                                kind: .init(parsedIdentifier: .property, displayName: "Kind Display Name"),
-                                mixins: [:]
-                            ),
-                        ], relationships: [
-                            .init(source: "objc-only-member-id", target: symbolID, kind: .memberOf, targetFallback: nil)
-                        ])
-                    ),
-                ]),
-                
-                TextFile(name: "Extension.md", utf8Content: """
-                # ``SwiftName``
-                
-                A documentation extension that uses both language's language specific links to curate the same symbol 6 times (2 that fail with warnings)
-                
-                ## Topics
-                
-                ### Relative links
-                
-                - ``swiftOnlyMemberName``
-                - ``objectiveCOnlyMemberName``
-                
-                ### Correct absolute links
-                
-                - ``SwiftName/swiftOnlyMemberName``
-                - ``ObjectiveCName/objectiveCOnlyMemberName``
-                
-                ### Incorrect absolute links
-                
-                - ``ObjectiveCName/swiftOnlyMemberName``
-                - ``SwiftName/objectiveCOnlyMemberName``
-                """),
-            ])
+        let (_, context) = try loadBundle(
+            catalog:
+                Folder(
+                    name: "unit-test.docc",
+                    content: [
+                        Folder(
+                            name: "swift",
+                            content: [
+                                JSONFile(
+                                    name: "ModuleName.symbols.json",
+                                    content: makeSymbolGraph(
+                                        moduleName: "ModuleName",
+                                        symbols: [
+                                            .init(
+                                                identifier: .init(
+                                                    precise: symbolID,
+                                                    interfaceLanguage: SourceLanguage.swift.id),
+                                                names: .init(
+                                                    title: "SwiftName", navigator: nil,
+                                                    subHeading: nil, prose: nil),
+                                                pathComponents: ["SwiftName"],
+                                                docComment: nil,
+                                                accessLevel: .public,
+                                                kind: .init(
+                                                    parsedIdentifier: .class,
+                                                    displayName: "Kind Display Name"),
+                                                mixins: [:]
+                                            ),
+                                            .init(
+                                                identifier: .init(
+                                                    precise: "swift-only-member-id",
+                                                    interfaceLanguage: SourceLanguage.swift.id),
+                                                names: .init(
+                                                    title: "swiftOnlyMemberName", navigator: nil,
+                                                    subHeading: nil, prose: nil),
+                                                pathComponents: [
+                                                    "SwiftName", "swiftOnlyMemberName",
+                                                ],
+                                                docComment: nil,
+                                                accessLevel: .public,
+                                                kind: .init(
+                                                    parsedIdentifier: .property,
+                                                    displayName: "Kind Display Name"),
+                                                mixins: [:]
+                                            ),
+                                        ],
+                                        relationships: [
+                                            .init(
+                                                source: "swift-only-member-id", target: symbolID,
+                                                kind: .memberOf, targetFallback: nil)
+                                        ])
+                                )
+                            ]),
+
+                        Folder(
+                            name: "clang",
+                            content: [
+                                JSONFile(
+                                    name: "ModuleName.symbols.json",
+                                    content: makeSymbolGraph(
+                                        moduleName: "ModuleName",
+                                        symbols: [
+                                            .init(
+                                                identifier: .init(
+                                                    precise: symbolID,
+                                                    interfaceLanguage: SourceLanguage.objectiveC.id),
+                                                names: .init(
+                                                    title: "ObjectiveCName", navigator: nil,
+                                                    subHeading: nil, prose: nil),
+                                                pathComponents: ["ObjectiveCName"],
+                                                docComment: nil,
+                                                accessLevel: .public,
+                                                kind: .init(
+                                                    parsedIdentifier: .class,
+                                                    displayName: "Kind Display Name"),
+                                                mixins: [:]
+                                            ),
+                                            .init(
+                                                identifier: .init(
+                                                    precise: "objc-only-member-id",
+                                                    interfaceLanguage: SourceLanguage.objectiveC.id),
+                                                names: .init(
+                                                    title: "objectiveCOnlyMemberName",
+                                                    navigator: nil, subHeading: nil, prose: nil),
+                                                pathComponents: [
+                                                    "ObjectiveCName", "objectiveCOnlyMemberName",
+                                                ],
+                                                docComment: nil,
+                                                accessLevel: .public,
+                                                kind: .init(
+                                                    parsedIdentifier: .property,
+                                                    displayName: "Kind Display Name"),
+                                                mixins: [:]
+                                            ),
+                                        ],
+                                        relationships: [
+                                            .init(
+                                                source: "objc-only-member-id", target: symbolID,
+                                                kind: .memberOf, targetFallback: nil)
+                                        ])
+                                )
+                            ]),
+
+                        TextFile(
+                            name: "Extension.md",
+                            utf8Content: """
+                                # ``SwiftName``
+
+                                A documentation extension that uses both language's language specific links to curate the same symbol 6 times (2 that fail with warnings)
+
+                                ## Topics
+
+                                ### Relative links
+
+                                - ``swiftOnlyMemberName``
+                                - ``objectiveCOnlyMemberName``
+
+                                ### Correct absolute links
+
+                                - ``SwiftName/swiftOnlyMemberName``
+                                - ``ObjectiveCName/objectiveCOnlyMemberName``
+
+                                ### Incorrect absolute links
+
+                                - ``ObjectiveCName/swiftOnlyMemberName``
+                                - ``SwiftName/objectiveCOnlyMemberName``
+                                """),
+                    ])
         )
-        
-        XCTAssertEqual(context.problems.map(\.diagnostic.summary).sorted(), [
-            "'objectiveCOnlyMemberName' doesn't exist at '/ModuleName/SwiftName'",
-            "'swiftOnlyMemberName' doesn't exist at '/ModuleName/ObjectiveCName'",
-        ])
-        
-        let reference = ResolvedTopicReference(bundleID: "unit-test", path: "/documentation/ModuleName/SwiftName", sourceLanguage: .swift)
+
+        XCTAssertEqual(
+            context.problems.map(\.diagnostic.summary).sorted(),
+            [
+                "'objectiveCOnlyMemberName' doesn't exist at '/ModuleName/SwiftName'",
+                "'swiftOnlyMemberName' doesn't exist at '/ModuleName/ObjectiveCName'",
+            ])
+
+        let reference = ResolvedTopicReference(
+            bundleID: "unit-test", path: "/documentation/ModuleName/SwiftName",
+            sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
         let symbol = try XCTUnwrap(entity.semantic as? Symbol)
         let taskGroups = try XCTUnwrap(symbol.topics).taskGroups
-        
-        XCTAssertEqual(taskGroups.map { $0.links.map(\.destination) }, [
-            // Relative links
+
+        XCTAssertEqual(
+            taskGroups.map { $0.links.map(\.destination) },
             [
-                "doc://unit-test/documentation/ModuleName/SwiftName/swiftOnlyMemberName",
-                "doc://unit-test/documentation/ModuleName/ObjectiveCName/objectiveCOnlyMemberName",
-            ],
-            // Correct absolute links
-            [
-                "doc://unit-test/documentation/ModuleName/SwiftName/swiftOnlyMemberName",
-                "doc://unit-test/documentation/ModuleName/ObjectiveCName/objectiveCOnlyMemberName",
-            ],
-            // Incorrect absolute links
-            [
-                // This links remain as they were authored because they didn't resolve
-                "ObjectiveCName/swiftOnlyMemberName",
-                "SwiftName/objectiveCOnlyMemberName",
-            ]
-        ])
+                // Relative links
+                [
+                    "doc://unit-test/documentation/ModuleName/SwiftName/swiftOnlyMemberName",
+                    "doc://unit-test/documentation/ModuleName/ObjectiveCName/objectiveCOnlyMemberName",
+                ],
+                // Correct absolute links
+                [
+                    "doc://unit-test/documentation/ModuleName/SwiftName/swiftOnlyMemberName",
+                    "doc://unit-test/documentation/ModuleName/ObjectiveCName/objectiveCOnlyMemberName",
+                ],
+                // Incorrect absolute links
+                [
+                    // This links remain as they were authored because they didn't resolve
+                    "ObjectiveCName/swiftOnlyMemberName",
+                    "SwiftName/objectiveCOnlyMemberName",
+                ],
+            ])
     }
-    
+
     func testWarnOnMultipleMarkdownExtensions() throws {
         let fileContent = """
-        # ``MyKit/MyClass/myFunction()``
+            # ``MyKit/MyClass/myFunction()``
 
-        A cool function
+            A cool function
 
-        ## Overview
-        The function overview
-        """
-        let exampleDocumentation = Folder(name: "MyKit.docc", content: [
-            Folder(name: "Symbols", content: [
-                CopyOfFile(original: Bundle.module.url(forResource: "mykit-one-symbol.symbols", withExtension: "json", subdirectory: "Test Resources")!),
-            ]),
-            Folder(name: "MyKit", content: [
-                TextFile(name: "MyFunc.md", utf8Content: fileContent),
-                TextFile(name: "MyFunc2.md", utf8Content: fileContent),
-            ]),
-            TextFile(name: "MyKit.md", utf8Content: """
-            # ``MyKit``
+            ## Overview
+            The function overview
+            """
+        let exampleDocumentation = Folder(
+            name: "MyKit.docc",
+            content: [
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        CopyOfFile(
+                            original: Bundle.module.url(
+                                forResource: "mykit-one-symbol.symbols", withExtension: "json",
+                                subdirectory: "Test Resources")!)
+                    ]),
+                Folder(
+                    name: "MyKit",
+                    content: [
+                        TextFile(name: "MyFunc.md", utf8Content: fileContent),
+                        TextFile(name: "MyFunc2.md", utf8Content: fileContent),
+                    ]),
+                TextFile(
+                    name: "MyKit.md",
+                    utf8Content: """
+                        # ``MyKit``
 
-            Some cool docs
+                        Some cool docs
 
-            ## Topics
+                        ## Topics
 
-            ### Articles
-            - ``MyKit/MyClass/myFunction()``
-            """),
-            InfoPlist(displayName: "MyKit", identifier: "com.test.MyKit"),
-        ])
+                        ### Articles
+                        - ``MyKit/MyClass/myFunction()``
+                        """),
+                InfoPlist(displayName: "MyKit", identifier: "com.test.MyKit"),
+            ])
         let tempURL = try createTemporaryDirectory()
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
 
@@ -3429,26 +4382,33 @@ let expected = """
         let (_, _, context) = try loadBundle(from: bundleURL)
 
         let identifier = "org.swift.docc.DuplicateMarkdownTitleSymbolReferences"
-        let duplicateMarkdownProblems = context.problems.filter({ $0.diagnostic.identifier == identifier })
+        let duplicateMarkdownProblems = context.problems.filter({
+            $0.diagnostic.identifier == identifier
+        })
         XCTAssertEqual(duplicateMarkdownProblems.count, 1)
-        XCTAssertEqual(duplicateMarkdownProblems.first?.diagnostic.summary, "Multiple documentation extensions matched 'MyKit/MyClass/myFunction()'.")
+        XCTAssertEqual(
+            duplicateMarkdownProblems.first?.diagnostic.summary,
+            "Multiple documentation extensions matched 'MyKit/MyClass/myFunction()'.")
         XCTAssertEqual(duplicateMarkdownProblems.first?.diagnostic.notes.count, 1)
-        XCTAssertEqual(duplicateMarkdownProblems.first?.diagnostic.notes.first?.message, "'MyKit/MyClass/myFunction()' is also documented here.")
+        XCTAssertEqual(
+            duplicateMarkdownProblems.first?.diagnostic.notes.first?.message,
+            "'MyKit/MyClass/myFunction()' is also documented here.")
     }
-    
+
     /// This test verifies that collision nodes and children of collision nodes are correctly
     /// matched with their documentation extension files. Besides verifying the correct content
     /// it verifies also that the curation in these doc extensions is reflected in the topic graph.
     func testMatchesCorrectlyDocExtensionToChildOfCollisionTopic() throws {
         let fifthTestMemberPath = "ShapeKit/OverloadedParentStruct-1jr3p/fifthTestMember"
-        
+
         let (_, bundle, context) = try testBundleAndContext(copying: "OverloadedSymbols") { url in
             // Add an article to be curated from collided nodes' doc extensions.
             try """
             # New Article
             Article abstract.
-            """.write(to: url.appendingPathComponent("NewArticle.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("NewArticle.md"), atomically: true, encoding: .utf8)
+
             // Add doc extension file for a collision symbol
             try """
             # ``ShapeKit/OverloadedParentStruct-1jr3p``
@@ -3456,7 +4416,9 @@ let expected = """
             ## Topics
             ### Basics
             - <doc:NewArticle>
-            """.write(to: url.appendingPathComponent("OverloadedParentStruct.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("OverloadedParentStruct.md"), atomically: true,
+                encoding: .utf8)
 
             // Add doc extension file for a child of a collision symbol
             try """
@@ -3465,8 +4427,10 @@ let expected = """
             ## Topics
             ### Basics
             - <doc:NewArticle>
-            """.write(to: url.appendingPathComponent("fifthTestMember.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("fifthTestMember.md"), atomically: true,
+                encoding: .utf8)
+
             // Add doc extension file for a child of a collision symbol
             try """
             # ``\(fifthTestMemberPath)``
@@ -3474,80 +4438,96 @@ let expected = """
             ## Topics
             ### Basics
             - <doc:NewArticle>
-            """.write(to: url.appendingPathComponent("fifthTestMember.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("fifthTestMember.md"), atomically: true,
+                encoding: .utf8)
         }
-        
-        let articleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ShapeKit/NewArticle", sourceLanguage: .swift)
-        
+
+        let articleReference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/ShapeKit/NewArticle", sourceLanguage: .swift)
+
         // Fetch the "OverloadedParentStruct" node
-        let reference1 = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ShapeKit/OverloadedParentStruct-1jr3p", sourceLanguage: .swift)
+        let reference1 = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/ShapeKit/OverloadedParentStruct-1jr3p",
+            sourceLanguage: .swift)
         let node1 = try context.entity(with: reference1)
         let symbol1 = try XCTUnwrap(node1.semantic as? Symbol)
-        
+
         // Verify the doc extension content was loaded.
         XCTAssertEqual(symbol1.abstract?.plainText, "OverloadedParentStruct abstract.")
 
         // Verify the doc extension curation, thanks to the new link resolving this is an absolute identifier.
-        XCTAssertEqual(symbol1.topics?.taskGroups.first?.links.first?.destination, "doc://com.shapes.ShapeKit/documentation/ShapeKit/NewArticle")
+        XCTAssertEqual(
+            symbol1.topics?.taskGroups.first?.links.first?.destination,
+            "doc://com.shapes.ShapeKit/documentation/ShapeKit/NewArticle")
         let tgNode1 = try XCTUnwrap(context.topicGraph.edges[reference1])
         XCTAssertTrue(tgNode1.contains(articleReference))
-        
+
         // Fetch the "fifthTestMember" node
-        let reference2 = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/\(fifthTestMemberPath)", sourceLanguage: .swift)
-       
+        let reference2 = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/\(fifthTestMemberPath)",
+            sourceLanguage: .swift)
+
         let node2 = try context.entity(with: reference2)
         let symbol2 = try XCTUnwrap(node2.semantic as? Symbol)
-        
+
         // Verify the doc extension content was loaded.
         XCTAssertEqual(symbol2.abstract?.plainText, "fifthTestMember abstract.")
 
         // Verify the doc extension curation, thanks to the new link resolving this is an absolute identifier.
-        XCTAssertEqual(symbol2.topics?.taskGroups.first?.links.first?.destination, "doc://com.shapes.ShapeKit/documentation/ShapeKit/NewArticle")
+        XCTAssertEqual(
+            symbol2.topics?.taskGroups.first?.links.first?.destination,
+            "doc://com.shapes.ShapeKit/documentation/ShapeKit/NewArticle")
 
         // Verify the correct topic graph parent <-> child relationship is created.
         let tgNode2 = try XCTUnwrap(context.topicGraph.edges[reference2])
         XCTAssertTrue(tgNode2.contains(articleReference))
     }
-    
+
     func testMatchesDocumentationExtensionsAsSymbolLinks() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+        let (_, bundle, context) = try testBundleAndContext(
+            copying: "MixedLanguageFrameworkWithLanguageRefinements"
+        ) { url in
             // Two colliding symbols that differ by capitalization.
             try """
             # ``MixedFramework/CollisionsWithDifferentCapitalization/someThing``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             some thing
-            
+
             This documentation extension link doesn't need disambiguation because "someThing" is capitalized differently than "something".
-            """.write(to: url.appendingPathComponent("some-thing.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("some-thing.md"), atomically: true, encoding: .utf8)
+
             try """
             # ``MixedFramework/CollisionsWithDifferentCapitalization/something``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
 
             something
-            
+
             This documentation extension link doesn't need disambiguation because "something" is capitalized differently than "someThing".
-            """.write(to: url.appendingPathComponent("something.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("something.md"), atomically: true, encoding: .utf8)
+
             // Three colliding symbols that differ by symbol kind.
             try """
             # ``MixedFramework/CollisionsWithEscapedKeywords/subscript()-method``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             method
-            
+
             This documentation extension link can be disambiguated with only the kind information (without the language).
-            """.write(to: url.appendingPathComponent("method.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("method.md"), atomically: true, encoding: .utf8)
 
             try """
             # ``MixedFramework/CollisionsWithEscapedKeywords/subscript()-subscript``
@@ -3555,73 +4535,107 @@ let expected = """
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             subscript
-            
+
             This documentation extension link can be disambiguated with only the kind information (without the language).
-            """.write(to: url.appendingPathComponent("subscript.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("subscript.md"), atomically: true, encoding: .utf8)
 
             try """
             # ``MixedFramework/CollisionsWithEscapedKeywords/subscript()-type.method``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             type method
-            
+
             This documentation extension link can be disambiguated with only the kind information (without the language).
-            """.write(to: url.appendingPathComponent("type-method.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("type-method.md"), atomically: true, encoding: .utf8)
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/someThing-90i4h", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/someThing-90i4h",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "some thing", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "some thing",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/something-2c4k6", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/CollisionsWithDifferentCapitalization/something-2c4k6",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "something", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "something",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.method", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.method",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "method", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "method",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.subscript", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.subscript",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "subscript", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "subscript",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.type.method", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/CollisionsWithEscapedKeywords/subscript()-swift.type.method",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "type method", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "type method",
+                "The abstract should be from the overriding documentation extension.")
         }
     }
-    
+
     func testMatchesDocumentationExtensionsWithSourceLanguageSpecificLinks() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+        let (_, bundle, context) = try testBundleAndContext(
+            copying: "MixedLanguageFrameworkWithLanguageRefinements"
+        ) { url in
             // typedef NS_OPTIONS(NSInteger, MyObjectiveCOption) {
             //     MyObjectiveCOptionNone                                      = 0,
             //     MyObjectiveCOptionFirst                                     = 1 << 0,
@@ -3629,28 +4643,31 @@ let expected = """
             // };
             try """
             # ``MixedFramework/MyObjectiveCOption/MyObjectiveCOptionFirst``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             Objective-C option case
-            
+
             This documentation extension link uses the Objective-C spelling to refer to the "first" option case.
-            """.write(to: url.appendingPathComponent("objc-case.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("objc-case.md"), atomically: true, encoding: .utf8)
+
             try """
             # ``MixedFramework/MyObjectiveCOption/secondCaseSwiftName``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             Swift spelling of Objective-C option case
-            
+
             This documentation extension link uses the customized Swift spelling to refer to the "second" option case.
-            """.write(to: url.appendingPathComponent("objc-case-swift-name.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("objc-case-swift-name.md"), atomically: true,
+                encoding: .utf8)
+
             // NS_SWIFT_NAME(MyObjectiveCClassSwiftName)
             // @interface MyObjectiveCClassObjectiveCName : NSObject
             //
@@ -3662,141 +4679,189 @@ let expected = """
             // @end
             try """
             # ``MixedFramework/MyObjectiveCClassObjectiveCName/myMethodWithArgument:``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             Objective-C method with one argument
-            
+
             This documentation extension link uses the Objective-C spelling to refer to the method with an argument.
-            """.write(to: url.appendingPathComponent("objc-method.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("objc-method.md"), atomically: true, encoding: .utf8)
+
             try """
             # ``MixedFramework/MyObjectiveCClassSwiftName/myMethodSwiftName()``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             Swift spelling for Objective-C method without arguments
-            
+
             This documentation extension link uses the customized Swift spelling to refer to the method without an argument.
-            """.write(to: url.appendingPathComponent("objc-method-swift-name.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("objc-method-swift-name.md"), atomically: true,
+                encoding: .utf8)
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCOption/first", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCOption/first",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "Objective-C option case", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "Objective-C option case",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCOption/secondCaseSwiftName", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path: "/documentation/MixedFramework/MyObjectiveCOption/secondCaseSwiftName",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "Swift spelling of Objective-C option case", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "Swift spelling of Objective-C option case",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "Objective-C method with one argument", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "Objective-C method with one argument",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs the language info alongside the symbol kind info.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethodSwiftName()", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path:
+                    "/documentation/MixedFramework/MyObjectiveCClassSwiftName/myMethodSwiftName()",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "Swift spelling for Objective-C method without arguments", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText,
+                "Swift spelling for Objective-C method without arguments",
+                "The abstract should be from the overriding documentation extension.")
         }
     }
-    
+
     func testMatchesDocumentationExtensionsRelativeToModule() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+        let (_, bundle, context) = try testBundleAndContext(
+            copying: "MixedLanguageFrameworkWithLanguageRefinements"
+        ) { url in
             // Top level symbols, omitting the module name
             try """
             # ``MyStruct/myStructProperty``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             my struct property
-            """.write(to: url.appendingPathComponent("struct-property.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("struct-property.md"), atomically: true,
+                encoding: .utf8)
+
             try """
             # ``MyTypeAlias``
-            
+
             @Metadata {
               @DocumentationExtension(mergeBehavior: override)
             }
-            
+
             my type alias
             """.write(to: url.appendingPathComponent("alias.md"), atomically: true, encoding: .utf8)
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyStruct/myStructProperty", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path: "/documentation/MixedFramework/MyStruct/myStructProperty",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "my struct property", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "my struct property",
+                "The abstract should be from the overriding documentation extension.")
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MixedFramework/MyTypeAlias", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/MixedFramework/MyTypeAlias",
+                sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "my type alias", "The abstract should be from the overriding documentation extension.")
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "my type alias",
+                "The abstract should be from the overriding documentation extension.")
         }
     }
-    
+
     func testCurationOfSymbolsWithSameNameAsModule() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
+        let (_, bundle, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule")
+        { url in
             // Top level symbols, omitting the module name
             try """
             # ``Something``
-            
+
             This documentation extension covers the module symbol
-            
+
             ## Topics
-            
+
             This link curates the top-level struct
-            
+
             - ``Something``
-            """.write(to: url.appendingPathComponent("something.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("something.md"), atomically: true, encoding: .utf8)
         }
-        
+
         do {
             // The resolved reference needs more disambiguation than the documentation extension link did.
-            let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Something", sourceLanguage: .swift)
-            
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Something", sourceLanguage: .swift)
+
             let node = try context.entity(with: reference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
-            XCTAssertEqual(symbol.abstract?.plainText, "This documentation extension covers the module symbol", "The abstract should be from the overriding documentation extension.")
-            
+            XCTAssertEqual(
+                symbol.abstract?.plainText, "This documentation extension covers the module symbol",
+                "The abstract should be from the overriding documentation extension.")
+
             let topics = try XCTUnwrap(symbol.topics?.taskGroups.first)
-            XCTAssertEqual(topics.abstract?.paragraph.plainText, "This link curates the top-level struct")
-            XCTAssertEqual(topics.links.first?.destination, "doc://SymbolsWithSameNameAsModule/documentation/Something/Something")
+            XCTAssertEqual(
+                topics.abstract?.paragraph.plainText, "This link curates the top-level struct")
+            XCTAssertEqual(
+                topics.links.first?.destination,
+                "doc://SymbolsWithSameNameAsModule/documentation/Something/Something")
         }
     }
-    
+
     func testMultipleDocumentationExtensionMatchDiagnostic() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+        let (_, _, context) = try testBundleAndContext(
+            copying: "MixedLanguageFrameworkWithLanguageRefinements"
+        ) { url in
             // typedef NS_OPTIONS(NSInteger, MyObjectiveCOption) {
             //     MyObjectiveCOptionNone                                      = 0,
             //     MyObjectiveCOptionFirst                                     = 1 << 0,
@@ -3804,16 +4869,19 @@ let expected = """
             // };
             try """
             # ``MixedFramework/MyObjectiveCOption/MyObjectiveCOptionFirst``
-            
+
             This documentation extension link uses the Objective-C spelling to refer to the "first" option case.
-            """.write(to: url.appendingPathComponent("objc-case.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("objc-case.md"), atomically: true, encoding: .utf8)
+
             try """
             # ``MixedFramework/MyObjectiveCOption/first``
-            
+
             This documentation extension link uses the customized Swift spelling to refer to the "first" option case.
-            """.write(to: url.appendingPathComponent("objc-case-swift-name.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("objc-case-swift-name.md"), atomically: true,
+                encoding: .utf8)
+
             // NS_SWIFT_NAME(MyObjectiveCClassSwiftName)
             // @interface MyObjectiveCClassObjectiveCName : NSObject
             //
@@ -3825,207 +4893,293 @@ let expected = """
             // @end
             try """
             # ``MixedFramework/MyObjectiveCClassObjectiveCName/myMethodWithArgument:``
-            
+
             This documentation extension link uses the Objective-C spelling to refer to the method with an argument.
-            """.write(to: url.appendingPathComponent("objc-method.md"), atomically: true, encoding: .utf8)
-            
+            """.write(
+                to: url.appendingPathComponent("objc-method.md"), atomically: true, encoding: .utf8)
+
             try """
             # ``MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)``
-            
+
             This documentation extension link uses the customized Swift spelling to refer to the method with an argument.
-            """.write(to: url.appendingPathComponent("objc-method-swift-name.md"), atomically: true, encoding: .utf8)
+            """.write(
+                to: url.appendingPathComponent("objc-method-swift-name.md"), atomically: true,
+                encoding: .utf8)
         }
-        
-        let multipleDocExtensionProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.DuplicateMarkdownTitleSymbolReferences" })
+
+        let multipleDocExtensionProblems = context.problems.filter({
+            $0.diagnostic.identifier == "org.swift.docc.DuplicateMarkdownTitleSymbolReferences"
+        })
         XCTAssertEqual(multipleDocExtensionProblems.count, 2)
-        
-        let enumCaseMultipleMatchProblem = try XCTUnwrap(multipleDocExtensionProblems.first(where: { $0.diagnostic.summary == "Multiple documentation extensions matched 'MixedFramework/MyObjectiveCOption/first'." }))
-        XCTAssert(["objc-case.md", "objc-case-swift-name.md"].contains(enumCaseMultipleMatchProblem.diagnostic.source?.lastPathComponent ?? ""), "The warning should refer to one of the documentation extensions files")
+
+        let enumCaseMultipleMatchProblem = try XCTUnwrap(
+            multipleDocExtensionProblems.first(where: {
+                $0.diagnostic.summary
+                    == "Multiple documentation extensions matched 'MixedFramework/MyObjectiveCOption/first'."
+            }))
+        XCTAssert(
+            ["objc-case.md", "objc-case-swift-name.md"].contains(
+                enumCaseMultipleMatchProblem.diagnostic.source?.lastPathComponent ?? ""),
+            "The warning should refer to one of the documentation extensions files")
         XCTAssertEqual(enumCaseMultipleMatchProblem.diagnostic.notes.count, 1)
-        XCTAssert(["objc-case.md", "objc-case-swift-name.md"].contains(enumCaseMultipleMatchProblem.diagnostic.notes.first?.source.lastPathComponent ?? ""), "The note should refer to one of the documentation extension files")
-        XCTAssertNotEqual(enumCaseMultipleMatchProblem.diagnostic.source, enumCaseMultipleMatchProblem.diagnostic.notes.first?.source, "The warning and the note should refer to different documentation extension files")
-        
-        let methodMultipleMatchProblem = try XCTUnwrap(multipleDocExtensionProblems.first(where: { $0.diagnostic.summary == "Multiple documentation extensions matched 'MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)'." }))
-        XCTAssert(["objc-method.md", "objc-method-swift-name.md"].contains(methodMultipleMatchProblem.diagnostic.source?.lastPathComponent ?? ""), "The warning should refer to one of the documentation extensions files")
+        XCTAssert(
+            ["objc-case.md", "objc-case-swift-name.md"].contains(
+                enumCaseMultipleMatchProblem.diagnostic.notes.first?.source.lastPathComponent ?? ""),
+            "The note should refer to one of the documentation extension files")
+        XCTAssertNotEqual(
+            enumCaseMultipleMatchProblem.diagnostic.source,
+            enumCaseMultipleMatchProblem.diagnostic.notes.first?.source,
+            "The warning and the note should refer to different documentation extension files")
+
+        let methodMultipleMatchProblem = try XCTUnwrap(
+            multipleDocExtensionProblems.first(where: {
+                $0.diagnostic.summary
+                    == "Multiple documentation extensions matched 'MixedFramework/MyObjectiveCClassSwiftName/myMethod(argument:)'."
+            }))
+        XCTAssert(
+            ["objc-method.md", "objc-method-swift-name.md"].contains(
+                methodMultipleMatchProblem.diagnostic.source?.lastPathComponent ?? ""),
+            "The warning should refer to one of the documentation extensions files")
         XCTAssertEqual(methodMultipleMatchProblem.diagnostic.notes.count, 1)
-        XCTAssert(["objc-method.md", "objc-method-swift-name.md"].contains(methodMultipleMatchProblem.diagnostic.notes.first?.source.lastPathComponent ?? ""), "The note should refer to one of the documentation extension files")
-        XCTAssertNotEqual(methodMultipleMatchProblem.diagnostic.source, methodMultipleMatchProblem.diagnostic.notes.first?.source, "The warning and the note should refer to different documentation extension files")
+        XCTAssert(
+            ["objc-method.md", "objc-method-swift-name.md"].contains(
+                methodMultipleMatchProblem.diagnostic.notes.first?.source.lastPathComponent ?? ""),
+            "The note should refer to one of the documentation extension files")
+        XCTAssertNotEqual(
+            methodMultipleMatchProblem.diagnostic.source,
+            methodMultipleMatchProblem.diagnostic.notes.first?.source,
+            "The warning and the note should refer to different documentation extension files")
     }
-    
+
     func testAutomaticallyCuratesArticles() throws {
-        let articleOne = TextFile(name: "Article1.md", utf8Content: """
-            # Article 1
-
-            ## Topics
-            ### Group
-            - <doc:DoesNotResolve>
-            """)
-        
-        let articleTwo = TextFile(name: "Article2.md", utf8Content: """
-            # Article 2
-
-            ## Topics
-            ### Group
-            - <doc:Article1>
-            """)
-        
-        do {
-            let tempURL = try createTemporaryDirectory()
-            
-            let bundleURL = try Folder(name: "Module.docc", content: [
-                InfoPlist(displayName: "Module", identifier: "org.swift.docc.example"),
-                TextFile(name: "Module.md", utf8Content: """
-                # Autocurated Articles
-
-                @Metadata {
-                  @TechnologyRoot
-                }
-                
-                This bundle contains a single module, and the articles should be automatically curated.
-                """),
-                articleOne,
-                articleTwo,
-            ]).write(inside: tempURL)
-            let (_, bundle, context) = try loadBundle(from: bundleURL)
-            
-            let identifiers = context.problems.map(\.diagnostic.identifier)
-            XCTAssertFalse(identifiers.contains(where: { $0 == "org.swift.docc.ArticleUncurated" }))
-            
-            let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
-            let docNode = try context.entity(with: rootReference)
-            let article = try XCTUnwrap(docNode.semantic as? Article)
-            XCTAssertNil(article.topics)
-
-            XCTAssertEqual(article.automaticTaskGroups.count, 1)
-            
-            let taskGroup = try XCTUnwrap(article.automaticTaskGroups.first)
-            XCTAssertEqual(taskGroup.title, "Articles")
-            XCTAssertEqual(taskGroup.references.count, 2)
-            XCTAssert(taskGroup.references.map(\.absoluteString).contains("doc://org.swift.docc.example/documentation/Module/Article1"))
-            XCTAssert(taskGroup.references.map(\.absoluteString).contains("doc://org.swift.docc.example/documentation/Module/Article2"))
-        }
-        
-        do {
-            let tempURL = try createTemporaryDirectory()
-            
-            let bundleURL = try Folder(name: "Module.docc", content: [
-                InfoPlist(displayName: "Module", identifier: "org.swift.docc.example"),
-                TextFile(name: "Module.md", utf8Content: """
-                    # Autocurated Articles
-
-                    @Metadata {
-                      @TechnologyRoot
-                    }
-                    
-                    This bundle contains a single module, and the articles should be automatically curated.
-                    
-                    ## Topics
-                    ### Links
-                    - <doc:Article2>
-                    """),
-                articleOne,
-                articleTwo,
-            ]).write(inside: tempURL)
-            let (_, bundle, context) = try loadBundle(from: bundleURL)
-            
-            let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
-            let docNode = try context.entity(with: rootReference)
-            let article = try XCTUnwrap(docNode.semantic as? Article)
-            XCTAssertNotNil(article.topics)
-            XCTAssertTrue(article.automaticTaskGroups.isEmpty, "No automatic task groups should have been created as there are no uncurated articles left after curating Article2.")
-        }
-    }
-    
-    func testAutomaticTaskGroupsPlacedAfterManualCuration() throws {
-        let tempURL = try createTemporaryDirectory()
-        
-        let bundleURL = try Folder(name: "Module.docc", content: [
-            InfoPlist(displayName: "Module", identifier: "org.swift.docc.example"),
-            TextFile(name: "Module.md", utf8Content: """
-                # Autocurated Articles
-
-                @Metadata {
-                  @TechnologyRoot
-                }
-                
-                This bundle contains a single module, and the articles should be automatically curated.
-                
-                ## Topics
-                ### Links
-                - <doc:Article1>
-                """),
-            TextFile(name: "Article1.md", utf8Content: """
+        let articleOne = TextFile(
+            name: "Article1.md",
+            utf8Content: """
                 # Article 1
 
                 ## Topics
                 ### Group
                 - <doc:DoesNotResolve>
-                """),
-            TextFile(name: "Article2.md", utf8Content: """
+                """)
+
+        let articleTwo = TextFile(
+            name: "Article2.md",
+            utf8Content: """
                 # Article 2
-                
+
                 ## Topics
                 ### Group
                 - <doc:Article1>
-                """),
-        ]).write(inside: tempURL)
+                """)
+
+        do {
+            let tempURL = try createTemporaryDirectory()
+
+            let bundleURL = try Folder(
+                name: "Module.docc",
+                content: [
+                    InfoPlist(displayName: "Module", identifier: "org.swift.docc.example"),
+                    TextFile(
+                        name: "Module.md",
+                        utf8Content: """
+                            # Autocurated Articles
+
+                            @Metadata {
+                              @TechnologyRoot
+                            }
+
+                            This bundle contains a single module, and the articles should be automatically curated.
+                            """),
+                    articleOne,
+                    articleTwo,
+                ]
+            ).write(inside: tempURL)
+            let (_, bundle, context) = try loadBundle(from: bundleURL)
+
+            let identifiers = context.problems.map(\.diagnostic.identifier)
+            XCTAssertFalse(identifiers.contains(where: { $0 == "org.swift.docc.ArticleUncurated" }))
+
+            let rootReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
+            let docNode = try context.entity(with: rootReference)
+            let article = try XCTUnwrap(docNode.semantic as? Article)
+            XCTAssertNil(article.topics)
+
+            XCTAssertEqual(article.automaticTaskGroups.count, 1)
+
+            let taskGroup = try XCTUnwrap(article.automaticTaskGroups.first)
+            XCTAssertEqual(taskGroup.title, "Articles")
+            XCTAssertEqual(taskGroup.references.count, 2)
+            XCTAssert(
+                taskGroup.references.map(\.absoluteString).contains(
+                    "doc://org.swift.docc.example/documentation/Module/Article1"))
+            XCTAssert(
+                taskGroup.references.map(\.absoluteString).contains(
+                    "doc://org.swift.docc.example/documentation/Module/Article2"))
+        }
+
+        do {
+            let tempURL = try createTemporaryDirectory()
+
+            let bundleURL = try Folder(
+                name: "Module.docc",
+                content: [
+                    InfoPlist(displayName: "Module", identifier: "org.swift.docc.example"),
+                    TextFile(
+                        name: "Module.md",
+                        utf8Content: """
+                            # Autocurated Articles
+
+                            @Metadata {
+                              @TechnologyRoot
+                            }
+
+                            This bundle contains a single module, and the articles should be automatically curated.
+
+                            ## Topics
+                            ### Links
+                            - <doc:Article2>
+                            """),
+                    articleOne,
+                    articleTwo,
+                ]
+            ).write(inside: tempURL)
+            let (_, bundle, context) = try loadBundle(from: bundleURL)
+
+            let rootReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
+            let docNode = try context.entity(with: rootReference)
+            let article = try XCTUnwrap(docNode.semantic as? Article)
+            XCTAssertNotNil(article.topics)
+            XCTAssertTrue(
+                article.automaticTaskGroups.isEmpty,
+                "No automatic task groups should have been created as there are no uncurated articles left after curating Article2."
+            )
+        }
+    }
+
+    func testAutomaticTaskGroupsPlacedAfterManualCuration() throws {
+        let tempURL = try createTemporaryDirectory()
+
+        let bundleURL = try Folder(
+            name: "Module.docc",
+            content: [
+                InfoPlist(displayName: "Module", identifier: "org.swift.docc.example"),
+                TextFile(
+                    name: "Module.md",
+                    utf8Content: """
+                        # Autocurated Articles
+
+                        @Metadata {
+                          @TechnologyRoot
+                        }
+
+                        This bundle contains a single module, and the articles should be automatically curated.
+
+                        ## Topics
+                        ### Links
+                        - <doc:Article1>
+                        """),
+                TextFile(
+                    name: "Article1.md",
+                    utf8Content: """
+                        # Article 1
+
+                        ## Topics
+                        ### Group
+                        - <doc:DoesNotResolve>
+                        """),
+                TextFile(
+                    name: "Article2.md",
+                    utf8Content: """
+                        # Article 2
+
+                        ## Topics
+                        ### Group
+                        - <doc:Article1>
+                        """),
+            ]
+        ).write(inside: tempURL)
         let (_, bundle, context) = try loadBundle(from: bundleURL)
-        
-        let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
+
+        let rootReference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
         let docNode = try context.entity(with: rootReference)
         let article = try XCTUnwrap(docNode.semantic as? Article)
-        
+
         let topics = try XCTUnwrap(article.topics)
         XCTAssertEqual(topics.taskGroups.count, 1)
         let manualTaskGroup = try XCTUnwrap(topics.taskGroups.first)
         XCTAssertEqual(manualTaskGroup.heading?.title, "Links")
         XCTAssertEqual(manualTaskGroup.links.count, 1)
-        XCTAssertEqual(manualTaskGroup.links.first?.destination, "doc://org.swift.docc.example/documentation/Module/Article1")
-        
+        XCTAssertEqual(
+            manualTaskGroup.links.first?.destination,
+            "doc://org.swift.docc.example/documentation/Module/Article1")
+
         XCTAssertEqual(article.automaticTaskGroups.count, 1)
-        
+
         let taskGroup = try XCTUnwrap(article.automaticTaskGroups.first)
         XCTAssertEqual(taskGroup.title, "Articles")
         XCTAssertEqual(taskGroup.references.count, 1)
-        XCTAssert(taskGroup.references.map(\.absoluteString).contains("doc://org.swift.docc.example/documentation/Module/Article2"))
+        XCTAssert(
+            taskGroup.references.map(\.absoluteString).contains(
+                "doc://org.swift.docc.example/documentation/Module/Article2"))
     }
-    
+
     // Verifies if the context resolves linkable nodes.
     func testLinkableNodes() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
-            try "# Article1".write(to: url.appendingPathComponent("resolvable-article.md"), atomically: true, encoding: .utf8)
-            let myKitURL = url.appendingPathComponent("documentation").appendingPathComponent("mykit.md")
+        let (_, bundle, context) = try testBundleAndContext(
+            copying: "LegacyBundle_DoNotUseInNewTests"
+        ) { url in
+            try "# Article1".write(
+                to: url.appendingPathComponent("resolvable-article.md"), atomically: true,
+                encoding: .utf8)
+            let myKitURL = url.appendingPathComponent("documentation").appendingPathComponent(
+                "mykit.md")
             try String(contentsOf: myKitURL)
                 .replacingOccurrences(of: " - <doc:article>", with: " - <doc:resolvable-article>")
                 .write(to: myKitURL, atomically: true, encoding: .utf8)
         }
-        let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
+        let moduleReference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
 
         // Try resolving the new resolvable node
-        switch context.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc:resolvable-article")!)), in: moduleReference) {
+        switch context.resolve(
+            .unresolved(
+                UnresolvedTopicReference(
+                    topicURL: ValidatedURL(parsingExact: "doc:resolvable-article")!)),
+            in: moduleReference)
+        {
         case .success(let resolvedReference):
-            XCTAssertEqual(resolvedReference.absoluteString, "doc://\(bundle.id)/documentation/Test-Bundle/resolvable-article")
+            XCTAssertEqual(
+                resolvedReference.absoluteString,
+                "doc://\(bundle.id)/documentation/Test-Bundle/resolvable-article")
             XCTAssertNoThrow(try context.entity(with: resolvedReference))
         case .failure(_, let errorMessage):
             XCTFail("Did not resolve resolvable link. Error: \(errorMessage)")
         }
     }
-    
+
     // Verifies if the context fails to resolve non-resolvable nodes.
     func testNonLinkableNodes() throws {
         // Create a bundle with variety absolute and relative links and symbol links to a non linkable node.
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
-            try """
-            # ``SideKit/SideClass``
-            Abstract.
-            ## Discussion
-            This is a link to <doc:/documentation/SideKit/SideClass/Element/Protocol-Implementations>.
-            ## Topics
-            ### Basics
-             - <doc:documentation/SideKit/SideClass/Element/Protocol-Implementations>
-             - <doc:Element/Protocol-Implementations>
-            """.write(to: url.appendingPathComponent("sideclass.md"), atomically: true, encoding: .utf8)
-        })
+        let (_, _, context) = try testBundleAndContext(
+            copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:],
+            externalSymbolResolver: nil,
+            configureBundle: { url in
+                try """
+                # ``SideKit/SideClass``
+                Abstract.
+                ## Discussion
+                This is a link to <doc:/documentation/SideKit/SideClass/Element/Protocol-Implementations>.
+                ## Topics
+                ### Basics
+                 - <doc:documentation/SideKit/SideClass/Element/Protocol-Implementations>
+                 - <doc:Element/Protocol-Implementations>
+                """.write(
+                    to: url.appendingPathComponent("sideclass.md"), atomically: true,
+                    encoding: .utf8)
+            })
 
         let disabledDestinationProblems = context.problems.filter { p in
             return p.diagnostic.identifier == "org.swift.docc.disabledLinkDestination"
@@ -4034,182 +5188,238 @@ let expected = """
 
         let mapRangeAsString: (SourceRange?) -> String? = { range in
             guard let range else { return nil }
-            return "\(range.lowerBound.line):\(range.lowerBound.column) - \(range.upperBound.line):\(range.upperBound.column)"
+            return
+                "\(range.lowerBound.line):\(range.lowerBound.column) - \(range.upperBound.line):\(range.upperBound.column)"
         }
-        
+
         // Verify that all links in source have been detected and the special diagnostic is emitted.
-        XCTAssertEqual(Set(disabledDestinationProblems.map({ mapRangeAsString($0.diagnostic.range) })), [
-            "4:19 - 4:90",
-            "7:4 - 7:74",
-            "8:4 - 8:42",
-        ])
+        XCTAssertEqual(
+            Set(disabledDestinationProblems.map({ mapRangeAsString($0.diagnostic.range) })),
+            [
+                "4:19 - 4:90",
+                "7:4 - 7:74",
+                "8:4 - 8:42",
+            ])
     }
-    
+
     // Fixtures to exercise resolving links vs. symbol links.
 
     /// Empty symbol graph with a single symbol called "Test"
     private let testSymbolGraphSource = """
-     {
-       "metadata": {
-         "formatVersion": { "major": 0, "minor": 5, "patch": 2 },
-         "generator": "App"
-       },
-       "module": {
-         "name": "Minimal_docs",
-         "platform": {
-           "architecture": "x86_64",
-           "vendor": "apple",
-           "operatingSystem": {
-             "name": "macosx",
-             "minimumVersion": { "major": 10, "minor": 10, "patch": 0 }
-           }
-         }
-       },
-       "symbols": [
-         {
-           "kind": {
-             "identifier": "swift.struct",
-             "displayName": "Structure"
-           },
-           "identifier": {
-             "precise": "s:12Minimal_docs4TestV",
-             "interfaceLanguage": "swift"
-           },
-           "pathComponents": [
-             "Test"
-           ],
-           "names": {
-             "title": "Test"
-           },
-           "declarationFragments": [
-             {
-               "kind": "keyword",
-               "spelling": "struct"
-             },
-             {
-               "kind": "text",
-               "spelling": " "
-             },
-             {
-               "kind": "identifier",
-               "spelling": "Test"
-             }
-           ],
-           "accessLevel": "public"
-         }
-       ],
-       "relationships": []
-     }
-     """
-    private let testRootPageSource = """
-     # Root
-     @Metadata {
-        @TechnologyRoot
-     }
-     ## Topics
-     ### Articles
-      - <doc:/documentation/Test-Bundle/Test>
-     """
-    
-    private let testArticleSource = """
-     # Test Article
-     Test Article abstract.
-     """
-    
-    private let testTechnologySource = """
-     @Tutorials(name: "Test Technology") {
-        @Intro(title: "Introduction") { }
-     
-        @Chapter(name: "Essentials") {
-           @TutorialReference(tutorial: "doc:tutorials/Test-Bundle/Test")
+        {
+          "metadata": {
+            "formatVersion": { "major": 0, "minor": 5, "patch": 2 },
+            "generator": "App"
+          },
+          "module": {
+            "name": "Minimal_docs",
+            "platform": {
+              "architecture": "x86_64",
+              "vendor": "apple",
+              "operatingSystem": {
+                "name": "macosx",
+                "minimumVersion": { "major": 10, "minor": 10, "patch": 0 }
+              }
+            }
+          },
+          "symbols": [
+            {
+              "kind": {
+                "identifier": "swift.struct",
+                "displayName": "Structure"
+              },
+              "identifier": {
+                "precise": "s:12Minimal_docs4TestV",
+                "interfaceLanguage": "swift"
+              },
+              "pathComponents": [
+                "Test"
+              ],
+              "names": {
+                "title": "Test"
+              },
+              "declarationFragments": [
+                {
+                  "kind": "keyword",
+                  "spelling": "struct"
+                },
+                {
+                  "kind": "text",
+                  "spelling": " "
+                },
+                {
+                  "kind": "identifier",
+                  "spelling": "Test"
+                }
+              ],
+              "accessLevel": "public"
+            }
+          ],
+          "relationships": []
         }
-     }
-     """
-    
+        """
+    private let testRootPageSource = """
+        # Root
+        @Metadata {
+           @TechnologyRoot
+        }
+        ## Topics
+        ### Articles
+         - <doc:/documentation/Test-Bundle/Test>
+        """
+
+    private let testArticleSource = """
+        # Test Article
+        Test Article abstract.
+        """
+
+    private let testTechnologySource = """
+        @Tutorials(name: "Test Technology") {
+           @Intro(title: "Introduction") { }
+
+           @Chapter(name: "Essentials") {
+              @TutorialReference(tutorial: "doc:tutorials/Test-Bundle/Test")
+           }
+        }
+        """
+
     private let testTutorialSource = """
-     @Tutorial {
-        @Intro(title: "Test Tutorial") { }
-        @Assessments { }
-     }
-     """
+        @Tutorial {
+           @Intro(title: "Test Tutorial") { }
+           @Assessments { }
+        }
+        """
 
     /// Verify we resolve a relative link to the article if we have
     /// an article, a tutorial, and a symbol with the *same* names.
     func testResolvePrecedenceArticleOverTutorialOverSymbol() throws {
         // Verify resolves correctly between a bundle with an article and a tutorial.
         do {
-            let infoPlistURL = try XCTUnwrap(Bundle.module.url(forResource: "Info+Availability", withExtension: "plist", subdirectory: "Test Resources"))
-            let testBundle = Folder(name: "test.docc", content: [
-                CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
-                TextFile(name: "TestRoot.md", utf8Content: testRootPageSource),
-                TextFile(name: "Test.md", utf8Content: testArticleSource),
-                TextFile(name: "TestTechnology.tutorial", utf8Content: testTechnologySource),
-                TextFile(name: "Test.tutorial", utf8Content: testTutorialSource),
-            ])
+            let infoPlistURL = try XCTUnwrap(
+                Bundle.module.url(
+                    forResource: "Info+Availability", withExtension: "plist",
+                    subdirectory: "Test Resources"))
+            let testBundle = Folder(
+                name: "test.docc",
+                content: [
+                    CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
+                    TextFile(name: "TestRoot.md", utf8Content: testRootPageSource),
+                    TextFile(name: "Test.md", utf8Content: testArticleSource),
+                    TextFile(name: "TestTechnology.tutorial", utf8Content: testTechnologySource),
+                    TextFile(name: "Test.tutorial", utf8Content: testTutorialSource),
+                ])
             let tempFolderURL = try createTemporaryDirectory().appendingPathComponent("test.docc")
             try testBundle.write(to: tempFolderURL)
-            
+
             // Load the bundle
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
             // Verify the context contains the conflicting topic names
             // Article
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(
+                context.documentationCache[
+                    ResolvedTopicReference(
+                        bundleID: bundle.id, path: "/documentation/Test-Bundle/Test",
+                        sourceLanguage: .swift)])
             // Tutorial
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
-            
-            let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
-            let expected = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
+            XCTAssertNotNil(
+                context.documentationCache[
+                    ResolvedTopicReference(
+                        bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test",
+                        sourceLanguage: .swift)])
+
+            let unresolved = TopicReference.unresolved(
+                .init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
+            let expected = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift
+            )
 
             // Resolve from various locations in the bundle
-            for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialTableOfContentsContainer] {
+            for parent in [
+                bundle.rootReference, bundle.documentationRootReference,
+                bundle.tutorialTableOfContentsContainer,
+            ] {
                 switch context.resolve(unresolved, in: parent) {
-                    case .success(let reference):
-                        if reference.path != expected.path {
-                            XCTFail("Expected to resolve to \(expected.path) in parent path '\(parent.path)' but got \(reference.path)")
-                        }
-                    case .failure(_, let errorMessage): XCTFail("Didn't resolve to expected reference path \(expected.path). Error: \(errorMessage)")
+                case .success(let reference):
+                    if reference.path != expected.path {
+                        XCTFail(
+                            "Expected to resolve to \(expected.path) in parent path '\(parent.path)' but got \(reference.path)"
+                        )
+                    }
+                case .failure(_, let errorMessage):
+                    XCTFail(
+                        "Didn't resolve to expected reference path \(expected.path). Error: \(errorMessage)"
+                    )
                 }
             }
         }
-        
+
         // Verify resolves correctly between a bundle with an article, a tutorial, and a symbol
         do {
-            let infoPlistURL = try XCTUnwrap(Bundle.module.url(forResource: "Info+Availability", withExtension: "plist", subdirectory: "Test Resources"))
-            let testBundle = Folder(name: "test.docc", content: [
-                CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
-                TextFile(name: "TestRoot.md", utf8Content: testRootPageSource),
-                TextFile(name: "Test.md", utf8Content: testArticleSource),
-                TextFile(name: "TestFramework.symbols.json", utf8Content: testSymbolGraphSource),
-                TextFile(name: "TestTechnology.tutorial", utf8Content: testTechnologySource),
-                TextFile(name: "Test.tutorial", utf8Content: testTutorialSource),
-            ])
+            let infoPlistURL = try XCTUnwrap(
+                Bundle.module.url(
+                    forResource: "Info+Availability", withExtension: "plist",
+                    subdirectory: "Test Resources"))
+            let testBundle = Folder(
+                name: "test.docc",
+                content: [
+                    CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
+                    TextFile(name: "TestRoot.md", utf8Content: testRootPageSource),
+                    TextFile(name: "Test.md", utf8Content: testArticleSource),
+                    TextFile(
+                        name: "TestFramework.symbols.json", utf8Content: testSymbolGraphSource),
+                    TextFile(name: "TestTechnology.tutorial", utf8Content: testTechnologySource),
+                    TextFile(name: "Test.tutorial", utf8Content: testTutorialSource),
+                ])
             let tempFolderURL = try createTemporaryDirectory().appendingPathComponent("test.docc")
             try testBundle.write(to: tempFolderURL)
-            
+
             // Load the bundle
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
             // Verify the context contains the conflicting topic names
             // Article
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(
+                context.documentationCache[
+                    ResolvedTopicReference(
+                        bundleID: bundle.id, path: "/documentation/Test-Bundle/Test",
+                        sourceLanguage: .swift)])
             // Tutorial
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(
+                context.documentationCache[
+                    ResolvedTopicReference(
+                        bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test",
+                        sourceLanguage: .swift)])
             // Symbol
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)])
-            
-            let unresolved = TopicReference.unresolved(.init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
-            let expected = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
-            
-            let symbolReference = try XCTUnwrap(context.documentationCache.reference(symbolID: "s:12Minimal_docs4TestV"))
-            
+            XCTAssertNotNil(
+                context.documentationCache[
+                    ResolvedTopicReference(
+                        bundleID: bundle.id, path: "/documentation/Minimal_docs/Test",
+                        sourceLanguage: .swift)])
+
+            let unresolved = TopicReference.unresolved(
+                .init(topicURL: try XCTUnwrap(ValidatedURL(parsingExact: "doc:Test"))))
+            let expected = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift
+            )
+
+            let symbolReference = try XCTUnwrap(
+                context.documentationCache.reference(symbolID: "s:12Minimal_docs4TestV"))
 
             // Resolve from various locations in the bundle
-            for parent in [bundle.rootReference, bundle.documentationRootReference, bundle.tutorialTableOfContentsContainer, symbolReference] {
+            for parent in [
+                bundle.rootReference, bundle.documentationRootReference,
+                bundle.tutorialTableOfContentsContainer, symbolReference,
+            ] {
                 switch context.resolve(unresolved, in: parent) {
-                    case .success(let reference):
-                        if reference.path != expected.path {
-                            XCTFail("Expected to resolve to \(expected.path) in parent path '\(parent.path)' but got \(reference.path)")
-                        }
-                    case .failure(_, let errorMessage): XCTFail("Didn't resolve to expected reference path \(expected.path). Error: \(errorMessage)")
+                case .success(let reference):
+                    if reference.path != expected.path {
+                        XCTFail(
+                            "Expected to resolve to \(expected.path) in parent path '\(parent.path)' but got \(reference.path)"
+                        )
+                    }
+                case .failure(_, let errorMessage):
+                    XCTFail(
+                        "Didn't resolve to expected reference path \(expected.path). Error: \(errorMessage)"
+                    )
                 }
             }
         }
@@ -4218,117 +5428,158 @@ let expected = """
     func testResolvePrecedenceSymbolInBackticks() throws {
         // Verify resolves correctly a double-backtick link.
         do {
-            let infoPlistURL = try XCTUnwrap(Bundle.module.url(forResource: "Info+Availability", withExtension: "plist", subdirectory: "Test Resources"))
-            let testBundle = Folder(name: "test.docc", content: [
-                CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
-                TextFile(name: "Minimal_docs.md", utf8Content:
+            let infoPlistURL = try XCTUnwrap(
+                Bundle.module.url(
+                    forResource: "Info+Availability", withExtension: "plist",
+                    subdirectory: "Test Resources"))
+            let testBundle = Folder(
+                name: "test.docc",
+                content: [
+                    CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
+                    TextFile(
+                        name: "Minimal_docs.md",
+                        utf8Content:
                             """
-                             # ``Minimal_docs``
-                             Module abstract.
-                             
-                             ``Test``
-                             ## Topics
-                             ### Articles
-                              - <doc:Article>
-                             """),
-                TextFile(name: "TestRoot.md", utf8Content: testRootPageSource),
-                TextFile(name: "Article.md", utf8Content: "# Article"),
-                TextFile(name: "Test.md", utf8Content:
+                            # ``Minimal_docs``
+                            Module abstract.
+
+                            ``Test``
+                            ## Topics
+                            ### Articles
+                             - <doc:Article>
+                            """),
+                    TextFile(name: "TestRoot.md", utf8Content: testRootPageSource),
+                    TextFile(name: "Article.md", utf8Content: "# Article"),
+                    TextFile(
+                        name: "Test.md",
+                        utf8Content:
                             """
-                             # Test Article
-                             Article abstract.
-                             
-                             ``Test``
-                             """),
-                TextFile(name: "TestFramework.symbols.json", utf8Content: testSymbolGraphSource),
-                TextFile(name: "TestTechnology.tutorial", utf8Content: testTechnologySource),
-                TextFile(name: "Test.tutorial", utf8Content: testTutorialSource),
-            ])
+                            # Test Article
+                            Article abstract.
+
+                            ``Test``
+                            """),
+                    TextFile(
+                        name: "TestFramework.symbols.json", utf8Content: testSymbolGraphSource),
+                    TextFile(name: "TestTechnology.tutorial", utf8Content: testTechnologySource),
+                    TextFile(name: "Test.tutorial", utf8Content: testTutorialSource),
+                ])
             let tempFolderURL = try createTemporaryDirectory().appendingPathComponent("test.docc")
             try testBundle.write(to: tempFolderURL)
-            
+
             // Load the bundle
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
-            
-            let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)
-            let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
-            let articleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)
+
+            let symbolReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Minimal_docs/Test",
+                sourceLanguage: .swift)
+            let moduleReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
+            let articleReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift
+            )
 
             // Verify we resolve/not resolve non-symbols when calling directly context.resolve(...)
             // with an explicit preference.
-            let unresolvedSymbolRef1 = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "Test")!)
-            switch context.resolve(.unresolved(unresolvedSymbolRef1), in: moduleReference, fromSymbolLink: true) {
-                case .failure(_, let errorMessage): XCTFail("Did not resolve a symbol link to the symbol Test. Error: \(errorMessage)")
-                default: break
+            let unresolvedSymbolRef1 = UnresolvedTopicReference(
+                topicURL: ValidatedURL(parsingExact: "Test")!)
+            switch context.resolve(
+                .unresolved(unresolvedSymbolRef1), in: moduleReference, fromSymbolLink: true)
+            {
+            case .failure(_, let errorMessage):
+                XCTFail("Did not resolve a symbol link to the symbol Test. Error: \(errorMessage)")
+            default: break
             }
-            switch context.resolve(.unresolved(unresolvedSymbolRef1), in: moduleReference, fromSymbolLink: false) {
-                case .failure(_, let errorMessage): XCTFail("Did not resolve a topic link to the symbol Test. Error: \(errorMessage)")
-                default: break
+            switch context.resolve(
+                .unresolved(unresolvedSymbolRef1), in: moduleReference, fromSymbolLink: false)
+            {
+            case .failure(_, let errorMessage):
+                XCTFail("Did not resolve a topic link to the symbol Test. Error: \(errorMessage)")
+            default: break
             }
 
-            let articleRef1 = UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "Article")!)
-            switch context.resolve(.unresolved(articleRef1), in: moduleReference, fromSymbolLink: true) {
-                case .success: XCTFail("Did resolve a symbol link to an article")
-                default: break
+            let articleRef1 = UnresolvedTopicReference(
+                topicURL: ValidatedURL(parsingExact: "Article")!)
+            switch context.resolve(
+                .unresolved(articleRef1), in: moduleReference, fromSymbolLink: true)
+            {
+            case .success: XCTFail("Did resolve a symbol link to an article")
+            default: break
             }
-            switch context.resolve(.unresolved(articleRef1), in: moduleReference, fromSymbolLink: false) {
-                case .failure(_, let errorMessage): XCTFail("Did not resolve a topic link to an article. Error: \(errorMessage)")
-                default: break
+            switch context.resolve(
+                .unresolved(articleRef1), in: moduleReference, fromSymbolLink: false)
+            {
+            case .failure(_, let errorMessage):
+                XCTFail("Did not resolve a topic link to an article. Error: \(errorMessage)")
+            default: break
             }
 
             // Verify the context contains the conflicting topic names
             // Tutorial
-            XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test", sourceLanguage: .swift)])
+            XCTAssertNotNil(
+                context.documentationCache[
+                    ResolvedTopicReference(
+                        bundleID: bundle.id, path: "/tutorials/Test-Bundle/Test",
+                        sourceLanguage: .swift)])
             // Symbol
             XCTAssertNotNil(context.documentationCache[symbolReference])
-            
+
             // Verify the symbol link resolved correctly to the symbol
             let node = try context.entity(with: moduleReference)
             let symbol = try XCTUnwrap(node.semantic as? Symbol)
             let discussion = try XCTUnwrap(symbol.discussion)
-            
+
             let resolvedSymbolLink = try XCTUnwrap(discussion.content.first)
             // Verify the reference has been expanded to the absolute path to the symbol when resolved.
             XCTAssertEqual(resolvedSymbolLink.format(), "``\(symbolReference.absoluteString)``")
-            
+
             // Verify the symbol link will not resolve from elsewhere (i.e. if the relative link isn't resolvable in the parent symbol)
             let node1 = try context.entity(with: articleReference)
             let article = try XCTUnwrap(node1.semantic as? Article)
             let discussion1 = try XCTUnwrap(article.discussion)
-            
+
             let unresolvedSymbolLink = try XCTUnwrap(discussion1.content.first)
             XCTAssertEqual(unresolvedSymbolLink.format(), "``Test``")
         }
     }
-    
+
     func testSymbolMatchingModuleName() throws {
         // Verify as top-level symbol with name matching the module name
         // does not trip the context when building the topic graph
         do {
             // Rename a top-level symbol to match the framework name.
-            let symbolGraphFixture = testSymbolGraphSource
+            let symbolGraphFixture =
+                testSymbolGraphSource
                 .replacingOccurrences(of: #"Test"#, with: #"Minimal_docs"#)
-        
-            let infoPlistURL = try XCTUnwrap(Bundle.module.url(forResource: "Info+Availability", withExtension: "plist", subdirectory: "Test Resources"))
-            let testBundle = Folder(name: "test.docc", content: [
-                CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
-                TextFile(name: "TestFramework.symbols.json", utf8Content: symbolGraphFixture),
-            ])
+
+            let infoPlistURL = try XCTUnwrap(
+                Bundle.module.url(
+                    forResource: "Info+Availability", withExtension: "plist",
+                    subdirectory: "Test Resources"))
+            let testBundle = Folder(
+                name: "test.docc",
+                content: [
+                    CopyOfFile(original: infoPlistURL, newName: "Info.plist"),
+                    TextFile(name: "TestFramework.symbols.json", utf8Content: symbolGraphFixture),
+                ])
             let tempFolderURL = try createTemporaryDirectory().appendingPathComponent("test.docc")
             try testBundle.write(to: tempFolderURL)
-            
+
             // Load the bundle
             let (_, bundle, context) = try loadBundle(from: tempFolderURL)
-            
+
             // Verify the module and symbol node kinds.
-            let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Minimal_docs", sourceLanguage: .swift)
-            let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
+            let symbolReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Minimal_docs/Minimal_docs",
+                sourceLanguage: .swift)
+            let moduleReference = ResolvedTopicReference(
+                bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
 
             XCTAssertEqual(context.topicGraph.nodeWithReference(symbolReference)?.kind, .structure)
             XCTAssertEqual(context.topicGraph.nodeWithReference(moduleReference)?.kind, .module)
         }
     }
-    
+
     /// Verifies that we emit a warning about a link that resolves in its context
     /// but is then inherited and will not resolve in its inherited context.
     ///
@@ -4355,26 +5606,31 @@ let expected = """
         let tempURL = try createTemporaryDirectory()
 
         // Create test bundle
-        let bundleURL = try Folder(name: "InheritedDocs.docc", content: [
-            InfoPlist(displayName: "Inheritance", identifier: "com.test.inheritance"),
-            CopyOfFile(original: Bundle.module.url(
+        let bundleURL = try Folder(
+            name: "InheritedDocs.docc",
+            content: [
+                InfoPlist(displayName: "Inheritance", identifier: "com.test.inheritance"),
+                CopyOfFile(
+                    original: Bundle.module.url(
                         forResource: "InheritedDocs-RelativeLinks.symbols", withExtension: "json",
                         subdirectory: "Test Resources")!),
-        ]).write(inside: tempURL)
-        
+            ]
+        ).write(inside: tempURL)
+
         // Load the test bundle
         let (_, _, context) = try loadBundle(from: bundleURL)
-        
+
         // Get the emitted diagnostic and verify it contains a solution and replacement fix-it.
-        let problem = try XCTUnwrap(context.problems.first(where: { p in
-            return p.diagnostic.identifier == "org.swift.docc.UnresolvableLinkWhenInherited"
-                && !p.possibleSolutions.isEmpty
-                && !p.possibleSolutions[0].replacements.isEmpty
-        }))
-        
+        let problem = try XCTUnwrap(
+            context.problems.first(where: { p in
+                return p.diagnostic.identifier == "org.swift.docc.UnresolvableLinkWhenInherited"
+                    && !p.possibleSolutions.isEmpty
+                    && !p.possibleSolutions[0].replacements.isEmpty
+            }))
+
         // Verify the diagnostic is at the expected range.
         let range = try XCTUnwrap(problem.diagnostic.range)
-        
+
         XCTAssertEqual(range.lowerBound.line, 4)
         XCTAssertEqual(range.lowerBound.column, 29)
         XCTAssertEqual(range.upperBound.line, 4)
@@ -4382,90 +5638,111 @@ let expected = """
 
         // Verify the replacement range is at the expected location.
         let replacementRange = try XCTUnwrap(problem.possibleSolutions[0].replacements[0].range)
-        
+
         XCTAssertEqual(replacementRange.lowerBound.line, 4)
         XCTAssertEqual(replacementRange.lowerBound.column, 29)
         XCTAssertEqual(replacementRange.upperBound.line, 4)
         XCTAssertEqual(replacementRange.upperBound.column, 49)
 
         // Verify the solution proposes the expected absolute link replacement.
-        XCTAssertEqual(problem.possibleSolutions[0].replacements[0].replacement, "<doc:/documentation/Minimal_docs/A/method(_:)-7mctk>")
+        XCTAssertEqual(
+            problem.possibleSolutions[0].replacements[0].replacement,
+            "<doc:/documentation/Minimal_docs/A/method(_:)-7mctk>")
     }
-    
+
     func testCustomModuleKind() throws {
         let (bundle, context) = try testBundleAndContext(named: "BundleWithExecutableModuleKind")
         XCTAssertEqual(bundle.info.defaultModuleKind, "Executable")
-        
-        let moduleSymbol = try XCTUnwrap(context.documentationCache["ExampleDocumentedExecutable"]?.symbol)
+
+        let moduleSymbol = try XCTUnwrap(
+            context.documentationCache["ExampleDocumentedExecutable"]?.symbol)
         XCTAssertEqual(moduleSymbol.kind.identifier.identifier, "module")
         XCTAssertEqual(moduleSymbol.kind.displayName, "Executable")
     }
-    
+
     /// Verifies that the number of symbols registered in the documentation context is consistent with
     /// the number of symbols in the symbol graph files.
     func testSymbolsCountIsConsistentWithSymbolGraphData() throws {
-        let exampleDocumentation = Folder(name: "unit-test.docc", content: [
-            Folder(name: "Symbols", content: [
-                JSONFile(
-                    name: "module.symbols.json",
-                    content: SymbolGraph(
-                        metadata: .init(formatVersion: .init(string: "1.0.0")!, generator: "generator"),
-                        module: .init(name: "module", platform: .init(), version: nil, bystanders: nil),
-                        symbols: (1...1000).map { index in
-                            SymbolGraph.Symbol(
-                                identifier: .init(precise: UUID().uuidString, interfaceLanguage: "swift"),
-                                names: .init(
-                                    title: "Symbol \(index)",
-                                    navigator: nil,
-                                    subHeading: [],
-                                    prose: "Symbol \(index)"
+        let exampleDocumentation = Folder(
+            name: "unit-test.docc",
+            content: [
+                Folder(
+                    name: "Symbols",
+                    content: [
+                        JSONFile(
+                            name: "module.symbols.json",
+                            content: SymbolGraph(
+                                metadata: .init(
+                                    formatVersion: .init(string: "1.0.0")!, generator: "generator"),
+                                module: .init(
+                                    name: "module", platform: .init(), version: nil, bystanders: nil
                                 ),
-                                pathComponents: ["Module", "Symbol\(index)"],
-                                docComment: nil,
-                                accessLevel: .init(rawValue: "public"),
-                                kind: .init(parsedIdentifier: .struct, displayName: "Struct"),
-                                mixins: [:]
+                                symbols: (1...1000).map { index in
+                                    SymbolGraph.Symbol(
+                                        identifier: .init(
+                                            precise: UUID().uuidString, interfaceLanguage: "swift"),
+                                        names: .init(
+                                            title: "Symbol \(index)",
+                                            navigator: nil,
+                                            subHeading: [],
+                                            prose: "Symbol \(index)"
+                                        ),
+                                        pathComponents: ["Module", "Symbol\(index)"],
+                                        docComment: nil,
+                                        accessLevel: .init(rawValue: "public"),
+                                        kind: .init(
+                                            parsedIdentifier: .struct, displayName: "Struct"),
+                                        mixins: [:]
+                                    )
+                                },
+                                relationships: []
                             )
-                        },
-                        relationships: []
-                    )
-                )
-            ]),
-            InfoPlist(displayName: "TestBundle", identifier: "com.test.example")
-        ])
-        
+                        )
+                    ]),
+                InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
+            ])
+
         let (_, context) = try loadBundle(catalog: exampleDocumentation)
-        
+
         XCTAssertEqual(
             context.documentationCache.count,
             1001,
             "Expected 1000 nodes for each symbol of the symbol graph + 1 for the module."
         )
     }
-    
+
     func testDocumentationExtensionURLForReferenceReturnsURLForSymbolReference() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
-                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
-            ])),
-            
-            TextFile(name: "Extension.md", utf8Content: """
-            # ``SomeClass``
-            """),
-        ])
-        
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "SomeModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
+                        ])),
+
+                TextFile(
+                    name: "Extension.md",
+                    utf8Content: """
+                        # ``SomeClass``
+                        """),
+            ])
+
         let (bundle, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
-        
+
         XCTAssertEqual(
             context.documentationExtensionURL(for: moduleReference.appendingPath("SomeClass")),
             bundle.markupURLs.first
         )
     }
-    
+
     func testDocumentationExtensionURLForReferenceReturnsNilForTutorialReference() throws {
         let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
-        
+
         XCTAssertNil(
             context.documentationExtensionURL(
                 for: ResolvedTopicReference(
@@ -4538,7 +5815,10 @@ let expected = """
         } else {
             XCTAssertEqual(1, problems.count)
         }
-        let problem = try XCTUnwrap(problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
+        let problem = try XCTUnwrap(
+            problems.first(where: {
+                $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference"
+            }))
         let basename = try XCTUnwrap(problem.diagnostic.source?.lastPathComponent)
         XCTAssertEqual("HelloWorldFramework.h", basename)
         let start = Markdown.SourceLocation(line: 24, column: 56, source: nil)
@@ -4546,241 +5826,305 @@ let expected = """
         let range = try XCTUnwrap(problem.diagnostic.range)
         XCTAssertEqual(start..<end, range)
     }
-    
+
     func testPathsToHandlesCyclicCuration() throws {
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                Folder(name: "clang", content: [
-                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                        moduleName: "ModuleName",
-                        symbols: [
-                            // Any class declaration.
-                            makeSymbol(
-                                id: "some-class-id",
-                                language: .objectiveC,
-                                kind: .class,
-                                pathComponents: ["SomeClass"]
-                            ),
-                            
-                            // extern NSErrorDomain const SomeErrorDomain;
-                            makeSymbol(
-                                id: "some-error-domain-id",
-                                language: .objectiveC,
-                                kind: .var,
-                                pathComponents: ["SomeErrorDomain"]
-                            ),
-                            
-                            // typedef NS_ERROR_ENUM(SomeErrorDomain, SomeErrorCode) {
-                            //     SomeErrorCodeSomeCase = 1
-                            // };
-                            makeSymbol(
-                                id: "some-error-code-id",
-                                language: .objectiveC,
-                                kind: .enum,
-                                pathComponents: ["SomeErrorCode"]
-                            ),
-                            makeSymbol(
-                                id: "some-error-code-case-id",
-                                language: .objectiveC,
-                                kind: .case,
-                                pathComponents: ["SomeErrorCode", "SomeErrorCodeSomeCase"]
-                            ),
-                        ],
-                        relationships: [
-                            .init(source: "some-error-code-case-id", target: "some-error-code-id", kind: .memberOf, targetFallback: nil),
-                        ]
-                    ))
-                ]),
-                
-                Folder(name: "swift", content: [
-                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                        moduleName: "ModuleName",
-                        symbols: [
-                            // The Swift representation of the Objective-C class above.
-                            makeSymbol(
-                                id: "some-class-id",
-                                kind: .class,
-                                pathComponents: ["SomeClass"]
-                            ),
-                            
-                            // The domain defined using NS_ERROR_ENUM translates to a struct with an 'errorDomain' and 'code'. Something like:
-                            //
-                            // let SomeErrorDomain: String
-                            // struct SomeError: CustomNSError, Error {
-                            //     static var errorDomain: String
-                            //     static var code: Code
-                            //     enum Code {
-                            //         someCase = 1
-                            //     }
-                            // }
-                            makeSymbol(
-                                id: "some-error-domain-id",
-                                kind: .var,
-                                pathComponents: ["SomeErrorDomain"]
-                            ),
-                            
-                            makeSymbol(
-                                id: "some-error-id",
-                                kind: .struct,
-                                pathComponents: ["SomeError"]
-                            ),
-                            makeSymbol(
-                                id: "some-error-domain-property-id",
-                                kind: .typeProperty,
-                                pathComponents: ["SomeError", "errorDomain"]
-                            ),
-                            makeSymbol(
-                                id: "some-error-code-property-id",
-                                kind: .typeProperty,
-                                pathComponents: ["SomeError", "code"]
-                            ),
-                            makeSymbol(
-                                id: "some-error-code-id",
-                                kind: .enum,
-                                pathComponents: ["SomeError", "Code"]
-                            ),
-                            makeSymbol(
-                                id: "some-error-code-case-id",
-                                kind: .case,
-                                pathComponents: ["SomeError", "Code", "someCase"]
-                            ),
-                        ],
-                        relationships: [
-                            // static properties are members of struct
-                            .init(source: "some-error-domain-property-id", target: "some-error-id", kind: .memberOf, targetFallback: nil),
-                            .init(source: "some-error-code-property-id", target: "some-error-id", kind: .memberOf, targetFallback: nil),
-                            // enum is member of struct
-                            .init(source: "some-error-code-id", target: "some-error-id", kind: .memberOf, targetFallback: nil),
-                            // case is member of enum
-                            .init(source: "some-error-code-case-id", target: "some-error-code-id", kind: .memberOf, targetFallback: nil),
-                        ]
-                    ))
-                ]),
-                
-                // In addition to the automatic curation (thin lines) where all symbols are members of the module (SomeErrorCode is a top-level enum in Objective-C),
-                // Add manual curation (thick lines) from `SomeClass` to `SomeError` and from `SomeError/Code` to `SomeClass`, creating a cycle in the total curation.
-                //
-                //            ModuleName
-                //                 │
-                //     ┌───────┬───┴───┬─────────────┐
-                //     ▼       │       ▼             ▼
-                // SomeClass━━━━━━▶SomeError  SomeErrorDomain
-                //     ▲       │       │
-                //     ┃       ▼       │
-                //     ┗━━━━━Code◀─────┘
-                //             │
-                //             ▼
-                //          someCase
-                
-                TextFile(name: "SomeClass.md", utf8Content: """
-                # ``SomeClass``
-                
-                Curate the error
-                
-                ## Topics
-                
-                - ``SomeError``
-                """),
-                
-                TextFile(name: "SomeErrorCode.md", utf8Content: """
-                # ``SomeError/Code``
-                
-                Curate the class
-                
-                ## Topics
-                
-                - ``SomeClass``
-                """),
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    Folder(
+                        name: "clang",
+                        content: [
+                            JSONFile(
+                                name: "ModuleName.symbols.json",
+                                content: makeSymbolGraph(
+                                    moduleName: "ModuleName",
+                                    symbols: [
+                                        // Any class declaration.
+                                        makeSymbol(
+                                            id: "some-class-id",
+                                            language: .objectiveC,
+                                            kind: .class,
+                                            pathComponents: ["SomeClass"]
+                                        ),
+
+                                        // extern NSErrorDomain const SomeErrorDomain;
+                                        makeSymbol(
+                                            id: "some-error-domain-id",
+                                            language: .objectiveC,
+                                            kind: .var,
+                                            pathComponents: ["SomeErrorDomain"]
+                                        ),
+
+                                        // typedef NS_ERROR_ENUM(SomeErrorDomain, SomeErrorCode) {
+                                        //     SomeErrorCodeSomeCase = 1
+                                        // };
+                                        makeSymbol(
+                                            id: "some-error-code-id",
+                                            language: .objectiveC,
+                                            kind: .enum,
+                                            pathComponents: ["SomeErrorCode"]
+                                        ),
+                                        makeSymbol(
+                                            id: "some-error-code-case-id",
+                                            language: .objectiveC,
+                                            kind: .case,
+                                            pathComponents: [
+                                                "SomeErrorCode", "SomeErrorCodeSomeCase",
+                                            ]
+                                        ),
+                                    ],
+                                    relationships: [
+                                        .init(
+                                            source: "some-error-code-case-id",
+                                            target: "some-error-code-id", kind: .memberOf,
+                                            targetFallback: nil)
+                                    ]
+                                ))
+                        ]),
+
+                    Folder(
+                        name: "swift",
+                        content: [
+                            JSONFile(
+                                name: "ModuleName.symbols.json",
+                                content: makeSymbolGraph(
+                                    moduleName: "ModuleName",
+                                    symbols: [
+                                        // The Swift representation of the Objective-C class above.
+                                        makeSymbol(
+                                            id: "some-class-id",
+                                            kind: .class,
+                                            pathComponents: ["SomeClass"]
+                                        ),
+
+                                        // The domain defined using NS_ERROR_ENUM translates to a struct with an 'errorDomain' and 'code'. Something like:
+                                        //
+                                        // let SomeErrorDomain: String
+                                        // struct SomeError: CustomNSError, Error {
+                                        //     static var errorDomain: String
+                                        //     static var code: Code
+                                        //     enum Code {
+                                        //         someCase = 1
+                                        //     }
+                                        // }
+                                        makeSymbol(
+                                            id: "some-error-domain-id",
+                                            kind: .var,
+                                            pathComponents: ["SomeErrorDomain"]
+                                        ),
+
+                                        makeSymbol(
+                                            id: "some-error-id",
+                                            kind: .struct,
+                                            pathComponents: ["SomeError"]
+                                        ),
+                                        makeSymbol(
+                                            id: "some-error-domain-property-id",
+                                            kind: .typeProperty,
+                                            pathComponents: ["SomeError", "errorDomain"]
+                                        ),
+                                        makeSymbol(
+                                            id: "some-error-code-property-id",
+                                            kind: .typeProperty,
+                                            pathComponents: ["SomeError", "code"]
+                                        ),
+                                        makeSymbol(
+                                            id: "some-error-code-id",
+                                            kind: .enum,
+                                            pathComponents: ["SomeError", "Code"]
+                                        ),
+                                        makeSymbol(
+                                            id: "some-error-code-case-id",
+                                            kind: .case,
+                                            pathComponents: ["SomeError", "Code", "someCase"]
+                                        ),
+                                    ],
+                                    relationships: [
+                                        // static properties are members of struct
+                                        .init(
+                                            source: "some-error-domain-property-id",
+                                            target: "some-error-id", kind: .memberOf,
+                                            targetFallback: nil),
+                                        .init(
+                                            source: "some-error-code-property-id",
+                                            target: "some-error-id", kind: .memberOf,
+                                            targetFallback: nil),
+                                        // enum is member of struct
+                                        .init(
+                                            source: "some-error-code-id", target: "some-error-id",
+                                            kind: .memberOf, targetFallback: nil),
+                                        // case is member of enum
+                                        .init(
+                                            source: "some-error-code-case-id",
+                                            target: "some-error-code-id", kind: .memberOf,
+                                            targetFallback: nil),
+                                    ]
+                                ))
+                        ]),
+
+                    // In addition to the automatic curation (thin lines) where all symbols are members of the module (SomeErrorCode is a top-level enum in Objective-C),
+                    // Add manual curation (thick lines) from `SomeClass` to `SomeError` and from `SomeError/Code` to `SomeClass`, creating a cycle in the total curation.
+                    //
+                    //            ModuleName
+                    //                 │
+                    //     ┌───────┬───┴───┬─────────────┐
+                    //     ▼       │       ▼             ▼
+                    // SomeClass━━━━━━▶SomeError  SomeErrorDomain
+                    //     ▲       │       │
+                    //     ┃       ▼       │
+                    //     ┗━━━━━Code◀─────┘
+                    //             │
+                    //             ▼
+                    //          someCase
+
+                    TextFile(
+                        name: "SomeClass.md",
+                        utf8Content: """
+                            # ``SomeClass``
+
+                            Curate the error
+
+                            ## Topics
+
+                            - ``SomeError``
+                            """),
+
+                    TextFile(
+                        name: "SomeErrorCode.md",
+                        utf8Content: """
+                            # ``SomeError/Code``
+
+                            Curate the class
+
+                            ## Topics
+
+                            - ``SomeClass``
+                            """),
+                ])
+
         let (bundle, context) = try loadBundle(catalog: catalog)
-        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase", sourceLanguage: .swift)
-        
+        let reference = ResolvedTopicReference(
+            bundleID: bundle.id,
+            path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase",
+            sourceLanguage: .swift)
+
         XCTAssertEqual(
-            context.topicGraph.reverseEdgesGraph.cycles(from: reference).map { $0.map(\.lastPathComponent) },
-            [ ["Code-swift.enum", "SomeError", "SomeClass"] ],
+            context.topicGraph.reverseEdgesGraph.cycles(from: reference).map {
+                $0.map(\.lastPathComponent)
+            },
+            [["Code-swift.enum", "SomeError", "SomeClass"]],
             "There is one cyclic path encountered while traversing the reverse edges from the 'someCase' enum case."
         )
-        
+
         XCTAssertEqual(
             context.finitePaths(to: reference).map { $0.map(\.lastPathComponent) },
-            [ ["ModuleName", "Code-swift.enum"] ],
+            [["ModuleName", "Code-swift.enum"]],
             "There is only one _finite_ path from the 'someCase' enum case, through the reverse edges in the topic graph."
         )
     }
-    
+
     func testUnresolvedLinkWarnings() throws {
-        let catalog = Folder(name: "unit-test.docc", content: [
-            JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
-                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
-            ])),
-            
-            TextFile(name: "Extension.md", utf8Content: """
-            # ``SomeClass``
-            
-            Some class abstract
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                JSONFile(
+                    name: "SomeModuleName.symbols.json",
+                    content: makeSymbolGraph(
+                        moduleName: "SomeModuleName",
+                        symbols: [
+                            makeSymbol(
+                                id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
+                        ])),
 
-            ## Overview
+                TextFile(
+                    name: "Extension.md",
+                    utf8Content: """
+                        # ``SomeClass``
 
-            This is unresolvable: <doc:Does-Not-Exist>.
-            
-            ## Topics
-            
-            - <doc:NonExistingDoc>
+                        Some class abstract
 
-            """),
-        ])
-        
+                        ## Overview
+
+                        This is unresolvable: <doc:Does-Not-Exist>.
+
+                        ## Topics
+
+                        - <doc:NonExistingDoc>
+
+                        """),
+            ])
+
         var (_, context) = try loadBundle(catalog: catalog)
         var problems = context.diagnosticEngine.problems
-        var linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("Extension.md") == true }
+        var linkResolutionProblems = problems.filter {
+            $0.diagnostic.source?.relativePath.hasSuffix("Extension.md") == true
+        }
         XCTAssertEqual(linkResolutionProblems.count, 2)
         var problem = try XCTUnwrap(linkResolutionProblems.last)
-        XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/SomeModuleName/SomeClass\'")
+        XCTAssertEqual(
+            problem.diagnostic.summary,
+            "\'NonExistingDoc\' doesn\'t exist at \'/SomeModuleName/SomeClass\'")
         (_, _, context) = try testBundleAndContext(copying: "BookLikeContent") { url in
             let extensionFile = """
-            # My Article
+                # My Article
 
-            Abstract
+                Abstract
 
-            ## Overview
+                ## Overview
 
-            Overview
-            
-            ## Topics
-            
-            - <doc:NonExistingDoc>
+                Overview
 
-            """
+                ## Topics
+
+                - <doc:NonExistingDoc>
+
+                """
             let fileURL = url.appendingPathComponent("MyArticle.md")
             try extensionFile.write(to: fileURL, atomically: true, encoding: .utf8)
         }
         problems = context.diagnosticEngine.problems
-        linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("MyArticle.md") == true }
+        linkResolutionProblems = problems.filter {
+            $0.diagnostic.source?.relativePath.hasSuffix("MyArticle.md") == true
+        }
         XCTAssertEqual(linkResolutionProblems.count, 1)
         problem = try XCTUnwrap(linkResolutionProblems.last)
-        XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/BestBook/MyArticle\'")
+        XCTAssertEqual(
+            problem.diagnostic.summary,
+            "\'NonExistingDoc\' doesn\'t exist at \'/BestBook/MyArticle\'")
     }
-    
+
     func testContextRecognizesOverloads() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
-        
-        let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { $0.isOverloadableKind }
+
+        let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter {
+            $0.isOverloadableKind
+        }
         // Generate a 4 symbols with the same name for every overloadable symbol kind
-        let symbols: [SymbolGraph.Symbol] = overloadableKindIDs.flatMap { [
-            makeSymbol(id: "first-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "second-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "third-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "fourth-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
-        ] }
-        
+        let symbols: [SymbolGraph.Symbol] = overloadableKindIDs.flatMap {
+            [
+                makeSymbol(
+                    id: "first-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "second-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "third-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "fourth-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+            ]
+        }
+
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    symbols: symbols
-                ))
-            ])
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            symbols: symbols
+                        ))
+                ])
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
@@ -4788,37 +6132,50 @@ let expected = """
             var seenIndices = Set<Int>()
             // Find the 4 symbols of this specific kind. SymbolKit will have assigned a display
             // index based on their sorted USRs, so sort them ahead of time based on that
-            let overloadedReferences = try symbols.filter { $0.kind.identifier == kindID }.sorted(by: \.identifier.precise)
-                .map { try XCTUnwrap(context.documentationCache.reference(symbolID: $0.identifier.precise)) }
+            let overloadedReferences = try symbols.filter { $0.kind.identifier == kindID }.sorted(
+                by: \.identifier.precise
+            )
+            .map {
+                try XCTUnwrap(context.documentationCache.reference(symbolID: $0.identifier.precise))
+            }
 
             let overloadGroupNode: DocumentationNode
             let overloadGroupSymbol: Symbol
             let overloadGroupReferences: Symbol.Overloads
-            switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName-\(kindID.identifier)"))), in: moduleReference, fromSymbolLink: true) {
+            switch context.resolve(
+                .unresolved(.init(topicURL: .init(symbolPath: "SymbolName-\(kindID.identifier)"))),
+                in: moduleReference, fromSymbolLink: true)
+            {
             case let .failure(_, errorMessage):
-                XCTFail("Could not resolve overload group page for \(kindID.identifier). Error message: \(errorMessage)")
+                XCTFail(
+                    "Could not resolve overload group page for \(kindID.identifier). Error message: \(errorMessage)"
+                )
                 continue
             case let .success(overloadGroupReference):
                 overloadGroupNode = try context.entity(with: overloadGroupReference)
                 overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
-                overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+                overloadGroupReferences = try XCTUnwrap(
+                    overloadGroupSymbol.overloadsVariants.firstValue)
 
                 XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
             }
 
             // Check that each symbol lists the other 3 overloads
             for (index, reference) in overloadedReferences.indexed() {
-                let overloadedDocumentationNode = try XCTUnwrap(context.documentationCache[reference])
-                let overloadedSymbol = try XCTUnwrap(overloadedDocumentationNode.semantic as? Symbol)
-                
+                let overloadedDocumentationNode = try XCTUnwrap(
+                    context.documentationCache[reference])
+                let overloadedSymbol = try XCTUnwrap(
+                    overloadedDocumentationNode.semantic as? Symbol)
+
                 let overloads = try XCTUnwrap(overloadedSymbol.overloadsVariants.firstValue)
-                
+
                 // Make sure that each symbol contains all of its sibling overloads.
                 XCTAssertEqual(overloads.references.count, overloadedReferences.count - 1)
-                for (otherIndex, otherReference) in overloadedReferences.indexed() where otherIndex != index {
+                for (otherIndex, otherReference) in overloadedReferences.indexed()
+                where otherIndex != index {
                     XCTAssert(overloads.references.contains(otherReference))
                 }
-                
+
                 // Each symbol needs to tell the renderer where it belongs in the array of overloaded declarations.
                 XCTAssertFalse(seenIndices.contains(overloads.displayIndex))
                 XCTAssertEqual(overloads.displayIndex, index)
@@ -4827,7 +6184,9 @@ let expected = """
                 if overloads.displayIndex == 0 {
                     // The first declaration in the display list should be the same declaration as
                     // the overload group page
-                    XCTAssertEqual(overloadedSymbol.declaration.first?.value.declarationFragments, overloadGroupSymbol.declaration.first?.value.declarationFragments)
+                    XCTAssertEqual(
+                        overloadedSymbol.declaration.first?.value.declarationFragments,
+                        overloadGroupSymbol.declaration.first?.value.declarationFragments)
                 } else {
                     // Otherwise, this reference should also be referenced by the overload group
                     XCTAssert(overloadGroupReferences.references.contains(reference))
@@ -4841,45 +6200,66 @@ let expected = """
     }
 
     func testContextRecognizesOverloadsFromPlistFlag() throws {
-        let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { $0.isOverloadableKind }
+        let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter {
+            $0.isOverloadableKind
+        }
         // Generate a 4 symbols with the same name for every overloadable symbol kind
-        let symbols: [SymbolGraph.Symbol] = overloadableKindIDs.flatMap { [
-            makeSymbol(id: "first-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "second-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "third-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "fourth-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
-        ] }
+        let symbols: [SymbolGraph.Symbol] = overloadableKindIDs.flatMap {
+            [
+                makeSymbol(
+                    id: "first-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "second-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "third-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "fourth-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+            ]
+        }
 
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    symbols: symbols
-                )),
-                DataFile(name: "Info.plist", data: Data("""
-                <plist version="1.0">
-                <dict>
-                    <key>CDExperimentalFeatureFlags</key>
-                    <dict>
-                        <key>ExperimentalOverloadedSymbolPresentation</key>
-                        <true/>
-                    </dict>
-                </dict>
-                </plist>
-                """.utf8))
-            ])
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            symbols: symbols
+                        )),
+                    DataFile(
+                        name: "Info.plist",
+                        data: Data(
+                            """
+                            <plist version="1.0">
+                            <dict>
+                                <key>CDExperimentalFeatureFlags</key>
+                                <dict>
+                                    <key>ExperimentalOverloadedSymbolPresentation</key>
+                                    <true/>
+                                </dict>
+                            </dict>
+                            </plist>
+                            """.utf8)),
+                ])
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         for kindID in overloadableKindIDs {
-            switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName-\(kindID.identifier)"))), in: moduleReference, fromSymbolLink: true) {
+            switch context.resolve(
+                .unresolved(.init(topicURL: .init(symbolPath: "SymbolName-\(kindID.identifier)"))),
+                in: moduleReference, fromSymbolLink: true)
+            {
             case let .failure(_, errorMessage):
-                XCTFail("Could not resolve overload group page for \(kindID.identifier). Error message: \(errorMessage)")
+                XCTFail(
+                    "Could not resolve overload group page for \(kindID.identifier). Error message: \(errorMessage)"
+                )
                 continue
             case let .success(overloadGroupReference):
                 let overloadGroupNode = try context.entity(with: overloadGroupReference)
                 let overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
-                let overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+                let overloadGroupReferences = try XCTUnwrap(
+                    overloadGroupSymbol.overloadsVariants.firstValue)
 
                 XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
             }
@@ -4889,31 +6269,46 @@ let expected = """
     // The overload behavior doesn't apply to symbol kinds that don't support overloading
     func testContextDoesNotRecognizeNonOverloadableSymbolKinds() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
-        
-        let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { !$0.isOverloadableKind }
+
+        let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter {
+            !$0.isOverloadableKind
+        }
         // Generate a 4 symbols with the same name for every non overloadable symbol kind
-        let symbols: [SymbolGraph.Symbol] = nonOverloadableKindIDs.flatMap { [
-            makeSymbol(id: "first-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "second-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "third-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "fourth-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
-        ] }
-        
+        let symbols: [SymbolGraph.Symbol] = nonOverloadableKindIDs.flatMap {
+            [
+                makeSymbol(
+                    id: "first-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "second-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "third-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+                makeSymbol(
+                    id: "fourth-\($0.identifier)-id", kind: $0, pathComponents: ["SymbolName"]),
+            ]
+        }
+
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    symbols: symbols
-                ))
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            symbols: symbols
+                        ))
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
-        
+
         for kindID in nonOverloadableKindIDs {
             // Find the 4 symbols of this specific kind
             let overloadedReferences = try symbols.filter { $0.kind.identifier == kindID }
-                .map { try XCTUnwrap(context.documentationCache.reference(symbolID: $0.identifier.precise)) }
-            
+                .map {
+                    try XCTUnwrap(
+                        context.documentationCache.reference(symbolID: $0.identifier.precise))
+                }
+
             // Check that none of the symbols lists any overloads
             for reference in overloadedReferences {
                 let documentationNode = try XCTUnwrap(context.documentationCache[reference])
@@ -4925,79 +6320,110 @@ let expected = """
 
     func testWarnsOnUnknownPlistFeatureFlag() throws {
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                DataFile(name: "Info.plist", data: Data("""
-                <plist version="1.0">
-                <dict>
-                    <key>CDExperimentalFeatureFlags</key>
-                    <dict>
-                        <key>NonExistentFeature</key>
-                        <true/>
-                    </dict>
-                </dict>
-                </plist>
-                """.utf8))
-            ])
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    DataFile(
+                        name: "Info.plist",
+                        data: Data(
+                            """
+                            <plist version="1.0">
+                            <dict>
+                                <key>CDExperimentalFeatureFlags</key>
+                                <dict>
+                                    <key>NonExistentFeature</key>
+                                    <true/>
+                                </dict>
+                            </dict>
+                            </plist>
+                            """.utf8))
+                ])
         let (_, context) = try loadBundle(catalog: catalog)
 
-        let unknownFeatureFlagProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.UnknownBundleFeatureFlag" })
+        let unknownFeatureFlagProblems = context.problems.filter({
+            $0.diagnostic.identifier == "org.swift.docc.UnknownBundleFeatureFlag"
+        })
         XCTAssertEqual(unknownFeatureFlagProblems.count, 1)
         let problem = try XCTUnwrap(unknownFeatureFlagProblems.first)
 
         XCTAssertEqual(problem.diagnostic.severity, .warning)
-        XCTAssertEqual(problem.diagnostic.summary, "Unknown feature flag in Info.plist: 'NonExistentFeature'")
+        XCTAssertEqual(
+            problem.diagnostic.summary, "Unknown feature flag in Info.plist: 'NonExistentFeature'")
     }
 
     func testUnknownFeatureFlagSuggestsOtherFlags() throws {
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                DataFile(name: "Info.plist", data: Data("""
-                <plist version="1.0">
-                <dict>
-                    <key>CDExperimentalFeatureFlags</key>
-                    <dict>
-                        <key>ExperimenalOverloadedSymbolPresentation</key>
-                        <true/>
-                    </dict>
-                </dict>
-                </plist>
-                """.utf8))
-            ])
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    DataFile(
+                        name: "Info.plist",
+                        data: Data(
+                            """
+                            <plist version="1.0">
+                            <dict>
+                                <key>CDExperimentalFeatureFlags</key>
+                                <dict>
+                                    <key>ExperimenalOverloadedSymbolPresentation</key>
+                                    <true/>
+                                </dict>
+                            </dict>
+                            </plist>
+                            """.utf8))
+                ])
         let (_, context) = try loadBundle(catalog: catalog)
 
-        let unknownFeatureFlagProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.UnknownBundleFeatureFlag" })
+        let unknownFeatureFlagProblems = context.problems.filter({
+            $0.diagnostic.identifier == "org.swift.docc.UnknownBundleFeatureFlag"
+        })
         XCTAssertEqual(unknownFeatureFlagProblems.count, 1)
         let problem = try XCTUnwrap(unknownFeatureFlagProblems.first)
 
         XCTAssertEqual(problem.diagnostic.severity, .warning)
         XCTAssertEqual(
             problem.diagnostic.summary,
-            "Unknown feature flag in Info.plist: 'ExperimenalOverloadedSymbolPresentation'. Possible suggestions: 'ExperimentalOverloadedSymbolPresentation'")
+            "Unknown feature flag in Info.plist: 'ExperimenalOverloadedSymbolPresentation'. Possible suggestions: 'ExperimentalOverloadedSymbolPresentation'"
+        )
     }
 
     func testContextGeneratesUnifiedOverloadGroupsAcrossPlatforms() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
+        let symbolKind = try XCTUnwrap(
+            SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
 
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName-macos.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "macosx")),
-                    symbols: [
-                        makeSymbol(id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]),
-                        makeSymbol(id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-                JSONFile(name: "ModuleName-ios.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "ios")),
-                    symbols: [
-                        makeSymbol(id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]),
-                        makeSymbol(id: "symbol-3", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName-macos.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "macosx")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                                makeSymbol(
+                                    id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                            ])),
+                    JSONFile(
+                        name: "ModuleName-ios.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "ios")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                                makeSymbol(
+                                    id: "symbol-3", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                            ])),
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
@@ -5007,19 +6433,25 @@ let expected = """
 
         // There should only be one overload group for `SymbolName` - the one from the iOS symbol
         // graph should have been removed during graph collection.
-        switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference, fromSymbolLink: true) {
+        switch context.resolve(
+            .unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference,
+            fromSymbolLink: true)
+        {
         case let .failure(_, errorMessage):
             XCTFail("Could not resolve overload group page. Error message: \(errorMessage)")
             return
         case let .success(overloadGroupReference):
             overloadGroupNode = try context.entity(with: overloadGroupReference)
             overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
-            overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+            overloadGroupReferences = try XCTUnwrap(
+                overloadGroupSymbol.overloadsVariants.firstValue)
 
             XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
 
             let unifiedSymbol = try XCTUnwrap(overloadGroupNode.unifiedSymbol)
-            XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
+            XCTAssertEqual(
+                unifiedSymbol.uniqueIdentifier,
+                "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
         }
 
         let overloadedReferences = try ["symbol-1", "symbol-2", "symbol-3"]
@@ -5033,14 +6465,17 @@ let expected = """
 
             // Make sure that each symbol contains all of its sibling overloads.
             XCTAssertEqual(overloads.references.count, overloadedReferences.count - 1)
-            for (otherIndex, otherReference) in overloadedReferences.indexed() where otherIndex != index {
+            for (otherIndex, otherReference) in overloadedReferences.indexed()
+            where otherIndex != index {
                 XCTAssert(overloads.references.contains(otherReference))
             }
 
             if overloads.displayIndex == 0 {
                 // The first declaration in the display list should be the same declaration as
                 // the overload group page
-                XCTAssertEqual(overloadedSymbol.declaration.first?.value.declarationFragments, overloadGroupSymbol.declaration.first?.value.declarationFragments)
+                XCTAssertEqual(
+                    overloadedSymbol.declaration.first?.value.declarationFragments,
+                    overloadGroupSymbol.declaration.first?.value.declarationFragments)
             } else {
                 // Otherwise, this reference should also be referenced by the overload group
                 XCTAssert(overloadGroupReferences.references.contains(reference))
@@ -5051,7 +6486,8 @@ let expected = """
     func testContextGeneratesOverloadGroupsWhenOnePlatformHasNoOverloads() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
+        let symbolKind = try XCTUnwrap(
+            SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
 
         // This situation used to crash. The macOS symbol graph only has one symbol in the overload
         // group, whereas the iOS graph has two. Due to the way that Symbol loaded the overload
@@ -5059,22 +6495,34 @@ let expected = """
         // DocumentationContext. We need to ensure that an overload group is properly created, and
         // that both symbols are correctly grouped underneath it.
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName-macos.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "macosx")),
-                    symbols: [
-                        makeSymbol(id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-                JSONFile(name: "ModuleName-ios.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "ios")),
-                    symbols: [
-                        makeSymbol(id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]),
-                        makeSymbol(id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName-macos.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "macosx")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]
+                                )
+                            ])),
+                    JSONFile(
+                        name: "ModuleName-ios.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "ios")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                                makeSymbol(
+                                    id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                            ])),
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
@@ -5085,19 +6533,25 @@ let expected = """
         // Even though the macOS symbol graph doesn't contain an overload group, one should still
         // have been created from the iOS symbol graph, and that overload group should reference
         // both symbols.
-        switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference, fromSymbolLink: true) {
+        switch context.resolve(
+            .unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference,
+            fromSymbolLink: true)
+        {
         case let .failure(_, errorMessage):
             XCTFail("Could not resolve overload group page. Error message: \(errorMessage)")
             return
         case let .success(overloadGroupReference):
             overloadGroupNode = try context.entity(with: overloadGroupReference)
             overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
-            overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+            overloadGroupReferences = try XCTUnwrap(
+                overloadGroupSymbol.overloadsVariants.firstValue)
 
             XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
 
             let unifiedSymbol = try XCTUnwrap(overloadGroupNode.unifiedSymbol)
-            XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
+            XCTAssertEqual(
+                unifiedSymbol.uniqueIdentifier,
+                "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
         }
 
         let overloadedReferences = try ["symbol-1", "symbol-2"]
@@ -5111,14 +6565,17 @@ let expected = """
 
             // Make sure that each symbol contains all of its sibling overloads.
             XCTAssertEqual(overloads.references.count, overloadedReferences.count - 1)
-            for (otherIndex, otherReference) in overloadedReferences.indexed() where otherIndex != index {
+            for (otherIndex, otherReference) in overloadedReferences.indexed()
+            where otherIndex != index {
                 XCTAssert(overloads.references.contains(otherReference))
             }
 
             if overloads.displayIndex == 0 {
                 // The first declaration in the display list should be the same declaration as
                 // the overload group page
-                XCTAssertEqual(overloadedSymbol.declaration.first?.value.declarationFragments, overloadGroupSymbol.declaration.first?.value.declarationFragments)
+                XCTAssertEqual(
+                    overloadedSymbol.declaration.first?.value.declarationFragments,
+                    overloadGroupSymbol.declaration.first?.value.declarationFragments)
             } else {
                 // Otherwise, this reference should also be referenced by the overload group
                 XCTAssert(overloadGroupReferences.references.contains(reference))
@@ -5131,25 +6588,38 @@ let expected = """
     func testContextGeneratesOverloadGroupsForExtensionGraphOverloads() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
+        let symbolKind = try XCTUnwrap(
+            SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
 
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "macosx")),
-                    symbols: [
-                        makeSymbol(id: "RegularSymbol", kind: .class, pathComponents: ["RegularSymbol"]),
-                    ])),
-                JSONFile(name: "OtherModule@ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "OtherModule",
-                    platform: .init(operatingSystem: .init(name: "macosx")),
-                    symbols: [
-                        makeSymbol(id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]),
-                        makeSymbol(id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-            ])
-        
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "macosx")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "RegularSymbol", kind: .class,
+                                    pathComponents: ["RegularSymbol"])
+                            ])),
+                    JSONFile(
+                        name: "OtherModule@ModuleName.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "OtherModule",
+                            platform: .init(operatingSystem: .init(name: "macosx")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                                makeSymbol(
+                                    id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                            ])),
+                ])
+
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
@@ -5157,19 +6627,25 @@ let expected = """
         let overloadGroupSymbol: Symbol
         let overloadGroupReferences: Symbol.Overloads
 
-        switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference, fromSymbolLink: true) {
+        switch context.resolve(
+            .unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference,
+            fromSymbolLink: true)
+        {
         case let .failure(_, errorMessage):
             XCTFail("Could not resolve overload group page. Error message: \(errorMessage)")
             return
         case let .success(overloadGroupReference):
             overloadGroupNode = try context.entity(with: overloadGroupReference)
             overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
-            overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+            overloadGroupReferences = try XCTUnwrap(
+                overloadGroupSymbol.overloadsVariants.firstValue)
 
             XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
 
             let unifiedSymbol = try XCTUnwrap(overloadGroupNode.unifiedSymbol)
-            XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
+            XCTAssertEqual(
+                unifiedSymbol.uniqueIdentifier,
+                "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
         }
 
         let overloadedReferences = try ["symbol-1", "symbol-2"]
@@ -5183,14 +6659,17 @@ let expected = """
 
             // Make sure that each symbol contains all of its sibling overloads.
             XCTAssertEqual(overloads.references.count, overloadedReferences.count - 1)
-            for (otherIndex, otherReference) in overloadedReferences.indexed() where otherIndex != index {
+            for (otherIndex, otherReference) in overloadedReferences.indexed()
+            where otherIndex != index {
                 XCTAssert(overloads.references.contains(otherReference))
             }
 
             if overloads.displayIndex == 0 {
                 // The first declaration in the display list should be the same declaration as
                 // the overload group page
-                XCTAssertEqual(overloadedSymbol.declaration.first?.value.declarationFragments, overloadGroupSymbol.declaration.first?.value.declarationFragments)
+                XCTAssertEqual(
+                    overloadedSymbol.declaration.first?.value.declarationFragments,
+                    overloadGroupSymbol.declaration.first?.value.declarationFragments)
             } else {
                 // Otherwise, this reference should also be referenced by the overload group
                 XCTAssert(overloadGroupReferences.references.contains(reference))
@@ -5201,24 +6680,37 @@ let expected = """
     func testContextGeneratesOverloadGroupsForDisjointOverloads() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
+        let symbolKind = try XCTUnwrap(
+            SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
 
         let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName-macos.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "macosx")),
-                    symbols: [
-                        makeSymbol(id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-                JSONFile(name: "ModuleName-ios.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    platform: .init(operatingSystem: .init(name: "ios")),
-                    symbols: [
-                        makeSymbol(id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]),
-                        makeSymbol(id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]),
-                    ])),
-            ])
+            Folder(
+                name: "unit-test.docc",
+                content: [
+                    JSONFile(
+                        name: "ModuleName-macos.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "macosx")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]
+                                )
+                            ])),
+                    JSONFile(
+                        name: "ModuleName-ios.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "ModuleName",
+                            platform: .init(operatingSystem: .init(name: "ios")),
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-1", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                                makeSymbol(
+                                    id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]
+                                ),
+                            ])),
+                ])
         let (_, context) = try loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
@@ -5226,19 +6718,25 @@ let expected = """
         let overloadGroupSymbol: Symbol
         let overloadGroupReferences: Symbol.Overloads
 
-        switch context.resolve(.unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference, fromSymbolLink: true) {
+        switch context.resolve(
+            .unresolved(.init(topicURL: .init(symbolPath: "SymbolName"))), in: moduleReference,
+            fromSymbolLink: true)
+        {
         case let .failure(_, errorMessage):
             XCTFail("Could not resolve overload group page. Error message: \(errorMessage)")
             return
         case let .success(overloadGroupReference):
             overloadGroupNode = try context.entity(with: overloadGroupReference)
             overloadGroupSymbol = try XCTUnwrap(overloadGroupNode.semantic as? Symbol)
-            overloadGroupReferences = try XCTUnwrap(overloadGroupSymbol.overloadsVariants.firstValue)
+            overloadGroupReferences = try XCTUnwrap(
+                overloadGroupSymbol.overloadsVariants.firstValue)
 
             XCTAssertEqual(overloadGroupReferences.displayIndex, 0)
 
             let unifiedSymbol = try XCTUnwrap(overloadGroupNode.unifiedSymbol)
-            XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
+            XCTAssertEqual(
+                unifiedSymbol.uniqueIdentifier,
+                "symbol-1" + SymbolGraph.Symbol.overloadGroupIdentifierSuffix)
         }
 
         let overloadedReferences = try ["symbol-1", "symbol-2"]
@@ -5252,300 +6750,394 @@ let expected = """
 
             // Make sure that each symbol contains all of its sibling overloads.
             XCTAssertEqual(overloads.references.count, overloadedReferences.count - 1)
-            for (otherIndex, otherReference) in overloadedReferences.indexed() where otherIndex != index {
+            for (otherIndex, otherReference) in overloadedReferences.indexed()
+            where otherIndex != index {
                 XCTAssert(overloads.references.contains(otherReference))
             }
 
             if overloads.displayIndex == 0 {
                 // The first declaration in the display list should be the same declaration as
                 // the overload group page
-                XCTAssertEqual(overloadedSymbol.declaration.first?.value.declarationFragments, overloadGroupSymbol.declaration.first?.value.declarationFragments)
+                XCTAssertEqual(
+                    overloadedSymbol.declaration.first?.value.declarationFragments,
+                    overloadGroupSymbol.declaration.first?.value.declarationFragments)
             } else {
                 // Otherwise, this reference should also be referenced by the overload group
                 XCTAssert(overloadGroupReferences.references.contains(reference))
             }
         }
     }
-    
+
     func testResolveExternalLinkFromTechnologyRoot() throws {
         enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
-        
+
         let externalModuleName = "ExternalModuleName"
-        
-        func makeExternalDependencyFiles() throws -> (SerializableLinkResolutionInformation, [LinkDestinationSummary]) {
+
+        func makeExternalDependencyFiles() throws -> (
+            SerializableLinkResolutionInformation, [LinkDestinationSummary]
+        ) {
             let (bundle, context) = try loadBundle(
-                catalog: Folder(name: "Dependency.docc", content: [
-                    JSONFile(name: "\(externalModuleName).symbols.json", content: makeSymbolGraph(moduleName: externalModuleName)),
-                    TextFile(name: "Extension.md", utf8Content: """
-                    # ``\(externalModuleName)``
-                    
-                    Some description of this module.
-                    """)
-                ])
+                catalog: Folder(
+                    name: "Dependency.docc",
+                    content: [
+                        JSONFile(
+                            name: "\(externalModuleName).symbols.json",
+                            content: makeSymbolGraph(moduleName: externalModuleName)),
+                        TextFile(
+                            name: "Extension.md",
+                            utf8Content: """
+                                # ``\(externalModuleName)``
+
+                                Some description of this module.
+                                """),
+                    ])
             )
-            
+
             // Retrieve the link information from the dependency, as if '--enable-experimental-external-link-support' was passed to DocC
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
-            let linkSummaries: [LinkDestinationSummary] = try context.knownPages.flatMap { reference in
+            let linkSummaries: [LinkDestinationSummary] = try context.knownPages.flatMap {
+                reference in
                 let entity = try context.entity(with: reference)
                 let renderNode = try XCTUnwrap(converter.convert(entity))
-                
-                return entity.externallyLinkableElementSummaries(context: context, renderNode: renderNode, includeTaskGroups: false)
+
+                return entity.externallyLinkableElementSummaries(
+                    context: context, renderNode: renderNode, includeTaskGroups: false)
             }
-            let linkResolutionInformation = try context.linkResolver.localResolver.prepareForSerialization(bundleID: bundle.id)
-            
+            let linkResolutionInformation = try context.linkResolver.localResolver
+                .prepareForSerialization(bundleID: bundle.id)
+
             return (linkResolutionInformation, linkSummaries)
         }
-        
-        let catalog = Folder(name: "unit-test.docc", content: [
-            TextFile(name: "Root.md", utf8Content: """
-            # Some root page
-            
-            A single-file article-only catalog.
-            
-            This root links to an external module ``/\(externalModuleName)``
-            """),
-        ])
-        
+
+        let catalog = Folder(
+            name: "unit-test.docc",
+            content: [
+                TextFile(
+                    name: "Root.md",
+                    utf8Content: """
+                        # Some root page
+
+                        A single-file article-only catalog.
+
+                        This root links to an external module ``/\(externalModuleName)``
+                        """)
+            ])
+
         let (linkResolutionInformation, linkSummaries) = try makeExternalDependencyFiles()
-        
+
         var configuration = DocumentationContext.Configuration()
         configuration.externalDocumentationConfiguration.dependencyArchives = [
             URL(fileURLWithPath: "/path/to/SomeDependency.doccarchive")
         ]
-        
+
         let (bundle, context) = try loadBundle(
             catalog: catalog,
             otherFileSystemDirectories: [
-                Folder(name: "path", content: [
-                    Folder(name: "to", content: [
-                        Folder(name: "SomeDependency.doccarchive", content: [
-                            JSONFile(name: "link-hierarchy.json", content: linkResolutionInformation),
-                            JSONFile(name: "linkable-entities.json", content: linkSummaries),
-                        ])
+                Folder(
+                    name: "path",
+                    content: [
+                        Folder(
+                            name: "to",
+                            content: [
+                                Folder(
+                                    name: "SomeDependency.doccarchive",
+                                    content: [
+                                        JSONFile(
+                                            name: "link-hierarchy.json",
+                                            content: linkResolutionInformation),
+                                        JSONFile(
+                                            name: "linkable-entities.json", content: linkSummaries),
+                                    ])
+                            ])
                     ])
-                ])
             ],
             configuration: configuration
         )
-        
-        XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
+
+        XCTAssert(
+            context.problems.isEmpty,
+            "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         let reference = try XCTUnwrap(context.soleRootModuleReference)
         let node = try context.entity(with: reference)
-        
+
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let renderNode = converter.convert(node)
-        
+
         let externalReference = "doc://Dependency/documentation/ExternalModuleName"
-        
+
         // Verify that the rendered page contains the resolved reference
-        let discussionSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
-        XCTAssertEqual(discussionSection.content, [
-            .heading(.init(level: 2, text: "Overview", anchor: "overview")),
-            
-            .paragraph(.init(inlineContent: [
-                .text("This root links to an external module "),
-                .reference(identifier: RenderReferenceIdentifier(externalReference), isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil)
-            ]))
-        ])
-        
+        let discussionSection = try XCTUnwrap(
+            renderNode.primaryContentSections.first as? ContentRenderSection)
+        XCTAssertEqual(
+            discussionSection.content,
+            [
+                .heading(.init(level: 2, text: "Overview", anchor: "overview")),
+
+                .paragraph(
+                    .init(inlineContent: [
+                        .text("This root links to an external module "),
+                        .reference(
+                            identifier: RenderReferenceIdentifier(externalReference),
+                            isActive: true, overridingTitle: nil, overridingTitleInlineContent: nil),
+                    ])),
+            ])
+
         // Verify that the rendered page has the render details about the resolved reference
         XCTAssertEqual(renderNode.references.keys.sorted(), [externalReference])
-        
-        let externalRenderReference = try XCTUnwrap(renderNode.references[externalReference] as? TopicRenderReference)
+
+        let externalRenderReference = try XCTUnwrap(
+            renderNode.references[externalReference] as? TopicRenderReference)
         XCTAssertEqual(externalRenderReference.title, externalModuleName)
-        XCTAssertEqual(externalRenderReference.abstract, [.text("Some description of this module.")])
+        XCTAssertEqual(
+            externalRenderReference.abstract, [.text("Some description of this module.")])
     }
 
     func testResolvesAlternateDeclarations() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(
-            name: "unit-test.docc",
-            content: [
-                TextFile(name: "Symbol.md", utf8Content: """
-                # ``Symbol``
-                @Metadata {
-                    @AlternateRepresentation(``CounterpartSymbol``)
-                    @AlternateRepresentation(OtherCounterpartSymbol)
-                    @AlternateRepresentation(``MissingSymbol``)
-                }
-                A symbol extension file defining an alternate representation.
-                """),
-                JSONFile(
-                    name: "unit-test.swift.symbols.json",
-                    content: makeSymbolGraph(
-                        moduleName: "unit-test",
-                        symbols: [
-                            makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
-                        ]
-                    )
-                ),
-                JSONFile(
-                    name: "unit-test.occ.symbols.json",
-                    content: makeSymbolGraph(
-                        moduleName: "unit-test",
-                        symbols: [
-                            makeSymbol(id: "counterpart-symbol-id", language: .objectiveC, kind: .class, pathComponents: ["CounterpartSymbol"]),
-                        ]
-                    )
-                ),
-                JSONFile(
-                    name: "unit-test.js.symbols.json",
-                    content: makeSymbolGraph(
-                        moduleName: "unit-test",
-                        symbols: [
-                            makeSymbol(id: "other-counterpart-symbol-id", language: .javaScript, kind: .class, pathComponents: ["OtherCounterpartSymbol"]),
-                        ]
-                    )
-                ),
-            ]
-        ))
-        
-        let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Symbol", sourceLanguage: .swift)
-        
+        let (bundle, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    TextFile(
+                        name: "Symbol.md",
+                        utf8Content: """
+                            # ``Symbol``
+                            @Metadata {
+                                @AlternateRepresentation(``CounterpartSymbol``)
+                                @AlternateRepresentation(OtherCounterpartSymbol)
+                                @AlternateRepresentation(``MissingSymbol``)
+                            }
+                            A symbol extension file defining an alternate representation.
+                            """),
+                    JSONFile(
+                        name: "unit-test.swift.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "unit-test",
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-id", kind: .class, pathComponents: ["Symbol"])
+                            ]
+                        )
+                    ),
+                    JSONFile(
+                        name: "unit-test.occ.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "unit-test",
+                            symbols: [
+                                makeSymbol(
+                                    id: "counterpart-symbol-id", language: .objectiveC,
+                                    kind: .class, pathComponents: ["CounterpartSymbol"])
+                            ]
+                        )
+                    ),
+                    JSONFile(
+                        name: "unit-test.js.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "unit-test",
+                            symbols: [
+                                makeSymbol(
+                                    id: "other-counterpart-symbol-id", language: .javaScript,
+                                    kind: .class, pathComponents: ["OtherCounterpartSymbol"])
+                            ]
+                        )
+                    ),
+                ]
+            ))
+
+        let reference = ResolvedTopicReference(
+            bundleID: bundle.id, path: "/documentation/unit-test/Symbol", sourceLanguage: .swift)
+
         let entity = try context.entity(with: reference)
         XCTAssertEqual(entity.metadata?.alternateRepresentations.count, 3)
-        
+
         // First alternate representation should have been resolved successfully
         var alternateRepresentation = try XCTUnwrap(entity.metadata?.alternateRepresentations.first)
         XCTAssertEqual(
             alternateRepresentation.reference,
-            .resolved(.success(.init(bundleID: bundle.id, path: "/documentation/unit-test/CounterpartSymbol", sourceLanguage: .objectiveC)))
+            .resolved(
+                .success(
+                    .init(
+                        bundleID: bundle.id, path: "/documentation/unit-test/CounterpartSymbol",
+                        sourceLanguage: .objectiveC)))
         )
-        
+
         // Second alternate representation without "``" should also have been resolved successfully
-        alternateRepresentation = try XCTUnwrap(entity.metadata?.alternateRepresentations.dropFirst().first)
+        alternateRepresentation = try XCTUnwrap(
+            entity.metadata?.alternateRepresentations.dropFirst().first)
         XCTAssertEqual(
             alternateRepresentation.reference,
-            .resolved(.success(.init(bundleID: bundle.id, path: "/documentation/unit-test/OtherCounterpartSymbol", sourceLanguage: .objectiveC)))
+            .resolved(
+                .success(
+                    .init(
+                        bundleID: bundle.id,
+                        path: "/documentation/unit-test/OtherCounterpartSymbol",
+                        sourceLanguage: .objectiveC)))
         )
-        
+
         // Third alternate representation shouldn't have been resolved at all
-        alternateRepresentation = try XCTUnwrap(entity.metadata?.alternateRepresentations.dropFirst().last)
-        guard case .resolved(.failure(let unresolvedPath, _)) = alternateRepresentation.reference else {
-            XCTFail("Expected alternate representation to be unresolved, but was resolved as \(alternateRepresentation.reference)")
+        alternateRepresentation = try XCTUnwrap(
+            entity.metadata?.alternateRepresentations.dropFirst().last)
+        guard case .resolved(.failure(let unresolvedPath, _)) = alternateRepresentation.reference
+        else {
+            XCTFail(
+                "Expected alternate representation to be unresolved, but was resolved as \(alternateRepresentation.reference)"
+            )
             return
         }
-        XCTAssertEqual(unresolvedPath, .init(topicURL: .init(parsingAuthoredLink: "MissingSymbol")!))
-        
+        XCTAssertEqual(
+            unresolvedPath, .init(topicURL: .init(parsingAuthoredLink: "MissingSymbol")!))
+
         // And an error should have been reported
         XCTAssertEqual(context.problems.count, 1)
-        
+
         let problem = try XCTUnwrap(context.problems.first)
         XCTAssertEqual(problem.diagnostic.severity, .warning)
         XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'MissingSymbol'")
     }
-        
+
     func testDiagnosesSymbolAlternateDeclarations() throws {
-        let (_, context) = try loadBundle(catalog: Folder(
-            name: "unit-test.docc",
-            content: [
-                TextFile(name: "Symbol.md", utf8Content: """
-                # ``Symbol``
-                @Metadata {
-                    @AlternateRepresentation(``CounterpartSymbol``)
-                    @AlternateRepresentation(``OtherCounterpartSymbol``)
-                }
-                A symbol extension file defining an alternate representation which overlaps source languages with another one.
-                """),
-                TextFile(name: "SwiftSymbol.md", utf8Content: """
-                # ``SwiftSymbol``
-                @Metadata {
-                    @AlternateRepresentation(``Symbol``)
-                }
-                A symbol extension file defining an alternate representation which overlaps source languages with the current node.
-                """),
-                JSONFile(
-                    name: "unit-test.swift.symbols.json",
-                    content: makeSymbolGraph(
-                        moduleName: "unit-test",
-                        symbols: [
-                            makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
-                            makeSymbol(id: "other-symbol-id", kind: .class, pathComponents: ["SwiftSymbol"]),
-                        ]
-                    )
-                ),
-                JSONFile(
-                    name: "unit-test.occ.symbols.json",
-                    content: makeSymbolGraph(
-                        moduleName: "unit-test",
-                        symbols: [
-                            makeSymbol(id: "counterpart-symbol-id", language: .objectiveC, kind: .class, pathComponents: ["CounterpartSymbol"]),
-                            makeSymbol(id: "other-counterpart-symbol-id", language: .objectiveC, kind: .class, pathComponents: ["OtherCounterpartSymbol"]),
-                        ]
-                    )
-                ),
-            ]
-        ))
+        let (_, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    TextFile(
+                        name: "Symbol.md",
+                        utf8Content: """
+                            # ``Symbol``
+                            @Metadata {
+                                @AlternateRepresentation(``CounterpartSymbol``)
+                                @AlternateRepresentation(``OtherCounterpartSymbol``)
+                            }
+                            A symbol extension file defining an alternate representation which overlaps source languages with another one.
+                            """),
+                    TextFile(
+                        name: "SwiftSymbol.md",
+                        utf8Content: """
+                            # ``SwiftSymbol``
+                            @Metadata {
+                                @AlternateRepresentation(``Symbol``)
+                            }
+                            A symbol extension file defining an alternate representation which overlaps source languages with the current node.
+                            """),
+                    JSONFile(
+                        name: "unit-test.swift.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "unit-test",
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
+                                makeSymbol(
+                                    id: "other-symbol-id", kind: .class,
+                                    pathComponents: ["SwiftSymbol"]),
+                            ]
+                        )
+                    ),
+                    JSONFile(
+                        name: "unit-test.occ.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "unit-test",
+                            symbols: [
+                                makeSymbol(
+                                    id: "counterpart-symbol-id", language: .objectiveC,
+                                    kind: .class, pathComponents: ["CounterpartSymbol"]),
+                                makeSymbol(
+                                    id: "other-counterpart-symbol-id", language: .objectiveC,
+                                    kind: .class, pathComponents: ["OtherCounterpartSymbol"]),
+                            ]
+                        )
+                    ),
+                ]
+            ))
 
         let alternateRepresentationProblems = context.problems.sorted(by: \.diagnostic.summary)
         XCTAssertEqual(alternateRepresentationProblems.count, 2)
-        
+
         // Verify a problem is reported for trying to define an alternate representation for a language the symbol already supports
         var problem = try XCTUnwrap(alternateRepresentationProblems.first)
         XCTAssertEqual(problem.diagnostic.severity, .warning)
-        XCTAssertEqual(problem.diagnostic.summary, "'SwiftSymbol' already has a representation in Swift")
-        XCTAssertEqual(problem.diagnostic.explanation, "Symbols can only specify custom alternate language representations for languages that the documented symbol doesn't already have a representation for.")
+        XCTAssertEqual(
+            problem.diagnostic.summary, "'SwiftSymbol' already has a representation in Swift")
+        XCTAssertEqual(
+            problem.diagnostic.explanation,
+            "Symbols can only specify custom alternate language representations for languages that the documented symbol doesn't already have a representation for."
+        )
         XCTAssertEqual(problem.possibleSolutions.count, 1)
-    
+
         // Verify solutions provide context, but no replacements
         var solution = try XCTUnwrap(problem.possibleSolutions.first)
-        XCTAssertEqual(solution.summary, "Replace this alternate language representation with a symbol which isn't available in Swift")
+        XCTAssertEqual(
+            solution.summary,
+            "Replace this alternate language representation with a symbol which isn't available in Swift"
+        )
         XCTAssertEqual(solution.replacements.count, 0)
 
         // Verify a problem is reported for having alternate representations with duplicate source languages
         problem = try XCTUnwrap(alternateRepresentationProblems[1])
         XCTAssertEqual(problem.diagnostic.severity, .warning)
-        XCTAssertEqual(problem.diagnostic.summary, "A custom alternate language representation for Objective-C has already been specified")
-        XCTAssertEqual(problem.diagnostic.explanation, "Only one custom alternate language representation can be specified per language.")
+        XCTAssertEqual(
+            problem.diagnostic.summary,
+            "A custom alternate language representation for Objective-C has already been specified")
+        XCTAssertEqual(
+            problem.diagnostic.explanation,
+            "Only one custom alternate language representation can be specified per language.")
         XCTAssertEqual(problem.possibleSolutions.count, 1)
-                
+
         // Verify solutions provide context and suggest to remove the duplicate directive
         solution = try XCTUnwrap(problem.possibleSolutions.first)
         XCTAssertEqual(solution.summary, "Remove this alternate representation")
         XCTAssertEqual(solution.replacements.count, 1)
         XCTAssertEqual(solution.replacements.first?.replacement, "")
     }
-    
+
     func testDiagnosesArticleAlternateDeclarations() throws {
-        let (_, context) = try loadBundle(catalog: Folder(
-            name: "unit-test.docc",
-            content: [
-                TextFile(name: "Symbol.md", utf8Content: """
-                # ``Symbol``
-                @Metadata {
-                    @AlternateRepresentation("doc:Article")
-                }
-                A symbol extension file specifying an alternate representation which is an article.
-                """),
-                TextFile(name: "Article.md", utf8Content: """
-                # Article
-                @Metadata {
-                    @AlternateRepresentation(``Symbol``)
-                }
-                An article specifying a custom alternate representation.
-                """),
-                JSONFile(
-                    name: "unit-test.occ.symbols.json",
-                    content: makeSymbolGraph(
-                        moduleName: "unit-test",
-                        symbols: [
-                            makeSymbol(id: "symbol-id", kind: .class, pathComponents: ["Symbol"]),
-                        ]
-                    )
-                )
-            ]
-        ))
+        let (_, context) = try loadBundle(
+            catalog: Folder(
+                name: "unit-test.docc",
+                content: [
+                    TextFile(
+                        name: "Symbol.md",
+                        utf8Content: """
+                            # ``Symbol``
+                            @Metadata {
+                                @AlternateRepresentation("doc:Article")
+                            }
+                            A symbol extension file specifying an alternate representation which is an article.
+                            """),
+                    TextFile(
+                        name: "Article.md",
+                        utf8Content: """
+                            # Article
+                            @Metadata {
+                                @AlternateRepresentation(``Symbol``)
+                            }
+                            An article specifying a custom alternate representation.
+                            """),
+                    JSONFile(
+                        name: "unit-test.occ.symbols.json",
+                        content: makeSymbolGraph(
+                            moduleName: "unit-test",
+                            symbols: [
+                                makeSymbol(
+                                    id: "symbol-id", kind: .class, pathComponents: ["Symbol"])
+                            ]
+                        )
+                    ),
+                ]
+            ))
 
         let alternateRepresentationProblems = context.problems.sorted(by: \.diagnostic.summary)
         XCTAssertEqual(alternateRepresentationProblems.count, 2)
-        
+
         // Verify a problem is reported for trying to define an alternate representation for a language the symbol already supports
         var problem = try XCTUnwrap(alternateRepresentationProblems.first)
         XCTAssertEqual(problem.diagnostic.severity, .warning)
-        XCTAssertEqual(problem.diagnostic.summary, "Custom alternate representations are not supported for page kind 'Article'")
-        XCTAssertEqual(problem.diagnostic.explanation, "Alternate representations are only supported for symbols.")
+        XCTAssertEqual(
+            problem.diagnostic.summary,
+            "Custom alternate representations are not supported for page kind 'Article'")
+        XCTAssertEqual(
+            problem.diagnostic.explanation,
+            "Alternate representations are only supported for symbols.")
         XCTAssertEqual(problem.possibleSolutions.count, 1)
-    
+
         // Verify solutions provide context and suggest to remove the invalid directive
         var solution = try XCTUnwrap(problem.possibleSolutions.first)
         XCTAssertEqual(solution.summary, "Remove this alternate representation")
@@ -5555,10 +7147,14 @@ let expected = """
         // Verify a problem is reported for having alternate representations with duplicate source languages
         problem = try XCTUnwrap(alternateRepresentationProblems[1])
         XCTAssertEqual(problem.diagnostic.severity, .warning)
-        XCTAssertEqual(problem.diagnostic.summary, "Page kind 'Article' is not allowed as a custom alternate language representation")
-        XCTAssertEqual(problem.diagnostic.explanation, "Symbols can only specify other symbols as custom language representations.")
+        XCTAssertEqual(
+            problem.diagnostic.summary,
+            "Page kind 'Article' is not allowed as a custom alternate language representation")
+        XCTAssertEqual(
+            problem.diagnostic.explanation,
+            "Symbols can only specify other symbols as custom language representations.")
         XCTAssertEqual(problem.possibleSolutions.count, 1)
-                
+
         // Verify solutions provide context and suggest to remove the invalid directive
         solution = try XCTUnwrap(problem.possibleSolutions.first)
         XCTAssertEqual(solution.summary, "Remove this alternate representation")
@@ -5568,12 +7164,17 @@ let expected = """
 
 }
 
-func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {
+func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line)
+{
     // The default message by XCTAssertEqual isn't helpful in this case as it dumps both values in the console
     // and is difficult to track any changes
     guard lhs.removingLeadingSpaces == rhs.removingLeadingSpaces else {
-        XCTFail("\n" + diffDescription(lhs: lhs.removingLeadingSpaces, rhs: rhs.removingLeadingSpaces), file: (file), line: line)
-        XCTFail("\n" + diffDescription(lhs: lhs.removingLeadingSpaces, rhs: rhs.removingLeadingSpaces), file: (file), line: line)
+        XCTFail(
+            "\n" + diffDescription(lhs: lhs.removingLeadingSpaces, rhs: rhs.removingLeadingSpaces),
+            file: (file), line: line)
+        XCTFail(
+            "\n" + diffDescription(lhs: lhs.removingLeadingSpaces, rhs: rhs.removingLeadingSpaces),
+            file: (file), line: line)
         return
     }
 }
@@ -5585,19 +7186,57 @@ extension String {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .joined(separator: "\n")
     }
-    
+
     var removingLeadingSpaces: String {
         var result = self
         var count = 0
-        
+
         while result.hasPrefix(" ") {
             result = String(result.dropFirst())
             count += 1
         }
-        
+
         return components(separatedBy: .newlines)
             .filter({ !$0.isEmpty })
             .map({ return String($0.dropFirst(count)) })
             .joined(separator: "\n")
     }
+}
+
+func testWarnsOnMultipleRootPagesDetails() throws {
+    let (bundle, context) = try testBundleAndContext(copying: "TestBundle") { url in
+        try """
+        # Additional Root
+        @TechnologyRoot
+
+        Additional root page
+        """.write(
+            to: url.appendingPathComponent("additional-root.md"), atomically: true, encoding: .utf8)
+    }
+
+    // Find the warning diagnostic
+    let warning = try XCTUnwrap(
+        context.problems.first {
+            $0.diagnostic.identifier == "org.swift.docc.MultipleRootPages"
+        }
+    )
+
+    // Verify warning details
+    XCTAssertEqual(warning.diagnostic.severity, .warning)
+    XCTAssertEqual(
+        warning.diagnostic.summary,
+        "Found 2 root pages in documentation"
+    )
+    XCTAssertTrue(
+        warning.diagnostic.explanation.contains("Documentation should have exactly one root page"),
+        "Warning only one root page is allowed"
+    )
+    XCTAssertTrue(
+        warning.diagnostic.explanation.contains("Primary:"),
+        "Warning identify the primary root"
+    )
+    XCTAssertTrue(
+        warning.diagnostic.explanation.contains("Additional:"),
+        "Warning list additional roots"
+    )
 }

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -7204,39 +7204,43 @@ extension String {
 }
 
 func testWarnsOnMultipleRootPagesDetails() throws {
+    // Set up the bundle and context using the static method
     let (bundle, context) = try testBundleAndContext(copying: "TestBundle") { url in
         try """
         # Additional Root
         @TechnologyRoot
-
         Additional root page
         """.write(
-            to: url.appendingPathComponent("additional-root.md"), atomically: true, encoding: .utf8)
+            to: url.appendingPathComponent("additional-root.md"),
+            atomically: true,
+            encoding: .utf8
+        )
     }
 
-    // Find the warning diagnostic
-    let warning = try XCTUnwrap(
+    // Find the warning diagnostic in the context
+    let warning: Problem = try XCTUnwrap(
         context.problems.first {
             $0.diagnostic.identifier == "org.swift.docc.MultipleRootPages"
         }
     )
 
-    // Verify warning details
+    // Verify the warning details
     XCTAssertEqual(warning.diagnostic.severity, .warning)
     XCTAssertEqual(
         warning.diagnostic.summary,
         "Found 2 root pages in documentation"
     )
     XCTAssertTrue(
-        warning.diagnostic.explanation.contains("Documentation should have exactly one root page"),
+        warning.diagnostic.explanation?.contains("Documentation should have exactly one root page")
+            ?? false,
         "Warning only one root page is allowed"
     )
     XCTAssertTrue(
-        warning.diagnostic.explanation.contains("Primary:"),
+        warning.diagnostic.explanation?.contains("Primary:") ?? false,
         "Warning identify the primary root"
     )
     XCTAssertTrue(
-        warning.diagnostic.explanation.contains("Additional:"),
+        warning.diagnostic.explanation?.contains("Additional:") ?? false,
         "Warning list additional roots"
     )
 }


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

## **Issue "Warn when the documentation contains more than one root page #1170"**

### Summary

Added diagnostic for multiple root pages warning, root page count validation, test coverage to verify warning message and details

Resolves #1170 

Having warnings about unexpected inputs would help developers notice issues and correct the inputs they are passing to DocC or other misconfigurations in their projects.

As mentioned by [d-ronnqvist](https://github.com/d-ronnqvist)  the primary objective was to assist developers who don't use DocC through a higher level integration have more reason to be notified about unexpected inputs because the inputs are in their control.

File Edited

DocumentationContext.swift to add Diagnostic for validation

DocumentationContextTests.swift to add test case for test Warning On Multiple Root Pages Details

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [✅ ] Added tests
- [✅ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary