### PR TITLE
Adopt the upcoming feature SE-0274 (concise magic file name)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,8 @@ import class Foundation.ProcessInfo
 
 let swiftSettings: [SwiftSetting] = [
     .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=1000"], .when(configuration: .debug)),
+    
+    .enableUpcomingFeature("ConciseMagicFile"), // SE-0274: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0274-magic-file.md
 ]
 
 let package = Package(

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -199,7 +199,7 @@ let supportedDirectives: [Directive] = [
     }
 
 func generateSwiftDocCFrameworkSymbolGraph() throws -> SymbolGraph {
-    let packagePath = URL(fileURLWithPath: #file)
+    let packagePath = URL(fileURLWithPath: #filePath) // Absolute path to this file
         .deletingLastPathComponent() // generate-symbol-graph
         .deletingLastPathComponent() // Sources
         .deletingLastPathComponent() // swift-docc
@@ -680,7 +680,7 @@ private struct SortedSymbolGraph: Codable {
     }
 }
 
-let output = URL(fileURLWithPath: #file)
+let output = URL(fileURLWithPath: #filePath) // Absolute path to this file
     .deletingLastPathComponent()
     .deletingLastPathComponent()
     .appendingPathComponent("docc/DocCDocumentation.docc/docc.symbols.json")

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -2396,7 +2396,7 @@ class ConvertServiceTests: XCTestCase {
         source: URL,
         title: String?,
         isDocumentationExtensionContent: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         let topicContentKey = try XCTUnwrap(referenceStore.topics.keys.first { $0.path == topicPath })

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -2052,7 +2052,7 @@ fileprivate func validateTree(node: NavigatorTree.Node, validator: (NavigatorTre
     return true
 }
 
-fileprivate func assertUniqueIDs(node: NavigatorTree.Node, message: String = "The tree has duplicated IDs.", file: StaticString = #file, line: UInt = #line) {
+fileprivate func assertUniqueIDs(node: NavigatorTree.Node, message: String = "The tree has duplicated IDs.", file: StaticString = #filePath, line: UInt = #line) {
     var collector = Set<UInt32>()
     var brokenItemTitle = ""
     

--- a/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutomaticCurationTests.swift
@@ -95,7 +95,7 @@ class AutomaticCurationTests: XCTestCase {
         containsAutomaticTopicSectionFor kind: SymbolGraph.Symbol.KindIdentifier,
         context: DocumentationContext,
         bundle: DocumentationBundle,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift))
@@ -771,7 +771,7 @@ class AutomaticCurationTests: XCTestCase {
 
         func assertAutomaticCuration(
             variants: Set<DocumentationDataVariantsTrait>,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) throws {
             let topics = try AutomaticCuration.topics(

--- a/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/BundleDiscoveryTests.swift
@@ -136,13 +136,13 @@ class BundleDiscoveryTests: XCTestCase {
         
         let expectedBundle = try parsedBundle(from: CopyOfFolder(original: testBundleLocation))
         
-        func checkExpectedFilesFoundIn(_ folder: File, file: StaticString = #file, line: UInt = #line) throws {
+        func checkExpectedFilesFoundIn(_ folder: File, file: StaticString = #filePath, line: UInt = #line) throws {
             let bundle = try parsedBundle(from: folder)
             
             XCTAssertEqual(bundle.id, expectedBundle.id)
             XCTAssertEqual(bundle.displayName, expectedBundle.displayName)
             
-            func assertEqualFiles(_ got: [URL], _ expected: [URL], file: StaticString = #file, line: UInt = #line) {
+            func assertEqualFiles(_ got: [URL], _ expected: [URL], file: StaticString = #filePath, line: UInt = #line) {
                 let gotFileNames = Set(got.map { $0.lastPathComponent })
                 let expectedFileNames = Set(expected.map { $0.lastPathComponent })
                 

--- a/Tests/SwiftDocCTests/Infrastructure/DataAssetManagerTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DataAssetManagerTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 class DataAssetManagerTests: XCTestCase {
     
-    func assertIsRegistered(named name: String, trait: DataTraitCollection, expectedURL: URL, manager: DataAssetManager, file: StaticString = #file, line: UInt = #line) {
+    func assertIsRegistered(named name: String, trait: DataTraitCollection, expectedURL: URL, manager: DataAssetManager, file: StaticString = #filePath, line: UInt = #line) {
         let data = manager.data(named: name, bestMatching: trait)!
         XCTAssertEqual(data.url, expectedURL)
         XCTAssertEqual(data.traitCollection, trait)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageLinkResolutionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageLinkResolutionTests.swift
@@ -24,7 +24,7 @@ class DocumentationContext_MixedLanguageLinkResolutionTests: XCTestCase {
         func assertCanResolveSymbolLinks(
             symbolPaths: String...,
             parentPath: String,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) {
             for symbolPath in symbolPaths {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageSourceLanguagesTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageSourceLanguagesTests.swift
@@ -36,7 +36,7 @@ class DocumentationContext_MixedLanguageSourceLanguagesTests: XCTestCase {
     func assertArticleAvailableSourceLanguages(
         moduleAvailableLanguages: Set<SourceLanguage>,
         expectedArticleDefaultLanguage: SourceLanguage,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         precondition(

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5568,7 +5568,7 @@ let expected = """
 
 }
 
-func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #file, line: UInt = #line) {
+func assertEqualDumps(_ lhs: String, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
     // The default message by XCTAssertEqual isn't helpful in this case as it dumps both values in the console
     // and is difficult to track any changes
     guard lhs.removingLeadingSpaces == rhs.removingLeadingSpaces else {

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -920,7 +920,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         func assertSuccessfullyResolves(
             authoredLink: String,
             to absoluteReferenceString: String? = nil,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) throws {
             let expectedAbsoluteReferenceString = absoluteReferenceString ?? {
@@ -943,7 +943,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         func assertBetaStatus(
             authoredLink: String,
             isBeta: Bool,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) throws {
             try assertResults(authoredLink: authoredLink) { result, label in
@@ -961,7 +961,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             authoredLink: String,
             errorMessage: String,
             solutions: [Solution],
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) throws {
            try assertResults(authoredLink: authoredLink) { result, label in

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -1203,7 +1203,7 @@ class ExternalReferenceResolverTests: XCTestCase {
         XCTAssertEqual(externalLinks.count, 4, "Did not resolve the 4 expected external links.")
     }
 
-    func exampleDocumentation(copying bundleName: String, documentationExtension: TextFile, path: String, file: StaticString = #file, line: UInt = #line) throws -> Symbol {
+    func exampleDocumentation(copying bundleName: String, documentationExtension: TextFile, path: String, file: StaticString = #filePath, line: UInt = #line) throws -> Symbol {
         let externalResolver = TestExternalReferenceResolver()
         let (_, bundle, context) = try testBundleAndContext(
             copying: bundleName,
@@ -1280,7 +1280,7 @@ class ExternalReferenceResolverTests: XCTestCase {
     // Create some example documentation using the symbol graph file located under
     // Tests/SwiftDocCTests/Test Bundles/HTTPRequests.docc, and the following
     // documentation extension markup.
-    func exampleRESTDocumentation(file: StaticString = #file, line: UInt = #line) throws -> Symbol {
+    func exampleRESTDocumentation(file: StaticString = #filePath, line: UInt = #line) throws -> Symbol {
         let documentationExtension = TextFile(
             name: "GetArtist.md",
             utf8Content: """

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3785,7 +3785,7 @@ class PathHierarchyTests: XCTestCase {
     
     // MARK: Test helpers
 
-    private func assertFindsPath(_ path: String, in tree: PathHierarchy, asSymbolID symbolID: String, file: StaticString = #file, line: UInt = #line) throws {
+    private func assertFindsPath(_ path: String, in tree: PathHierarchy, asSymbolID symbolID: String, file: StaticString = #filePath, line: UInt = #line) throws {
         do {
             let symbol = try tree.findSymbol(path: path)
             XCTAssertEqual(symbol.identifier.precise, symbolID, file: file, line: line)
@@ -3801,7 +3801,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    private func assertPathNotFound(_ path: String, in tree: PathHierarchy, file: StaticString = #file, line: UInt = #line) throws {
+    private func assertPathNotFound(_ path: String, in tree: PathHierarchy, file: StaticString = #filePath, line: UInt = #line) throws {
         do {
             let symbol = try tree.findSymbol(path: path)
             XCTFail("Unexpectedly found symbol with ID \(symbol.identifier.precise) for path \(path.singleQuoted)", file: file, line: line)
@@ -3817,7 +3817,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    private func assertPathCollision(_ path: String, in tree: PathHierarchy, collisions expectedCollisions: [(symbolID: String, disambiguation: String)], file: StaticString = #file, line: UInt = #line) throws {
+    private func assertPathCollision(_ path: String, in tree: PathHierarchy, collisions expectedCollisions: [(symbolID: String, disambiguation: String)], file: StaticString = #filePath, line: UInt = #line) throws {
         do {
             let symbol = try tree.findSymbol(path: path)
             XCTFail("Unexpectedly found unambiguous symbol with ID \(symbol.identifier.precise) for path \(path.singleQuoted)", file: file, line: line)
@@ -3846,7 +3846,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    private func assertPathRaisesErrorMessage(_ path: String, in tree: PathHierarchy, context: DocumentationContext, expectedErrorMessage: String, file: StaticString = #file, line: UInt = #line, _ additionalAssertion: (TopicReferenceResolutionErrorInfo) -> Void = { _ in }) throws {
+    private func assertPathRaisesErrorMessage(_ path: String, in tree: PathHierarchy, context: DocumentationContext, expectedErrorMessage: String, file: StaticString = #filePath, line: UInt = #line, _ additionalAssertion: (TopicReferenceResolutionErrorInfo) -> Void = { _ in }) throws {
         XCTAssertThrowsError(try tree.findSymbol(path: path), "Finding path \(path) didn't raise an error.",file: file,line: line) { untypedError in
             let error = untypedError as! PathHierarchy.Error
             let referenceError = error.makeTopicReferenceResolutionErrorInfo() { context.linkResolver.localResolver.fullName(of: $0, in: context) }
@@ -3855,7 +3855,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    private func assertParsedPathComponents(_ path: String, _ expected: [(String, PathHierarchy.PathComponent.Disambiguation?)], file: StaticString = #file, line: UInt = #line) {
+    private func assertParsedPathComponents(_ path: String, _ expected: [(String, PathHierarchy.PathComponent.Disambiguation?)], file: StaticString = #filePath, line: UInt = #line) {
         let (actual, _) = PathHierarchy.PathParser.parse(path: path)
         XCTAssertEqual(actual.count, expected.count, "Incorrect number of path components for \(path.singleQuoted)", file: file, line: line)
         for (actualComponents, expectedComponents) in zip(actual, expected) {

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -624,7 +624,7 @@ class ReferenceResolverTests: XCTestCase {
             _ symbol2: Symbol,
             keyPath: KeyPath<Symbol, DocumentationDataVariants<Variant>>,
             assertion: (Variant, Variant) -> (),
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) {
             let variants1Values = symbol1[keyPath: keyPath].allValues
@@ -651,7 +651,7 @@ class ReferenceResolverTests: XCTestCase {
         func populateObjCVariantAndCreateAssertion<Variant>(
             keyPath: ReferenceWritableKeyPath<Symbol, DocumentationDataVariants<Variant>>,
             assertion: @escaping (Variant, Variant) -> (),
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) -> ((_ resolvedSymbol: Symbol) -> Void) {
             symbol[keyPath: keyPath][.objectiveC] = symbol[keyPath: keyPath].firstValue
@@ -676,7 +676,7 @@ class ReferenceResolverTests: XCTestCase {
         func populateObjCVariantAndCreateAssertion<Variant: Equatable>(
             keyPath: ReferenceWritableKeyPath<Symbol, DocumentationDataVariants<Variant>>,
             assertion: @escaping (Variant, Variant) -> () = { XCTAssertEqual($0, $1, file: #file, line: #line) },
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) -> ((_ resolvedSymbol: Symbol) -> Void) {
             populateObjCVariantAndCreateAssertion(keyPath: keyPath, assertion: assertion)

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
@@ -17,7 +17,7 @@ class LinkCompletionToolsTests: XCTestCase {
         func assertParsing(
             _ linkString: String,
             equal expected: [(name: String, disambiguation: LinkCompletionTools.ParsedDisambiguation)],
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) {
             let got = LinkCompletionTools.parse(linkString: linkString)

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
@@ -137,7 +137,7 @@ class SymbolBreadcrumbTests: XCTestCase {
         _ reference: ResolvedTopicReference,
         _ context: DocumentationContext,
         _ bundle: DocumentationBundle,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         var hierarchyTranslator = RenderHierarchyTranslator(context: context, bundle: bundle)
@@ -151,7 +151,7 @@ class SymbolBreadcrumbTests: XCTestCase {
         _ reference: ResolvedTopicReference,
         _ context: DocumentationContext,
         _ bundle: DocumentationBundle,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         var hierarchyTranslator = RenderHierarchyTranslator(context: context, bundle: bundle)

--- a/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
+++ b/Tests/SwiftDocCTests/Model/DocumentationMarkupTests.swift
@@ -204,20 +204,20 @@ class DocumentationMarkupTests: XCTestCase {
 
     func testCertainDirectivesAreRemovedFromContent() throws {
 
-        func checkSectionContent(expectedContent: String?, section: Section?, file: StaticString = #file, line: UInt = #line) {
+        func checkSectionContent(expectedContent: String?, section: Section?, file: StaticString = #filePath, line: UInt = #line) {
             if let desc = section?.content.map({ $0.detachedFromParent.debugDescription() }).joined(separator: "\n") {
                 XCTAssertEqual(expectedContent, desc, "Found unexpected content: \n\(desc)", file: file, line: line)
             }
         }
 
 
-        func checkAbstractAndDiscussion(source: String, expectedAbstract: String, expectedDiscussion: String, file: StaticString = #file, line: UInt = #line) {
+        func checkAbstractAndDiscussion(source: String, expectedAbstract: String, expectedDiscussion: String, file: StaticString = #filePath, line: UInt = #line) {
             let model = DocumentationMarkup(markup: Document(parsing: source, options: .parseBlockDirectives))
             checkSectionContent(expectedContent: expectedAbstract, section: model.abstractSection, file: file, line: line)
             checkSectionContent(expectedContent: expectedDiscussion, section: model.discussionSection, file: file, line: line)
         }
 
-        func checkDirectiveIsRemoved(_ directiveSource: String, file: StaticString = #file, line: UInt = #line) {
+        func checkDirectiveIsRemoved(_ directiveSource: String, file: StaticString = #filePath, line: UInt = #line) {
             let expectedAbstract = """
                                    Text "My abstract "
                                    Strong

--- a/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
@@ -911,7 +911,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         docCommentModuleName: String? = "ModuleName",
         parameters: [(name: String, externalName: String?)],
         returnValue: SymbolGraph.Symbol.DeclarationFragments.Fragment,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> String {
         let fileSystem = try TestFileSystem(folders: [

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -333,7 +333,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         _ differences: JSONPatchDifferences,
         contains expectedDiff: JSONPatchOperation,
         valueType: Value.Type,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         guard let foundDiff = differences.first(where: { $0.pointer == expectedDiff.pointer &&

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -297,7 +297,7 @@ class RenderNodeSerializationTests: XCTestCase {
     
     // MARK: - Utility functions
 
-    func checkRoundTrip(_ inputNode: RenderNode, file: StaticString = #file, line: UInt = #line) {
+    func checkRoundTrip(_ inputNode: RenderNode, file: StaticString = #filePath, line: UInt = #line) {
         // Make sure we're not using a shared encoder
         let testEncoder = JSONEncoder()
         let testDecoder = JSONDecoder()

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1840,7 +1840,7 @@ Document
         Asserts if `expectedRoleHeading` does not match the parsed render node's `roleHeading` after it's parsed.
         Uses 'TestBundle's documentation as a base for compiling, overwriting 'article2' with `content`.
     */
-    private func assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: String?, content: String, file: StaticString = #file, line: UInt = #line) throws {
+    private func assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: String?, content: String, file: StaticString = #filePath, line: UInt = #line) throws {
         let renderNode = try renderNodeForArticleInTestBundle(content: content)
         XCTAssertEqual(expectedRoleHeading, renderNode.metadata.roleHeading, file: (file), line: line)
     }
@@ -1926,7 +1926,7 @@ Document
     }
     
     func testRendersBetaViolators() throws {
-        func makeTestBundle(currentPlatforms: [String : PlatformVersion]?, file: StaticString = #file, line: UInt = #line, referencePath: String) throws -> (DocumentationBundle, DocumentationContext, ResolvedTopicReference) {
+        func makeTestBundle(currentPlatforms: [String : PlatformVersion]?, file: StaticString = #filePath, line: UInt = #line, referencePath: String) throws -> (DocumentationBundle, DocumentationContext, ResolvedTopicReference) {
             var configuration = DocumentationContext.Configuration()
             // Add missing platforms if their fallback platform is present.
             var currentPlatforms = currentPlatforms ?? [:]

--- a/Tests/SwiftDocCTests/Model/TaskGroupTests.swift
+++ b/Tests/SwiftDocCTests/Model/TaskGroupTests.swift
@@ -386,7 +386,7 @@ class TaskGroupTests: XCTestCase {
     }
     
     func testTopicContentOrder() throws {
-        func assertExpectedParsedTaskGroupContent(_ content: String, file: StaticString = #file, line: UInt = #line) throws {
+        func assertExpectedParsedTaskGroupContent(_ content: String, file: StaticString = #filePath, line: UInt = #line) throws {
             let document = Document(parsing: """
                 # Title
                 

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -121,7 +121,7 @@ class DefaultAvailabilityTests: XCTestCase {
         ])
     }
 
-    private func assertRenderedPlatformsFor(currentPlatforms: [String : PlatformVersion], equal expected: [String], file: StaticString = #file, line: UInt = #line) throws {
+    private func assertRenderedPlatformsFor(currentPlatforms: [String : PlatformVersion], equal expected: [String], file: StaticString = #filePath, line: UInt = #line) throws {
         var configuration = DocumentationContext.Configuration()
         configuration.externalMetadata.currentPlatforms = currentPlatforms
         

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -60,7 +60,7 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
         var lines: [String]
     }
 
-    private func codeListing(at index: Int, in renderSection: ContentRenderSection, file: StaticString = #file, line: UInt = #line) throws -> CodeListing {
+    private func codeListing(at index: Int, in renderSection: ContentRenderSection, file: StaticString = #filePath, line: UInt = #line) throws -> CodeListing {
         if case let .codeListing(l) = renderSection.content[index] {
             return CodeListing(language: l.syntax, lines: l.code)
         }

--- a/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
@@ -178,7 +178,7 @@ class PlistSymbolTests: XCTestCase {
 
 
 /// Ensures a given render node can be encoded and decode back without throwing.
-public func AssertRoundtrip(for renderNode: RenderNode, file: StaticString = #file, line: UInt = #line) {
+public func AssertRoundtrip(for renderNode: RenderNode, file: StaticString = #filePath, line: UInt = #line) {
     // Ensure roundtripping, so we encode the render node and decode it back.
     do {
         let roundtripData = try JSONEncoder().encode(renderNode)

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -836,7 +836,7 @@ class RenderNodeTranslatorTests: XCTestCase {
     func assertDefaultImplementationCollectionTitles(
         in renderNode: RenderNode,
         _ expectedTitles: [String],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         let defaultImplementationSection = try XCTUnwrap(

--- a/Tests/SwiftDocCTests/Rendering/RoundTripCoding.swift
+++ b/Tests/SwiftDocCTests/Rendering/RoundTripCoding.swift
@@ -17,7 +17,7 @@ import XCTest
 /// - Throws: An error if encoding or decoding of the given value failed.
 func assertRoundTripCoding<Value: Equatable>(
     _ value: Value,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) throws where Value: Codable {
     let encoder = JSONEncoder()
@@ -42,7 +42,7 @@ func assertRoundTripCoding<Value: Equatable>(
 func assertJSONRepresentation<Value: Decodable & Equatable>(
     _ value: Value,
     _ json: String,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) throws {
     let decoder = JSONDecoder()

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -414,7 +414,7 @@ class MetadataTests: XCTestCase {
     
     func parseMetadataFromSource(
         _ source: String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (problems: [String], metadata: Metadata) {
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1359,7 +1359,7 @@ class SymbolTests: XCTestCase {
         docCommentLineOffset: Int = 0,
         articleContent: String?,
         diagnosticEngineFilterLevel: DiagnosticSeverity = .warning,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (DocumentationNode, [Problem]) {
         let myFunctionUSR = "s:5MyKit0A5ClassC10myFunctionyyF"
@@ -1422,7 +1422,7 @@ class SymbolTests: XCTestCase {
     func makeDocumentationNodeSymbol(
         docComment: String,
         articleContent: String?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (Symbol, [Problem]) {
         let (node, problems) = try makeDocumentationNodeForSymbol(

--- a/Tests/SwiftDocCTests/Utility/NearMissTests.swift
+++ b/Tests/SwiftDocCTests/Utility/NearMissTests.swift
@@ -327,7 +327,7 @@ class NearMissTests: XCTestCase {
         against authored: String,
         expectedMatches: [String],
         acceptedMatches: [String] = [],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let matches = NearMiss.bestMatches(for: possibilities, against: authored)

--- a/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+AssertingTestData.swift
@@ -36,7 +36,7 @@ extension XCTestCase {
         referenceTitles expectedReferenceTitles: [String],
         referenceFragments expectedReferenceFragments: [String],
         failureMessage failureMessageForField: (_ field: String) -> String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertEqual(

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -61,7 +61,7 @@ extension XCTestCase {
         return (bundle, context)
     }
     
-    func testCatalogURL(named name: String, file: StaticString = #file, line: UInt = #line) throws -> URL {
+    func testCatalogURL(named name: String, file: StaticString = #filePath, line: UInt = #line) throws -> URL {
         try XCTUnwrap(
             Bundle.module.url(forResource: name, withExtension: "docc", subdirectory: "Test Bundles"),
             file: file, line: line
@@ -159,7 +159,7 @@ extension XCTestCase {
     func parseDirective<Directive: DirectiveConvertible>(
         _ directive: Directive.Type,
         content: () -> String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (problemIdentifiers: [String], directive: Directive?) {
         let (bundle, context) = try testBundleAndContext()
@@ -192,7 +192,7 @@ extension XCTestCase {
         _ directive: Directive.Type,
         catalog: Folder,
         content: () -> String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (
         renderBlockContent: [RenderBlockContent],
@@ -208,7 +208,7 @@ extension XCTestCase {
         _ directive: Directive.Type,
         in bundleName: String? = nil,
         content: () -> String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (renderBlockContent: [RenderBlockContent], problemIdentifiers: [String], directive: Directive?) {
         let (renderedContent, problems, directive, _) = try parseDirective(
@@ -226,7 +226,7 @@ extension XCTestCase {
         _ directive: Directive.Type,
         in bundleName: String? = nil,
         content: () -> String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (
         renderBlockContent: [RenderBlockContent],
@@ -250,7 +250,7 @@ extension XCTestCase {
         bundle: DocumentationBundle,
         context: DocumentationContext,
         content: () -> String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (
         renderBlockContent: [RenderBlockContent],

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionTests.swift
@@ -1532,7 +1532,7 @@ class ConvertActionTests: XCTestCase {
             expectedCoverageInfoCount: Int,
             expectedCoverageFileExist: Bool,
             coverageOptions: DocumentationCoverageOptions,
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) async throws {
             let fileSystem = try TestFileSystem(folders: [bundle, Folder.emptyHTMLTemplateDirectory])

--- a/Tests/SwiftDocCUtilitiesTests/DirectoryMonitorTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/DirectoryMonitorTests.swift
@@ -29,7 +29,7 @@ class DirectoryMonitorTests: XCTestCase {
     
     /// Method that automates setting up a directory monitor, setting up the relevant expectations for a test,
     /// then executing a given trigger block and wait for the expectations to fullfill.
-    private func monitor(url rootURL: URL, forChangeAtURL expectedChangeOrigin: URL?, withDirectoryTreeReload isTreeReloadExpected: Bool, triggerBlock: () throws -> Void, file: StaticString = #file, line: UInt = #line) throws {
+    private func monitor(url rootURL: URL, forChangeAtURL expectedChangeOrigin: URL?, withDirectoryTreeReload isTreeReloadExpected: Bool, triggerBlock: () throws -> Void, file: StaticString = #filePath, line: UInt = #line) throws {
         // Creating a file will generate multiple fs events, we're interested in the fist one only
         // so we're using a Bool flag and a lock.
         let lock = NSLock()
@@ -89,7 +89,7 @@ class DirectoryMonitorTests: XCTestCase {
     }
     
     /// - Warning: Please do not overuse this method as it takes 10s of wait time and can potentially slow down running the test suite.
-    private func monitorNoUpdates(url: URL, testBlock: @escaping () throws -> Void, file: StaticString = #file, line: UInt = #line) throws {
+    private func monitorNoUpdates(url: URL, testBlock: @escaping () throws -> Void, file: StaticString = #filePath, line: UInt = #line) throws {
         let monitor = try DirectoryMonitor(root: url) { rootURL, url in
             XCTFail("Did produce file update event for a hidden file")
         }

--- a/Tests/SwiftDocCUtilitiesTests/EmitGeneratedCurationsActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/EmitGeneratedCurationsActionTests.swift
@@ -24,7 +24,7 @@ class EmitGeneratedCurationsActionTests: XCTestCase {
             depthLimit: Int?,
             startingPointSymbolLink: String?,
             expectedFilesList: [String],
-            file: StaticString = #file,
+            file: StaticString = #filePath,
             line: UInt = #line
         ) async throws {
             let fs = try TestFileSystem(folders: [

--- a/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
+++ b/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
@@ -27,7 +27,7 @@ protocol AssertableFile: File {
 
 extension AssertableFile {
     /// Asserts that a file exist a given URL.
-    func assertExist(at location: URL, fileManager: FileManagerProtocol = FileManager.default, file: StaticString = #file, line: UInt = #line) {
+    func assertExist(at location: URL, fileManager: FileManagerProtocol = FileManager.default, file: StaticString = #filePath, line: UInt = #line) {
         __assertExist(at: location, fileManager: fileManager, file: (file), line: line)
     }
 }
@@ -44,7 +44,7 @@ extension AssertableFile {
 // MARK: -
 
 extension Folder: AssertableFile {
-    func __assertExist(at location: URL, fileManager: FileManagerProtocol, file: StaticString = #file, line: UInt = #line) {
+    func __assertExist(at location: URL, fileManager: FileManagerProtocol, file: StaticString = #filePath, line: UInt = #line) {
         var isFolder: ObjCBool = false
         XCTAssert(fileManager.fileExists(atPath: location.path, isDirectory: &isFolder),
                   "Folder '\(name)' should exist at '\(location.path)'", file: (file), line: line)

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -429,7 +429,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         #endif
     }
     
-    func assertForwardsResolverErrors(resolver: OutOfProcessReferenceResolver, file: StaticString = #file, line: UInt = #line) throws {
+    func assertForwardsResolverErrors(resolver: OutOfProcessReferenceResolver, file: StaticString = #filePath, line: UInt = #line) throws {
         XCTAssertEqual(resolver.bundleID, "com.test.bundle", file: file, line: line)
         let resolverResult = resolver.resolve(.unresolved(UnresolvedTopicReference(topicURL: ValidatedURL(parsingExact: "doc://com.test.bundle/something")!)))
         guard case .failure(_, let error) = resolverResult else {
@@ -702,7 +702,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
     
     func assertSymbolBetaStatus(
         platforms: [OutOfProcessReferenceResolver.ResolvedInformation.PlatformAvailability], expectedStatus isBeta: Bool,
-        file: StaticString = #file, line: UInt = #line,
+        file: StaticString = #filePath, line: UInt = #line,
         makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver
     ) throws {
         let testMetadata = OutOfProcessReferenceResolver.ResolvedInformation(

--- a/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewActionIntegrationTests.swift
@@ -192,7 +192,7 @@ class PreviewActionIntegrationTests: XCTestCase {
         try await assert(bindPort: -1, expectedErrorMessage: "Can't start the preview server on port -1")
     }
     
-    func assert(bindPort: Int, expectedErrorMessage: String, file: StaticString = #file, line: UInt = #line) async throws {
+    func assert(bindPort: Int, expectedErrorMessage: String, file: StaticString = #filePath, line: UInt = #line) async throws {
         #if os(macOS)
         let (sourceURL, outputURL, templateURL) = try createPreviewSetup(source: createMinimalDocsBundle())
         defer {

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/RequestHandler/FileRequestHandlerTests.swift
@@ -21,7 +21,7 @@ import NIOHTTP1
 class FileRequestHandlerTests: XCTestCase {
     let fileIO = NonBlockingFileIO(threadPool: NIOThreadPool(numberOfThreads: 2))
 
-    private func verifyAsset(root: URL, path: String, body: String, type: String, file: StaticString = #file, line: UInt = #line) throws {
+    private func verifyAsset(root: URL, path: String, body: String, type: String, file: StaticString = #filePath, line: UInt = #line) throws {
         let request = makeRequestHead(uri: path)
         let factory = FileRequestHandler(rootURL: root)
         let response = try responseWithPipeline(request: request, handler: factory)

--- a/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
+++ b/Tests/SwiftDocCUtilitiesTests/PreviewServer/ServerTestUtils.swift
@@ -86,7 +86,7 @@ final class Response: ChannelOutboundHandler {
 }
 
 /// Builds up a local host server channel pipeline, fire the preset request and returns the response.
-func responseWithPipeline(request: HTTPRequestHead, handler factory: RequestHandlerFactory, file: StaticString = #file, line: UInt = #line) throws -> Response {
+func responseWithPipeline(request: HTTPRequestHead, handler factory: RequestHandlerFactory, file: StaticString = #filePath, line: UInt = #line) throws -> Response {
     let channel = EmbeddedChannel()
     let channelHandler = MockHandler(requestHead: request, requestHandler: factory)
 

--- a/Tests/SwiftDocCUtilitiesTests/XCTestCase+LoadingData.swift
+++ b/Tests/SwiftDocCUtilitiesTests/XCTestCase+LoadingData.swift
@@ -35,7 +35,7 @@ extension XCTestCase {
         return (bundle, context)
     }
     
-    func testCatalogURL(named name: String, file: StaticString = #file, line: UInt = #line) throws -> URL {
+    func testCatalogURL(named name: String, file: StaticString = #filePath, line: UInt = #line) throws -> URL {
         try XCTUnwrap(
             Bundle.module.url(forResource: name, withExtension: "docc", subdirectory: "Test Bundles"),
             file: file, line: line


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This opts in to the upcoming feature [SE-0274 (concise magic file name)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0274-magic-file.md). 

This feature is otherwise enabled in Swift 6:

> ### Source compatibility
> 
> [...]
>
> The change to the behavior of `#file` was deferred to the next major language version (Swift 6). However, it can be enabled with the [upcoming feature flag](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md) `ConciseMagicFile`.

By incrementally adopting certain features beforehand we can make the changes for a future update to Swift 6 smaller.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
