### PR TITLE
Add solution to remove invalid metadata directives in documentation c…

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/Metadata.swift
@@ -224,18 +224,20 @@ public final class Metadata: Semantic, AutomaticDirectiveConvertible {
         
         problems.append(
             contentsOf: namesAndRanges.map { (name, range) in
-                Problem(
-                    diagnostic: Diagnostic(
-                        source: symbolSource,
-                        severity: .warning,
-                        range: range,
-                        identifier: "org.swift.docc.\(Metadata.directiveName).Invalid\(name)InDocumentationComment",
-                        summary: "Invalid use of \(name.singleQuoted) directive in documentation comment; configuration will be ignored",
-                        explanation: "Specify this configuration in a documentation extension file"
-                        
-                        // TODO: It would be nice to offer a solution here that removes the directive for you (#1111, rdar://140846407)
-                    )
+                let diagnostic = Diagnostic(
+                    source: symbolSource,
+                    severity: .warning,
+                    range: range,
+                    identifier: "org.swift.docc.\(Metadata.directiveName).Invalid\(name)InDocumentationComment",
+                    summary: "Invalid use of \(name.singleQuoted) directive in documentation comment; configuration will be ignored",
+                    explanation: "Specify this configuration in a documentation extension file"
                 )
+                
+                let solutions = range.map {
+                    [Solution(summary: "Remove this \(name.singleQuoted) directive.", replacements: [Replacement(range: $0, replacement: "")])]
+                } ?? []
+                
+                return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
             }
         )
         


### PR DESCRIPTION
Bug/issue #, if applicable: #1111

## Summary

This PR addresses issue #1111 by adding a solution to remove invalid metadata directives in documentation comments. When a user encounters a warning about an invalid metadata directive in a documentation comment, they will now see a solution that allows them to remove the directive with a single click, rather than having to manually edit the source code.

## Dependencies

None. This PR doesn't depend on any other changes.

## Testing

To test this functionality, you can use the following test content:

```swift
@Metadata {
    @DisplayName("Custom Name")
    @TechnologyRoot
}
```

Steps:
1. Add the test content to a documentation comment in your Swift code.
2. Build the documentation with DocC.
3. You should see warnings about invalid metadata directives in documentation comments.
4. Each warning should have a solution that allows you to remove the directive.
5. Click on the solution to remove the directive.

The test case `testInvalidMetadataDirectivesInDocumentationCommentHaveSolution` in `Tests/SwiftDocCTests/Semantics/MetadataTests.swift` verifies that:
- The correct number of problems are generated
- Each problem has a solution
- The solution has the correct summary and replacement

## Checklist

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded ()
- [x] Updated documentation if necessary (No documentation updates were needed for this change)
