### PR TITLE
Ensure that synthesized landing pages for combined archives display page images and links in abstracts from referenced types

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
+++ b/Sources/SwiftDocC/Model/Rendering/DocumentationContentRenderer.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,9 +13,9 @@ import SymbolKit
 import Markdown
 
 public struct RenderReferenceDependencies {
-    var topicReferences = [ResolvedTopicReference]()
-    var linkReferences = [LinkReference]()
-    var imageReferences = [ImageReference]()
+    public var topicReferences = [ResolvedTopicReference]()
+    public var linkReferences = [LinkReference]()
+    public var imageReferences = [ImageReference]()
     
     public init(topicReferences: [ResolvedTopicReference] = [], linkReferences: [LinkReference] = [], imageReferences: [ImageReference] = []) {
         self.topicReferences = topicReferences

--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -64,7 +64,7 @@ package class TestFileSystem: FileManagerProtocol {
         files["/tmp"] = Self.folderFixtureData
  
         for folder in folders {
-            try addFolder(folder)
+            try addFolder(folder, basePath: URL(fileURLWithPath: "/"))
         }
     }
 
@@ -127,13 +127,13 @@ package class TestFileSystem: FileManagerProtocol {
     }
     
     @discardableResult
-    func addFolder(_ folder: Folder) throws -> [String] {
+    package func addFolder(_ folder: Folder, basePath: URL) throws -> [String] {
         guard !disableWriting else { return [] }
         
         filesLock.lock()
         defer { filesLock.unlock() }
 
-        let rootURL = URL(fileURLWithPath: "/\(folder.name)")
+        let rootURL = basePath.appendingPathComponent(folder.name)// URL(fileURLWithPath: "/\(folder.name)")
         files[rootURL.path] = Self.folderFixtureData
         let fileList = try filesIn(folder: folder, at: rootURL)
         files.merge(fileList, uniquingKeysWith: +)

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,9 +13,17 @@ import SwiftDocC
 
 extension MergeAction {
     struct RootRenderReferences {
-        var documentation, tutorials: [TopicRenderReference]
+        struct Information {
+            var reference: TopicRenderReference
+            var dependencies: RenderReferenceDependencies
+            
+            var rawIdentifier: String {
+                reference.identifier.identifier
+            }
+        }
+        var documentation, tutorials: [Information]
         
-        fileprivate var all: [TopicRenderReference] {
+        fileprivate var all: [Information] {
             documentation + tutorials
         }
         var isEmpty: Bool {
@@ -27,7 +35,7 @@ extension MergeAction {
     }
     
     func readRootNodeRenderReferencesIn(dataDirectory: URL) throws -> RootRenderReferences {
-        func inner(url: URL) throws -> [TopicRenderReference] {
+        func inner(url: URL) throws -> [RootRenderReferences.Information] {
             try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
                 .compactMap {
                     guard $0.pathExtension == "json" else {
@@ -35,11 +43,12 @@ extension MergeAction {
                     }
                     
                     let data = try fileManager.contents(of: $0)
-                    return try JSONDecoder().decode(RootNodeRenderReference.self, from: data)
-                        .renderReference
+                    let decoded = try JSONDecoder().decode(RootNodeRenderReference.self, from: data)
+                    
+                    return .init(reference: decoded.renderReference, dependencies: decoded.renderDependencies)
                 }
                 .sorted(by: { lhs, rhs in
-                    lhs.title < rhs.title
+                    lhs.reference.title < rhs.reference.title
                 })
         }
         
@@ -72,21 +81,26 @@ extension MergeAction {
         if rootRenderReferences.containsBothKinds {
             // If the combined archive contains both documentation and tutorial content, create separate topic sections for each.
             renderNode.topicSections = [
-                .init(title: "Modules", abstract: nil, discussion: nil, identifiers: rootRenderReferences.documentation.map(\.identifier.identifier)),
-                .init(title: "Tutorials", abstract: nil, discussion: nil, identifiers: rootRenderReferences.tutorials.map(\.identifier.identifier)),
+                .init(title: "Modules", abstract: nil, discussion: nil, identifiers: rootRenderReferences.documentation.map(\.rawIdentifier)),
+                .init(title: "Tutorials", abstract: nil, discussion: nil, identifiers: rootRenderReferences.tutorials.map(\.rawIdentifier)),
             ]
         } else {
             // Otherwise, create a single unnamed topic section
             renderNode.topicSections = [
-                .init(title: nil, abstract: nil, discussion: nil, identifiers: (rootRenderReferences.all).map(\.identifier.identifier)),
+                .init(title: nil, abstract: nil, discussion: nil, identifiers: (rootRenderReferences.all).map(\.rawIdentifier)),
             ]
         }
         
         for renderReference in rootRenderReferences.documentation {
-            renderNode.references[renderReference.identifier.identifier] = renderReference
+            renderNode.references[renderReference.rawIdentifier] = renderReference.reference
+            
+            for imageReference in renderReference.dependencies.imageReferences {
+                renderNode.references[imageReference.identifier.identifier] = imageReference
+            }
         }
         for renderReference in rootRenderReferences.tutorials {
-            renderNode.references[renderReference.identifier.identifier] = renderReference
+            renderNode.references[renderReference.rawIdentifier] = renderReference.reference
+            // Tutorial pages don't have page images.
         }
         
         return renderNode
@@ -97,6 +111,7 @@ extension MergeAction {
 private struct RootNodeRenderReference: Decodable {
     /// The decoded root node render reference
     var renderReference: TopicRenderReference
+    var renderDependencies: RenderReferenceDependencies
     
     enum CodingKeys: CodingKey {
         // The only render node keys that should be needed
@@ -107,7 +122,7 @@ private struct RootNodeRenderReference: Decodable {
     
     struct StringCodingKey: CodingKey {
         var stringValue: String
-        init?(stringValue: String) {
+        init(stringValue: String) {
             self.stringValue = stringValue
         }
         var intValue: Int? = nil
@@ -130,8 +145,15 @@ private struct RootNodeRenderReference: Decodable {
         // If the root page has a reference to itself, then that the fastest and easiest way to access the correct topic render reference.
         if container.contains(.references) {
             let referencesContainer = try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: .references)
-            if let selfReference = try referencesContainer.decodeIfPresent(TopicRenderReference.self, forKey: .init(stringValue: rawIdentifier)!) {
+            if let selfReference = try referencesContainer.decodeIfPresent(TopicRenderReference.self, forKey: .init(stringValue: rawIdentifier)) {
                 renderReference = selfReference
+                
+                let imageReferences = try Self.decodeImageReferences(container: referencesContainer, images: selfReference.images)
+                renderDependencies = RenderReferenceDependencies(
+                    topicReferences: [],
+                    linkReferences: [],
+                    imageReferences: imageReferences
+                )
                 return
             }
         }
@@ -148,5 +170,27 @@ private struct RootNodeRenderReference: Decodable {
             kind: try container.decode(RenderNode.Kind.self, forKey: .kind),
             images: metadata.images
         )
+        
+        let imageReferences: [ImageReference]
+        if !metadata.images.isEmpty, container.contains(.references) {
+            imageReferences = try Self.decodeImageReferences(
+                container: try container.nestedContainer(keyedBy: StringCodingKey.self, forKey: .references),
+                images: metadata.images
+            )
+        } else {
+            imageReferences = []
+        }
+        
+        renderDependencies = RenderReferenceDependencies(
+            topicReferences: [],
+            linkReferences: [],
+            imageReferences: imageReferences
+        )
+    }
+    
+    private static func decodeImageReferences(container: KeyedDecodingContainer<RootNodeRenderReference.StringCodingKey>, images: [TopicImage]) throws -> [ImageReference] {
+        try images.map { image in
+            try container.decode(ImageReference.self, forKey: .init(stringValue: image.identifier.identifier))
+        }
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://147392201

## Summary

This includes the dependency references of the merged archives in the synthesized landing page so that modules with page images display those images on the landing page:

<img width="1551" alt="Screenshot 2025-03-19 at 11 23 26" src="https://github.com/user-attachments/assets/dd652315-5784-46db-8c01-7a1b34662be1" />

## Dependencies

None

## Testing

For a project with multiple targets, for example https://github.com/d-ronnqvist/combined-documentation-example

- Add images and `@PageImage` directives to one or more of the documented products.
- Add a link in the abstract of one or more of the documented products.

- Build a local `docc` executable from this branch and specify its path for the `DOCC_EXEC` environmental variable.
- Build a combined documentation archive using `swift package generate-documentation --enable-experimental-combined-documentation`

- Start a preview server and preview the combined archives's landing page. 
  - Both the page images and the abstract links should display on the landing page. Note that the entire card is a single element, so the abstract link isn't clickable.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
