### PR TITLE
Adopt the upcoming feature SE-0409 (access-level modifiers on import declarations)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,8 @@ import class Foundation.ProcessInfo
 
 let swiftSettings: [SwiftSetting] = [
     .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=1000"], .when(configuration: .debug)),
+    
+    .enableUpcomingFeature("InternalImportsByDefault"), // SE-0409: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
 ]
 
 let package = Package(

--- a/Sources/SwiftDocC/Benchmark/Benchmark.swift
+++ b/Sources/SwiftDocC/Benchmark/Benchmark.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A logger that runs benchmarks and stores the results.
 public class Benchmark: Encodable {

--- a/Sources/SwiftDocC/Benchmark/BenchmarkResults.swift
+++ b/Sources/SwiftDocC/Benchmark/BenchmarkResults.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// The results of a single benchmark run.
 public struct BenchmarkResults: Codable {

--- a/Sources/SwiftDocC/Benchmark/Metrics/Duration.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/Duration.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 extension Benchmark {
     /// A duration metric in milliseconds.

--- a/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 extension Benchmark {
     /// Measures the total output size of a DocC archive.

--- a/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
+++ b/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import SymbolKit
 
 /// A type that writes the auto-generated curation into documentation extension files.

--- a/Sources/SwiftDocC/Checker/Checker.swift
+++ b/Sources/SwiftDocC/Checker/Checker.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /**
  A markup checker.

--- a/Sources/SwiftDocC/Checker/Checkers/AbstractContainsFormattedTextOnly.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/AbstractContainsFormattedTextOnly.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A document's abstract may only contain formatted text. Images and links are not allowed.

--- a/Sources/SwiftDocC/Checker/Checkers/DuplicateTopicsSection.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/DuplicateTopicsSection.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A `Document` may only have one level-2 "Topics" heading at the top level, since it serves as structured data for a documentation bundle's hierarchy.

--- a/Sources/SwiftDocC/Checker/Checkers/InvalidAdditionalTitle.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/InvalidAdditionalTitle.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A document should have a single title, i.e. a single first-level heading.

--- a/Sources/SwiftDocC/Checker/Checkers/MissingAbstract.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/MissingAbstract.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A document should have an abstract.

--- a/Sources/SwiftDocC/Checker/Checkers/NonInclusiveLanguageChecker.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/NonInclusiveLanguageChecker.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// Checks for non-inclusive language in documentation.
 ///

--- a/Sources/SwiftDocC/Checker/Checkers/NonOverviewHeadingChecker.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/NonOverviewHeadingChecker.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 public struct NonOverviewHeadingChecker: Checker {
     public var overviewHeading: Heading?

--- a/Sources/SwiftDocC/Checker/Checkers/SeeAlsoInTopicsHeadingChecker.swift
+++ b/Sources/SwiftDocC/Checker/Checkers/SeeAlsoInTopicsHeadingChecker.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 public struct SeeAlsoInTopicsHeadingChecker: Checker {
     public var seeAlsoInTopicsHeadings: [Heading] = []

--- a/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationContextConverter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A converter from documentation nodes to render nodes.
 ///

--- a/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
+++ b/Sources/SwiftDocC/Converter/DocumentationNodeConverter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A converter from documentation nodes to render nodes.
 public struct DocumentationNodeConverter {

--- a/Sources/SwiftDocC/Converter/RenderNode+Coding.swift
+++ b/Sources/SwiftDocC/Converter/RenderNode+Coding.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// An environmental variable to control the output formatting of the encoded render JSON.
 ///

--- a/Sources/SwiftDocC/Converter/Rewriter/RenderNodeTransformer.swift
+++ b/Sources/SwiftDocC/Converter/Rewriter/RenderNodeTransformer.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// An object that modifies a render node by applying transformations to it.
 open class RenderNodeTransformer {

--- a/Sources/SwiftDocC/Converter/TopicRenderReferenceEncoder.swift
+++ b/Sources/SwiftDocC/Converter/TopicRenderReferenceEncoder.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A thread-safe cache for encoded render references.
 public typealias RenderReferenceCache = Synchronized<[String: (reference: Data, overrides: [VariantOverride])]>

--- a/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/DocCSymbolRepresentable.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/DocCSymbolRepresentable.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 /// A type that can be converted to a DocC symbol.
 @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")

--- a/Sources/SwiftDocC/DocumentationService/DocumentationServer+createDefaultServer.swift
+++ b/Sources/SwiftDocC/DocumentationService/DocumentationServer+createDefaultServer.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 public extension DocumentationServer {
     /// Creates a server configured with default services.

--- a/Sources/SwiftDocC/DocumentationService/Models/DocumentationServer+Message.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/DocumentationServer+Message.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 public extension DocumentationServer {
     /// A message that can be provided to a documentation service.

--- a/Sources/SwiftDocC/DocumentationService/Models/DocumentationServer.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/DocumentationServer.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A server that provides documentation-related services.
 ///

--- a/Sources/SwiftDocC/DocumentationService/Models/DocumentationServerProtocol.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/DocumentationServerProtocol.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// Protocol for request-response based servers.
 public protocol DocumentationServerProtocol {

--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertRequest.swift
@@ -9,7 +9,7 @@
 */
 
 import SymbolKit
-import Foundation
+public import Foundation
 
 /// A request to convert in-memory documentation.
 public struct ConvertRequest: Codable {

--- a/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertResponse.swift
+++ b/Sources/SwiftDocC/DocumentationService/Models/Services/Convert/ConvertResponse.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A response for a successful documentation conversion.
 ///

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import Crypto
 
 /// A protocol to provide data to be indexed.

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorItem.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// Unpacks data as a `T` value
 /// - Note: To save space and avoid padding the data, we unpack data without requiring alignment.

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorTree.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorTree.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// Defines an object that can be represented as raw Data and therefore serialized to/deserialized from disk.
 public protocol Serializable: LMDBData, RawRepresentable where RawValue == Data {}

--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/BundleData.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/BundleData.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// The data associated with a documentation resource, for a specific trait collection.
 public struct BundleData {

--- a/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
+++ b/Sources/SwiftDocC/Infrastructure/Bundle Assets/DataAssetManager.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A container for a collection of data. Each data can have multiple variants.
 struct DataAssetManager {

--- a/Sources/SwiftDocC/Infrastructure/Communication/WebKitCommunicationBridge.swift
+++ b/Sources/SwiftDocC/Infrastructure/Communication/WebKitCommunicationBridge.swift
@@ -11,7 +11,7 @@
 // The WebKitCommunicationBridge is only available on platforms that support WebKit.
 #if canImport(WebKit)
 import Foundation
-import WebKit
+public import WebKit
 
 /// Provides bi-directional communication with a documentation renderer via JavaScript calls in a web view.
 public struct WebKitCommunicationBridge: CommunicationBridge {

--- a/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Context/DocumentationContext+Configuration.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import SymbolKit
 
 extension DocumentationContext {

--- a/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 #if canImport(os)
-import os
+package import os
 #endif
 
 package enum ConvertActionConverter {

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Diagnostic.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
-import SymbolKit
+public import Foundation
+public import Markdown
+public import SymbolKit
 
 /// A diagnostic explains a problem or issue that needs the end-user's attention.
 public struct Diagnostic {

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticConsoleWriter.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticConsoleWriter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import Markdown
 
 /// Writes diagnostic messages to a text output stream.

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticFileWriter.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticFileWriter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A diagnostic consumer that writes detailed diagnostic information to a file.
 ///

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticNote.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/DiagnosticNote.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A diagnostic note is a simple string message that should appear somewhere in a document.

--- a/Sources/SwiftDocC/Infrastructure/Diagnostics/Replacement.swift
+++ b/Sources/SwiftDocC/Infrastructure/Diagnostics/Replacement.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 import SymbolKit
 
 /**

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundle.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A collection of the build inputs for a unit of documentation.
 ///

--- a/Sources/SwiftDocC/Infrastructure/DocumentationBundleFileTypes.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationBundleFileTypes.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A collection of functions to check if a file is one of the documentation bundle files types.
 public enum DocumentationBundleFileTypes {

--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import Markdown
 import SymbolKit
 

--- a/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationConverter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A converter from a documentation bundle to an output that can be consumed by a renderer.
 ///

--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import Markdown
-import SymbolKit
+public import SymbolKit
 
 /// A reference resolver that launches and interactively communicates with another process or service to resolve links.
 ///

--- a/Sources/SwiftDocC/Infrastructure/Input Discovery/DataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Input Discovery/DataProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+package import Foundation
 
 /// A type that provides data for files.
 package protocol DataProvider {

--- a/Sources/SwiftDocC/Infrastructure/Input Discovery/DocumentationInputsProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Input Discovery/DocumentationInputsProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+package import Foundation
 import SymbolKit
 
 extension DocumentationContext {

--- a/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
+++ b/Sources/SwiftDocC/Infrastructure/NodeURLGenerator.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// Each path component can be a maximum of 255 characters on HFS+ and ext* file systems,
 /// but we set the limit to 240 to leave a convenient buffer for adding

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/AccessControl+Comparable.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/AccessControl+Comparable.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SymbolKit
+public import SymbolKit
 
 // Use fully-qualified types to silence a warning about retroactively conforming a type from another module to a new protocol (SE-0364).
 // The `@retroactive` attribute is new in the Swift 6 compiler. The backwards compatible syntax for a retroactive conformance is fully-qualified types.

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolReference.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 extension String {
     /// Returns a copy of the string with an appended hash of the given identifier.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationBundle+Info.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 extension DocumentationBundle {
     /// Information about a documentation bundle that's unrelated to its documentation content.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspace.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspace.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// The documentation workspace provides a unified interface for accessing serialized documentation bundles and their files, from a variety of sources.
 ///

--- a/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/DocumentationWorkspaceDataProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A type that vends bundles and responds to requests for data.
 @available(*, deprecated, message: "Pass the context its inputs at initialization instead. This deprecated API will be removed after 6.2 is released")

--- a/Sources/SwiftDocC/Infrastructure/Workspace/FileSystemProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/FileSystemProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A type that vends a tree of virtual filesystem objects.
 @available(*, deprecated, message: "Use 'FileManagerProtocol.recursiveFiles(startingPoint:)' instead. This deprecated API will be removed after 6.2 is released.")

--- a/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/GeneratedDataProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import SymbolKit
 
 /// A type that provides documentation bundles that it discovers by traversing the local file system.

--- a/Sources/SwiftDocC/Infrastructure/Workspace/LocalFileSystemDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/LocalFileSystemDataProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A type that provides documentation bundles that it discovers by traversing the local file system.
 @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released.")

--- a/Sources/SwiftDocC/Infrastructure/Workspace/PrebuiltLocalFileSystemDataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Workspace/PrebuiltLocalFileSystemDataProvider.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A data provider that provides existing in-memory documentation bundles with files on the local filesystem.
 @available(*, deprecated, message: "Use 'DocumentationContext.InputProvider' instead. This deprecated API will be removed after 6.2 is released")

--- a/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
+++ b/Sources/SwiftDocC/LinkTargets/LinkDestinationSummary.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import Markdown
 import SymbolKit
 

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -9,8 +9,8 @@
 */
 
 import Foundation
-import Markdown
-import SymbolKit
+public import Markdown
+public import SymbolKit
 
 /// A documentation node holds all the information about a documentation entity's content.
 ///

--- a/Sources/SwiftDocC/Model/Identifier.swift
+++ b/Sources/SwiftDocC/Model/Identifier.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import SymbolKit
-import Markdown
+public import Markdown
 
 /// A resolved or unresolved reference to a piece of documentation.
 ///

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A block content element.
 ///

--- a/Sources/SwiftDocC/Model/Rendering/PresentationURLGenerator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/PresentationURLGenerator.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import SymbolKit
 
 /// A type that generates URLs that you use to link to rendered pages.

--- a/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/FileReference.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A reference to a file resource.
 ///

--- a/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/ImageReference.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A reference to an image.
 public struct ImageReference: MediaReference, URLReference, Equatable {

--- a/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/RenderReference.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A reference to a resource.
 ///

--- a/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/References/VideoReference.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A reference to a video.
 public struct VideoReference: MediaReference, URLReference, Equatable {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// Arbitrary metadata for a render node.
 public struct RenderMetadata: VariantContainer {

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 import SymbolKit
 
 /// A visitor which converts a semantic model into a render node.

--- a/Sources/SwiftDocC/Model/Rendering/RenderReferenceStore.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderReferenceStore.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A storage for render reference information.
 ///

--- a/Sources/SwiftDocC/Model/Rendering/Symbol/MentionsRenderSection.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Symbol/MentionsRenderSection.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 public struct MentionsRenderSection: RenderSection, Codable, Equatable {
     public var kind: RenderSectionKind = .mentions

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/DownloadReference.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A reference to a resource that can be downloaded.
 public struct DownloadReference: RenderReference, URLReference, Equatable {

--- a/Sources/SwiftDocC/Model/Rendering/Tutorial/References/XcodeRequirementReference.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Tutorial/References/XcodeRequirementReference.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A reference to a version of Xcode that users of your documentation must use.
 public struct XcodeRequirementReference: RenderReference, Equatable {

--- a/Sources/SwiftDocC/Model/Rendering/Variants/JSONPatchApplier.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/JSONPatchApplier.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A utility type for applying JSON patches.
 ///

--- a/Sources/SwiftDocC/Model/Rendering/Variants/RenderNodeVariantOverridesApplier.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Variants/RenderNodeVariantOverridesApplier.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A utility type to apply variant overrides to an encoded render node.
 public struct RenderNodeVariantOverridesApplier {

--- a/Sources/SwiftDocC/Model/Section/Section.swift
+++ b/Sources/SwiftDocC/Model/Section/Section.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A structured piece of documentation content.
 public protocol Section {

--- a/Sources/SwiftDocC/Model/Section/Sections/Abstract.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/Abstract.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A one-paragraph section that represents a symbol's abstract description.
 public struct AbstractSection: Section {

--- a/Sources/SwiftDocC/Model/Section/Sections/DeprecatedSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/DeprecatedSection.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A section that contains deprecation information.
 public struct DeprecatedSection: Section {

--- a/Sources/SwiftDocC/Model/Section/Sections/Discussion.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/Discussion.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 public struct DiscussionSection: Section {
     public static var title: String? {

--- a/Sources/SwiftDocC/Model/Section/Sections/HTTPEndpointSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/HTTPEndpointSection.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SymbolKit
+public import SymbolKit
 
 /// A section that contains a request's endpoint.
 public struct HTTPEndpointSection {

--- a/Sources/SwiftDocC/Model/Section/Sections/PropertyListPossibleValuesSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/PropertyListPossibleValuesSection.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 import SymbolKit
 
 public struct PropertyListPossibleValuesSection {

--- a/Sources/SwiftDocC/Model/Section/Sections/ReturnsSection.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/ReturnsSection.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A section that contains return value information for a function.
 public struct ReturnsSection: Section {

--- a/Sources/SwiftDocC/Model/Section/Sections/SeeAlso.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/SeeAlso.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A section that contains groups of related symbols or external links.
 public struct SeeAlsoSection: GroupedSection {

--- a/Sources/SwiftDocC/Model/Section/Sections/Topics.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/Topics.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// Grouped source ranges.
 typealias GroupedLinkRanges = [[SourceRange?]]

--- a/Sources/SwiftDocC/Model/Semantics/DictionaryKey.swift
+++ b/Sources/SwiftDocC/Model/Semantics/DictionaryKey.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
-import SymbolKit
+public import Markdown
+public import SymbolKit
 
 /// Documentation about a dictionary key for a symbol.
 public struct DictionaryKey {

--- a/Sources/SwiftDocC/Model/Semantics/HTTPBody.swift
+++ b/Sources/SwiftDocC/Model/Semantics/HTTPBody.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
-import SymbolKit
+public import Markdown
+public import SymbolKit
 
 /// Documentation about the payload body of an HTTP request.
 public struct HTTPBody {

--- a/Sources/SwiftDocC/Model/Semantics/HTTPParameter.swift
+++ b/Sources/SwiftDocC/Model/Semantics/HTTPParameter.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
-import SymbolKit
+public import Markdown
+public import SymbolKit
 
 /// Documentation about a parameter for an HTTP request.
 public struct HTTPParameter {

--- a/Sources/SwiftDocC/Model/Semantics/HTTPResponse.swift
+++ b/Sources/SwiftDocC/Model/Semantics/HTTPResponse.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
-import SymbolKit
+public import Markdown
+public import SymbolKit
 
 /// Documentation about the response for an HTTP request symbol.
 public struct HTTPResponse {

--- a/Sources/SwiftDocC/Model/Semantics/LegacyTag.swift
+++ b/Sources/SwiftDocC/Model/Semantics/LegacyTag.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A generic documentation tag.
 ///

--- a/Sources/SwiftDocC/Model/Semantics/Parameter.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Parameter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// Documentation about a parameter for a symbol.
 public struct Parameter {

--- a/Sources/SwiftDocC/Model/Semantics/Return.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Return.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// Documentation about a symbol's return value.
 public struct Return {

--- a/Sources/SwiftDocC/Model/Semantics/Throw.swift
+++ b/Sources/SwiftDocC/Model/Semantics/Throw.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// Documentation about a symbol's potential errors.
 public struct Throw {

--- a/Sources/SwiftDocC/Model/TaskGroup.swift
+++ b/Sources/SwiftDocC/Model/TaskGroup.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /**
  A rewriter that extracts topic links for unordered list items.

--- a/Sources/SwiftDocC/Semantics/Article/Article.swift
+++ b/Sources/SwiftDocC/Semantics/Article/Article.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// The in-memory representation of an article.
 ///

--- a/Sources/SwiftDocC/Semantics/Article/MarkupConvertible.swift
+++ b/Sources/SwiftDocC/Semantics/Article/MarkupConvertible.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A type that can be initialized from markup.
 public protocol MarkupConvertible {

--- a/Sources/SwiftDocC/Semantics/Comment.swift
+++ b/Sources/SwiftDocC/Semantics/Comment.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A general purpose comment directive. All contents inside are stripped from

--- a/Sources/SwiftDocC/Semantics/ContentAndMedia.swift
+++ b/Sources/SwiftDocC/Semantics/ContentAndMedia.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A piece of media, such as an image or video, with an attached description.
 public final class ContentAndMedia: Semantic, DirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/DirectiveConvertable.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveConvertable.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A semantic object formed from a directive after a series of semantic analysis checks.

--- a/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveArgumentValueConvertible.swift
+++ b/Sources/SwiftDocC/Semantics/DirectiveInfrastructure/DirectiveArgumentValueConvertible.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 protocol DirectiveArgumentValueConvertible {
     /// Instantiates an instance of the conforming directive argument value type from a string representation.

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/Extract.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/Extract.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /**

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtLeastOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtLeastOne.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /**

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtMostOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasAtMostOne.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /**

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasContent.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasContent.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /**

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasExactlyOne.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasExactlyOne.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /**

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlyKnownArguments.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlyKnownArguments.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     public struct HasOnlyKnownArguments<Parent: Semantic & DirectiveConvertible> {

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlyKnownDirectives.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlyKnownDirectives.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /// Checks for any directives that are not valid as direct children of the parent directive.

--- a/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlySequentialHeadings.swift
+++ b/Sources/SwiftDocC/Semantics/General Purpose Analyses/HasOnlySequentialHeadings.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 extension Semantic.Analyses {
     /**

--- a/Sources/SwiftDocC/Semantics/Graph/SymbolKind.Swift.swift
+++ b/Sources/SwiftDocC/Semantics/Graph/SymbolKind.Swift.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 extension SymbolGraph.Symbol.KindIdentifier {
     /// The list of Swift-specific symbol kinds that could possibly have other symbols as children.

--- a/Sources/SwiftDocC/Semantics/Intro.swift
+++ b/Sources/SwiftDocC/Semantics/Intro.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /**
  An introductory section for instructional pages.

--- a/Sources/SwiftDocC/Semantics/Landmark.swift
+++ b/Sources/SwiftDocC/Semantics/Landmark.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A linkable point on a page.
 public protocol Landmark {

--- a/Sources/SwiftDocC/Semantics/MarkupContainer.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupContainer.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// A general purpose `Markup` semantic container.
 public final class MarkupContainer: Semantic {

--- a/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/ImageMedia.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A block filled with an image.
 public final class ImageMedia: Semantic, Media, AutomaticDirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
+++ b/Sources/SwiftDocC/Semantics/Media/VideoMedia.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A block filled with a video.
 public final class VideoMedia: Semantic, Media, AutomaticDirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 
 /// A directive that configures an alternate language representation of a symbol.

--- a/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Availability.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 extension Metadata {
     /// A directive that specifies when a documentation page is available for a given platform.

--- a/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CallToAction.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A directive that adds a prominent button or link to a page's header.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/CustomMetadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/CustomMetadata.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that accepts an arbitrary key/value pair and emits it into the metadata of the page
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/DisplayName.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/DisplayName.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that controls how the documentation-extension file overrides the symbol's display name.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/DocumentationExtension.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/DocumentationExtension.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// Defines whether the content in a documentation extension file amends or replaces in-source documentation.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that contains various metadata about a page.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageColor.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that specifies an accent color for a given documentation page.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageImage.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// Associates an image with a page.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/PageKind.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 extension Metadata {
     /// A directive that allows you to set a page's kind, which affects its default title heading and page icon.

--- a/Sources/SwiftDocC/Semantics/Metadata/SupportedLanguage.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/SupportedLanguage.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that controls what programming languages an article is available in.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/TechnologyRoot.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TechnologyRoot.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// Configures an article to become a top-level page.
 ///

--- a/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/TitleHeading.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive for customizing the text of a page's title heading.
 /// 

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticArticleSubheading.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticArticleSubheading.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that modifies Swift-DocC's default behavior for automatic subheading generation on
 /// article pages.

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticSeeAlso.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticSeeAlso.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive for specifying Swift-DocC's automatic behavior when generating a page's
 /// See Also section.

--- a/Sources/SwiftDocC/Semantics/Options/AutomaticTitleHeading.swift
+++ b/Sources/SwiftDocC/Semantics/Options/AutomaticTitleHeading.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive for specifying Swift-DocC's automatic behavior when generating a page's
 /// title heading.

--- a/Sources/SwiftDocC/Semantics/Options/Options.swift
+++ b/Sources/SwiftDocC/Semantics/Options/Options.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive to adjust Swift-DocC's default behaviors when rendering a page.
 ///

--- a/Sources/SwiftDocC/Semantics/Options/TopicsVisualStyle.swift
+++ b/Sources/SwiftDocC/Semantics/Options/TopicsVisualStyle.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive for specifying the style that should be used when rendering a page's
 /// Topics section.

--- a/Sources/SwiftDocC/Semantics/Redirect.swift
+++ b/Sources/SwiftDocC/Semantics/Redirect.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 
 /// A directive that specifies a previous URL for the page where the directive appears.

--- a/Sources/SwiftDocC/Semantics/Reference/Links.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Links.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive for authoring authoring embedded
 /// previews of documentation links (similar to how links are currently

--- a/Sources/SwiftDocC/Semantics/Reference/Row.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Row.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A container directive that arranges content into a grid-based row and column
 /// layout.

--- a/Sources/SwiftDocC/Semantics/Reference/Small.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/Small.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive for specifying small print text like legal, license, or copyright text that
 /// should be rendered in a smaller font size.

--- a/Sources/SwiftDocC/Semantics/Reference/TabNavigator.swift
+++ b/Sources/SwiftDocC/Semantics/Reference/TabNavigator.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A container directive that arranges content into a tab-based layout.
 ///

--- a/Sources/SwiftDocC/Semantics/SemanticAnalysis.swift
+++ b/Sources/SwiftDocC/Semantics/SemanticAnalysis.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A focused semantic analysis of a `BlockDirective`, recording problems and producing a result.

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 import SymbolKit
 
 public final class Snippet: Semantic, AutomaticDirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DeprecationSummary.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A directive that specifies a custom deprecation summary message to an already deprecated symbol.
 ///

--- a/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/DocumentationDataVariants.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 /// A model type that encapsulates variants of documentation node data.
 ///

--- a/Sources/SwiftDocC/Semantics/Symbol/Relationship.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Relationship.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 /// A relationship to a node in the topic graph.
 public enum Relationship {

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -9,8 +9,8 @@
 */
 
 import Foundation
-import Markdown
-import SymbolKit
+public import Markdown
+public import SymbolKit
 
 /// A programming symbol semantic type.
 ///

--- a/Sources/SwiftDocC/Semantics/Technology/Resources/Resources.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Resources/Resources.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// Additional resources that help users learn a technology.
 ///

--- a/Sources/SwiftDocC/Semantics/Technology/Resources/Tile.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Resources/Tile.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A semantic model for a view that links to a content type that you specify.
 ///

--- a/Sources/SwiftDocC/Semantics/Technology/TutorialTableOfContents.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/TutorialTableOfContents.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A top-level page that organizes a collection of tutorials into a hierarchy of volumes and chapters.
 ///

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/Chapter.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/Chapter.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A chapter containing ``Tutorial``s to complete.
 public final class Chapter: Semantic, AutomaticDirectiveConvertible, Abstracted, Redirected {

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/TutorialReference.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Chapter/TutorialReference.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A reference to a ``Tutorial`` or ``TutorialArticle`` by `URL`.
 public final class TutorialReference: Semantic, AutomaticDirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
+++ b/Sources/SwiftDocC/Semantics/Technology/Volume/Volume.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A grouping of chapters within a larger collection of tutorials.
 public final class Volume: Semantic, DirectiveConvertible, Abstracted, Redirected {

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Assessments.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Assessments.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A collection of questions about the concepts the documentation presents.
 public final class Assessments: Semantic, AutomaticDirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Choice.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Choice.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /**
  One of possibly many choices in a ``MultipleChoice`` question.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Justification.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/Choice/Justification.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /**
  A short justification as to whether a ``Choice`` is correct for a question.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/MultipleChoice.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Assessments/Multiple Choice/MultipleChoice.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// A multiple-choice question.
 ///

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Code.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
 A code file to display alongside a ``Step``.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Step.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Step.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  An instructional step to complete as a part of a ``TutorialSection``. ``DirectiveConvertible``

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Steps.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/Steps/Steps.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /// Wraps a series of ``Step``s in a tutorial task section.
 public final class Steps: Semantic, DirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tasks/TutorialSection.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tasks/TutorialSection.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  A section containing steps to complete to finish a ``Tutorial``.

--- a/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/Tutorial.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A tutorial to complete in order to gain knowledge of a technology.
 public final class Tutorial: Semantic, AutomaticDirectiveConvertible, Abstracted, Titled, Timed, Redirected {

--- a/Sources/SwiftDocC/Semantics/Tutorial/XcodeRequirement.swift
+++ b/Sources/SwiftDocC/Semantics/Tutorial/XcodeRequirement.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
  An informal Xcode requirement for completing an instructional ``Tutorial``.

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/Stack.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/Stack.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import Markdown
+public import Markdown
 
 /// A semantic model for a view that arranges its children in a row.
 public final class Stack: Semantic, AutomaticDirectiveConvertible {

--- a/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
+++ b/Sources/SwiftDocC/Semantics/TutorialArticle/TutorialArticle.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import Markdown
+public import Foundation
+public import Markdown
 
 /**
 An article alongside tutorial content, with the following structure:

--- a/Sources/SwiftDocC/Servers/DocumentationSchemeHandler.swift
+++ b/Sources/SwiftDocC/Servers/DocumentationSchemeHandler.swift
@@ -8,10 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 #if canImport(WebKit)
-import WebKit
+public import WebKit
+public import Foundation
 
 public class DocumentationSchemeHandler: NSObject {
     

--- a/Sources/SwiftDocC/Servers/FileServer.swift
+++ b/Sources/SwiftDocC/Servers/FileServer.swift
@@ -8,10 +8,10 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import SymbolKit
 #if canImport(FoundationNetworking)
-import FoundationNetworking
+public import FoundationNetworking
 #endif
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers

--- a/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
+++ b/Sources/SwiftDocC/SourceRepository/SourceRepository.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A remote repository that hosts source code.
 public struct SourceRepository {

--- a/Sources/SwiftDocC/Utility/Checksum.swift
+++ b/Sources/SwiftDocC/Utility/Checksum.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import Crypto
 
 /// A checksum generator.

--- a/Sources/SwiftDocC/Utility/Errors/DescribedError.swift
+++ b/Sources/SwiftDocC/Utility/Errors/DescribedError.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// An error that offers a plain-text error message.
 public protocol DescribedError: Foundation.LocalizedError {

--- a/Sources/SwiftDocC/Utility/FileManagerProtocol+FilesSequence.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol+FilesSequence.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+package import Foundation
 
 extension FileManagerProtocol {
     /// Returns a sequence of all the files in the directory structure from the starting point.

--- a/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+package import Foundation
 
 /// A read-write file manager.
 ///

--- a/Sources/SwiftDocC/Utility/LMDB/LMDB.swift
+++ b/Sources/SwiftDocC/Utility/LMDB/LMDB.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 import CLMDB
 
 /**

--- a/Sources/SwiftDocC/Utility/LogHandle.swift
+++ b/Sources/SwiftDocC/Utility/LogHandle.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// An object that writes logs to the given output device.
 ///

--- a/Sources/SwiftDocC/Utility/MarkupExtensions/AnyLink.swift
+++ b/Sources/SwiftDocC/Utility/MarkupExtensions/AnyLink.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Markdown
+public import Markdown
 
 /// Any kind of `Markdown.Markup` element that has a `destination` property.
 public protocol AnyLink: Markup {

--- a/Sources/SwiftDocC/Utility/RenderNodeDataExtractor.swift
+++ b/Sources/SwiftDocC/Utility/RenderNodeDataExtractor.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /**
  Extracts metadata from a render node.

--- a/Sources/SwiftDocC/Utility/SemanticVersion+Comparable.swift
+++ b/Sources/SwiftDocC/Utility/SemanticVersion+Comparable.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 // Use fully-qualified types to silence a warning about retroactively conforming a type from another module to a new protocol (SE-0364).
 // The `@retroactive` attribute is new in the Swift 6 compiler. The backwards compatible syntax for a retroactive conformance is fully-qualified types.

--- a/Sources/SwiftDocC/Utility/ValidatedURL.swift
+++ b/Sources/SwiftDocC/Utility/ValidatedURL.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// An RFC 3986 compliant URL.
 ///

--- a/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
+++ b/Sources/SwiftDocCTestUtilities/FilesAndFolders.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import XCTest
-import SwiftDocC
+public import Foundation
+public import XCTest
+public import SwiftDocC
 
 /*
     This file contains API for working with folder hierarchies, and is extensible to allow for testing

--- a/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
+++ b/Sources/SwiftDocCTestUtilities/SymbolGraphCreation.swift
@@ -10,9 +10,9 @@
 
 
 import Foundation
-import XCTest
-import SymbolKit
-import SwiftDocC
+public import XCTest
+package import SymbolKit
+package import SwiftDocC
 
 // MARK: - Symbol Graph objects
 

--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+package import Foundation
 import XCTest
 import SwiftDocC
 

--- a/Sources/SwiftDocCTestUtilities/XCTestCase+TemporaryDirectory.swift
+++ b/Sources/SwiftDocCTestUtilities/XCTestCase+TemporaryDirectory.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import XCTest
+public import Foundation
+public import XCTest
 
 // These helpers methods exist to put temp files for different test executions in different locations when running in Swift CI.
 

--- a/Sources/SwiftDocCUtilities/Action/Action.swift
+++ b/Sources/SwiftDocCUtilities/Action/Action.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SwiftDocC
+package import SwiftDocC
 
 /// An independent unit of work in the command-line workflow.
 ///

--- a/Sources/SwiftDocCUtilities/Action/ActionResult.swift
+++ b/Sources/SwiftDocCUtilities/Action/ActionResult.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SwiftDocC
-import Foundation
+public import SwiftDocC
+public import Foundation
 
 /// The result of executing an action.
 public struct ActionResult {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -8,10 +8,10 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+package import Foundation
 
 @_spi(ExternalLinks) // SPI to set `context.linkResolver.dependencyArchives`
-import SwiftDocC
+public import SwiftDocC
 
 /// An action that converts a source bundle into compiled documentation.
 public struct ConvertAction: AsyncAction {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/CoverageDataEntry+generateSummary.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import SwiftDocC
+public import Foundation
+public import SwiftDocC
 
 extension CoverageDataEntry {
     /// Outputs a short table summarizing the coverage statistics for a list of data entries in a file at the given URL.

--- a/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/CoverageAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SwiftDocC
+public import SwiftDocC
 
 /// An action that creates documentation coverage info for a documentation bundle.
 public struct CoverageAction: AsyncAction {

--- a/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/IndexAction.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import SwiftDocC
+public import Foundation
+public import SwiftDocC
 
 /// An action that creates an index of a documentation bundle.
 public struct IndexAction: AsyncAction {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Init/InitAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Init/InitAction.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import SwiftDocC
+public import Foundation
+public import SwiftDocC
 
 /// An action that generates a documentation catalog from a template seed.
 public struct InitAction: AsyncAction {

--- a/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/PreviewAction.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SwiftDocC
+public import SwiftDocC
 
 #if canImport(NIOHTTP1)
 /// A preview server instance.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/Action+performAndHandleResult.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SwiftDocC
+package import SwiftDocC
 import Foundation
 
 extension AsyncAction {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import SwiftDocC
-import Foundation
+package import SwiftDocC
+public import Foundation
 
 extension ConvertAction {
     /// Creates a convert action from the options in the given convert command.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/ActionExtensions/PreviewAction+CommandInitialization.swift
@@ -9,7 +9,7 @@
 */
 
 #if canImport(NIOHTTP1)
-import Foundation
+public import Foundation
 
 extension PreviewAction {
     /// Creates a preview action with the given preview options.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DirectoryPathOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DirectoryPathOption.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import ArgumentParser
+public import Foundation
+public import ArgumentParser
 
 /// A parsable argument for an optional directory path.
 ///

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationArchiveOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationArchiveOption.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
-import Foundation
+public import ArgumentParser
+public import Foundation
 
 /// Resolves and validates a URL value that provides the path to a documentation archive.
 public struct DocCArchiveOption: DirectoryPathOption {

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationBundleOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationBundleOption.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
-import Foundation
+public import ArgumentParser
+public import Foundation
 
 /// Resolves and validates a URL value that provides the path to a documentation catalog.
 ///

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationCoverageOptionsArgument.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/DocumentationCoverageOptionsArgument.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 import Foundation
-import SwiftDocC
+public import SwiftDocC
 
 /// Resolves and validates the arguments needed to enable the documentation coverage feature.
 ///

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/InitOptions.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/InitOptions.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
-import Foundation
+public import ArgumentParser
+public import Foundation
 
 /// Resolves and validates the arguments needed to run the init catalog actions.
 ///

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/OutOfProcessLinkResolverOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/OutOfProcessLinkResolverOption.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 import Foundation
 
 /// Resolves and validates a link resolve executable URL that points to a link resolver executable.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/PreviewOptions.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/PreviewOptions.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 import Foundation
 
 /// Resolves and validates the arguments needed to start a documentation preview server.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/Source Repository/SourceRepositoryArguments.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 import Foundation
 import SwiftDocC
 

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Options/TemplateOption.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Options/TemplateOption.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
-import Foundation
+public import ArgumentParser
+public import Foundation
 
 /// Resolves and validates a ``templateURL`` value that points to an HTML documentation template.
 ///

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Convert.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 import SwiftDocC
-import Foundation
+public import Foundation
 
 extension Docc {
     /// Converts documentation markup, assets, and symbol information into a documentation archive.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Index.swift
@@ -8,8 +8,8 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
-import Foundation
+public import ArgumentParser
+public import Foundation
 
 extension Docc {
     /// Indexes a documentation bundle.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Init.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Init.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 import Foundation
 import SwiftDocC
 

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Merge.swift
@@ -8,9 +8,9 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
-import SwiftDocC
-import Foundation
+public import ArgumentParser
+public import SwiftDocC
+public import Foundation
 
 extension Docc {
     /// Merge a list of documentation archives into a combined archive.

--- a/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
+++ b/Sources/SwiftDocCUtilities/ArgumentParsing/Subcommands/Preview.swift
@@ -9,7 +9,7 @@
 */
 
 #if canImport(NIOHTTP1)
-import ArgumentParser
+public import ArgumentParser
 import Foundation
 
 extension Docc {

--- a/Sources/SwiftDocCUtilities/Docc.swift
+++ b/Sources/SwiftDocCUtilities/Docc.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import ArgumentParser
+public import ArgumentParser
 
 private var subcommands: [AsyncParsableCommand.Type] {
     var subcommands: [AsyncParsableCommand.Type] = [

--- a/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities.md
+++ b/Sources/SwiftDocCUtilities/SwiftDocCUtilities.docc/SwiftDocCUtilities.md
@@ -9,7 +9,7 @@ SwiftDocCUtilities provides a default, command-line workflow for DocC, powered b
 Use SwiftDocCUtilities to build a custom, command-line interface and extend it with additional commands. To add a new sub-command called `example`, create a conformant ``Action`` type, `ExampleAction`, that performs the desired work, and add it as a sub-command. Optionally, you can also reuse any of the provided actions like ``ConvertAction``.
 
 ```swift
-import ArgumentParser
+public import ArgumentParser
 
 public struct MyDocumentationTool: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(

--- a/Sources/SwiftDocCUtilities/Utility/Throttle.swift
+++ b/Sources/SwiftDocCUtilities/Utility/Throttle.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+public import Foundation
 
 /// A task scheduler that throttles execution within a given time interval.
 ///

--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 @testable import SwiftDocC
 
 struct Directive {

--- a/Tests/SwiftDocCTests/Rendering/DiffAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DiffAvailabilityTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwiftDocC
 
-public class DiffAvailabilityTests: XCTestCase {
+class DiffAvailabilityTests: XCTestCase {
     func testDecode() throws {
         let json = """
         {

--- a/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import SwiftDocC
 import Markdown
 
-public class ExternalLinkTitleTests: XCTestCase {
+class ExternalLinkTitleTests: XCTestCase {
     private func getTranslatorAndBlockContentForMarkup(_ markupSource: String) throws -> (translator: RenderNodeTranslator, content: [RenderBlockContent]) {
         let document = Document(parsing: markupSource, options: [.parseBlockDirectives, .parseSymbolLinks])
         let testReference = ResolvedTopicReference(bundleID: "org.swift.docc", path: "/test", sourceLanguage: .swift)

--- a/Tests/SwiftDocCTests/Rendering/InlineContentPlainTextTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/InlineContentPlainTextTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import SwiftDocC
 
-public class InlineContentPlainTextTests: XCTestCase {
+class InlineContentPlainTextTests: XCTestCase {
     func testPlainTextFromCodeVoice() {
         let testText = "This text is code voiced."
         

--- a/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlistSymbolTests.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 import XCTest
-@testable import SwiftDocC
+@testable public import SwiftDocC
 import SwiftDocCTestUtilities
 
 class PlistSymbolTests: XCTestCase {

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 import XCTest
-@testable import SwiftDocC
+@testable public import SwiftDocC
 import Markdown
 
 class RowTests: XCTestCase {

--- a/Tests/SwiftDocCTests/Test Bundles/InheritedUnderCollision.docc/SwiftSources.txt
+++ b/Tests/SwiftDocCTests/Test Bundles/InheritedUnderCollision.docc/SwiftSources.txt
@@ -1,7 +1,7 @@
 // Before we have an automated way to regenerate the test bundles
 // let's keep the source in a text file alongside the extracted symbol graph.
 
-import Foundation
+public import Foundation
 
 protocol B {}
 

--- a/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
+++ b/Tests/SwiftDocCUtilitiesTests/FolderStructure.swift
@@ -11,7 +11,7 @@
 @testable import SwiftDocC
 @testable import SwiftDocCUtilities
 import XCTest
-import SwiftDocCTestUtilities
+public import SwiftDocCTestUtilities
 
 /*
  This file contains a test helper API for working with folder hierarchies, with the ability to:


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This opts in to the upcoming feature [SE-0409 (access-level modifiers on import declarations)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md).

By making imports internal by default we make it explicit when imported dependencies are visible to library clients.

By incrementally adopting certain features beforehand we can make the future changes for updates to future languages versions smaller.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
