### PR TITLE
Strip Leading Whitespace From Symbol Graph Doc Comments

### DIFF
--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -523,7 +523,10 @@ public struct DocumentationNode {
                 DocumentationChunk(source: .documentationExtension, markup: documentationExtensionMarkup)
             ]
         } else if let symbol = documentedSymbol, let docComment = symbol.docComment {
-            let docCommentString = docComment.lines.map { $0.text }.joined(separator: "\n")
+            let docCommentString = docComment.lines
+                                             .map(\.text)
+                                             .linesWithoutLeadingWhitespace()
+                                             .joined(separator: "\n")
 
             let docCommentLocation: SymbolGraph.Symbol.Location? = {
                 if let uri = docComment.uri, let position = docComment.lines.first?.range?.start {
@@ -847,5 +850,47 @@ private let directivesSupportedInDocumentationComments = [
 private extension BlockDirective {
     var isSupportedInDocumentationComment: Bool {
         directivesSupportedInDocumentationComments.contains(name)
+    }
+}
+
+extension [String] {
+
+    /// Strip the minimum leading whitespace from all the strings in this array, as follows:
+    /// - Find the line with least amount of leading whitespace. Ignore blank lines during this search.
+    /// - Remove that number of whitespace chars from all the lines (including blank lines).
+    /// - Returns: An array of strings with the minimum leading whitespace removed.
+    func linesWithoutLeadingWhitespace() -> [String] {
+
+        // Optimization: If the array of lines is empty then we return
+        guard !isEmpty else {
+            return self
+        }
+
+        // Optimization for the common case: If any of the lines do not start
+        // with whitespace, return the original lines.
+        for line in self {
+            if let firstChar = line.first, !firstChar.isWhitespace {
+                return self
+            }
+        }
+
+        /// - Count the leading whitespace characters in the given string.
+        /// - Returns: The count of leading whitespace characters, if the string is not blank,
+        ///     or `nil` if the string is empty or blank (contains only whitespace)
+        func leadingWhitespaceCount(_ line: String) -> Int? {
+            let count = line.prefix(while: \.isWhitespace).count
+            guard count < line.count else { return nil }
+            return count
+        }
+
+        // Find the minimum count of leading whitespace. If there are no
+        // leading whitespace counts (if all the lines were blank) then return
+        // the original lines.
+        guard let minimumWhitespaceCount = self.compactMap(leadingWhitespaceCount).min() else {
+            return self
+        }
+
+        // Drop the leading whitespace from all the lines.
+        return self.map { String($0.dropFirst(minimumWhitespaceCount)) }
     }
 }

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -868,10 +868,8 @@ extension [String] {
 
         // Optimization for the common case: If any of the lines do not start
         // with whitespace, return the original lines.
-        for line in self {
-            if let firstChar = line.first, !firstChar.isWhitespace {
-                return self
-            }
+        if contains(where: { $0.first?.isWhitespace == false }) {
+            return self
         }
 
         /// - Count the leading whitespace characters in the given string.

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -859,17 +859,12 @@ extension [String] {
     /// - Find the line with least amount of leading whitespace. Ignore blank lines during this search.
     /// - Remove that number of whitespace chars from all the lines (including blank lines).
     /// - Returns: An array of strings with the minimum leading whitespace removed.
-    func linesWithoutLeadingWhitespace() -> [String] {
-
-        // Optimization: If the array of lines is empty then we return
-        guard !isEmpty else {
-            return self
-        }
+    func linesWithoutLeadingWhitespace() -> [Substring] {
 
         // Optimization for the common case: If any of the lines do not start
         // with whitespace, return the original lines.
         if contains(where: { $0.first?.isWhitespace == false }) {
-            return self
+            return self.map{ .init($0) }
         }
 
         /// - Count the leading whitespace characters in the given string.
@@ -885,10 +880,10 @@ extension [String] {
         // leading whitespace counts (if all the lines were blank) then return
         // the original lines.
         guard let minimumWhitespaceCount = self.compactMap(leadingWhitespaceCount).min() else {
-            return self
+            return self.map{ .init($0) }
         }
 
         // Drop the leading whitespace from all the lines.
-        return self.map { String($0.dropFirst(minimumWhitespaceCount)) }
+        return self.map { $0.dropFirst(minimumWhitespaceCount) }
     }
 }

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -858,7 +858,7 @@ extension [String] {
     /// Strip the minimum leading whitespace from all the strings in this array, as follows:
     /// - Find the line with least amount of leading whitespace. Ignore blank lines during this search.
     /// - Remove that number of whitespace chars from all the lines (including blank lines).
-    /// - Returns: An array of strings with the minimum leading whitespace removed.
+    /// - Returns: An array of substrings of the original lines with the minimum leading whitespace removed.
     func linesWithoutLeadingWhitespace() -> [Substring] {
 
         // Optimization for the common case: If any of the lines does not start
@@ -879,12 +879,13 @@ extension [String] {
 
         // Find the minimum count of leading whitespace. If there are no
         // leading whitespace counts (if all the lines were blank) then return
-        // the original lines.
+        // the original lines as substrings.
         guard let minimumWhitespaceCount = self.compactMap(leadingWhitespaceCount).min() else {
             return self.map{ .init($0) }
         }
 
-        // Drop the leading whitespace from all the lines.
+        // Drop the leading whitespace from all the lines and return the
+        // modified lines as substrings of the original lines.
         return self.map { $0.dropFirst(minimumWhitespaceCount) }
     }
 }

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -861,9 +861,10 @@ extension [String] {
     /// - Returns: An array of strings with the minimum leading whitespace removed.
     func linesWithoutLeadingWhitespace() -> [Substring] {
 
-        // Optimization for the common case: If any of the lines do not start
-        // with whitespace, return the original lines.
-        if contains(where: { $0.first?.isWhitespace == false }) {
+        // Optimization for the common case: If any of the lines does not start
+        // with whitespace, or if there are no lines, then return the original lines
+        // as substrings.
+        if isEmpty || contains(where: { $0.first?.isWhitespace == false }) {
             return self.map{ .init($0) }
         }
 

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1352,6 +1352,158 @@ class SymbolTests: XCTestCase {
         XCTAssert(problems.isEmpty)
     }
 
+    // MARK: - Leading Whitespace in Doc Comments
+
+    func testWithoutLeadingWhitespace() {
+        let lines = [
+            "One",
+            "Two Words",
+            "With Trailing Whitespace "
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "One",
+            "Two Words",
+            "With Trailing Whitespace "
+        ]
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithLeadingWhitespace() {
+        let lines = [
+            "    One",
+            "    Two Words",
+            "    With Trailing Whitespace "
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "One",
+            "Two Words",
+            "With Trailing Whitespace "
+        ]
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithIncreasingLeadingWhitespace() {
+        let lines = [
+            " One",
+            "  Two Words",
+            "   With Trailing Whitespace "
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "One",
+            " Two Words",
+            "  With Trailing Whitespace "
+        ]
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithDecreasingLeadingWhitespace() {
+        let lines = [
+            "   One",
+            "  Two Words",
+            " With Trailing Whitespace "
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "  One",
+            " Two Words",
+            "With Trailing Whitespace "
+        ]
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithoutLeadingWhitespaceBlankLines() {
+        let lines = [
+            "    One",
+            "      ",
+            "    Two Words",
+            "    ",
+            "    With Trailing Whitespace "
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "One",
+            "  ",
+            "Two Words",
+            "",
+            "With Trailing Whitespace "
+        ]
+
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithoutLeadingWhitespaceEmptyLines() {
+        let lines = [
+            "    One",
+            "",
+            "    Two Words",
+            "",
+            "    With Trailing Whitespace "
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "One",
+            "",
+            "Two Words",
+            "",
+            "With Trailing Whitespace "
+        ]
+
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithoutLeadingWhitespaceAllEmpty() {
+        let lines = [
+            "",
+            "",
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "",
+            "",
+        ]
+
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithoutLeadingWhitespaceAllBlank() {
+        let lines = [
+            "   ",
+            "  ",
+        ]
+        let linesWithoutLeadingWhitespace = [
+            "   ",
+            "  ",
+        ]
+
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testWithoutLeadingWhitespaceEmpty() {
+        let lines = [String]()
+        let linesWithoutLeadingWhitespace = [String]()
+
+        XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
+    }
+
+    func testLeadingWhitespaceInDocComment() throws {
+        let (semanticWithLeadingWhitespace, problems) = try makeDocumentationNodeSymbol(
+            docComment: """
+                    This is an abstract.
+                     
+                    This is a multi-paragraph overview.
+                     
+                    It continues here.
+                """,
+            articleContent: nil
+        )
+        XCTAssert(problems.isEmpty)
+        XCTAssertEqual(semanticWithLeadingWhitespace.abstract?.format(), "This is an abstract.")
+        let lines = semanticWithLeadingWhitespace.discussion?.content.map{ $0.format() } ?? []
+        let expectedDiscussion = """
+            This is a multi-paragraph overview.
+            
+            It continues here.
+            """
+        XCTAssertEqual(lines.joined(), expectedDiscussion)
+    }
+
+
     // MARK: - Helpers
     
     func makeDocumentationNodeForSymbol(

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1360,7 +1360,7 @@ class SymbolTests: XCTestCase {
             "Two Words",
             "With Trailing Whitespace "
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "One",
             "Two Words",
             "With Trailing Whitespace "
@@ -1374,7 +1374,7 @@ class SymbolTests: XCTestCase {
             "    Two Words",
             "    With Trailing Whitespace "
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "One",
             "Two Words",
             "With Trailing Whitespace "
@@ -1388,7 +1388,7 @@ class SymbolTests: XCTestCase {
             "  Two Words",
             "   With Trailing Whitespace "
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "One",
             " Two Words",
             "  With Trailing Whitespace "
@@ -1402,7 +1402,7 @@ class SymbolTests: XCTestCase {
             "  Two Words",
             " With Trailing Whitespace "
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "  One",
             " Two Words",
             "With Trailing Whitespace "
@@ -1418,7 +1418,7 @@ class SymbolTests: XCTestCase {
             "    ",
             "    With Trailing Whitespace "
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "One",
             "  ",
             "Two Words",
@@ -1437,7 +1437,7 @@ class SymbolTests: XCTestCase {
             "",
             "    With Trailing Whitespace "
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "One",
             "",
             "Two Words",
@@ -1453,7 +1453,7 @@ class SymbolTests: XCTestCase {
             "",
             "",
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "",
             "",
         ]
@@ -1466,7 +1466,7 @@ class SymbolTests: XCTestCase {
             "   ",
             "  ",
         ]
-        let linesWithoutLeadingWhitespace = [
+        let linesWithoutLeadingWhitespace: [Substring] = [
             "   ",
             "  ",
         ]
@@ -1476,7 +1476,7 @@ class SymbolTests: XCTestCase {
 
     func testWithoutLeadingWhitespaceEmpty() {
         let lines = [String]()
-        let linesWithoutLeadingWhitespace = [String]()
+        let linesWithoutLeadingWhitespace = [Substring]()
 
         XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
     }


### PR DESCRIPTION
Bug/issue #, if applicable: 147354452

## Summary

This works around a Clang compiler issue with parsing Objective-C or C comments like this example that are missing the leading asterisk on each line:

```
/**
 Foo's brief description.

 Foo's discussion.
*/
```

...as opposed to this which Clang does parse properly:

```
/**
* Foo's brief description. *
*
* Foo's discussion. */
```

With the first example, Clang passes a doc comment to DocC that contains leading whitespace at the beginning of all the  lines. This, in turn, causes DocC to parse the comment (via Swift Markdown) as a code listing that includes both the abstract and discussion:

![Screenshot 2025-04-04 at 3 50 02 PM](https://github.com/user-attachments/assets/4b7c0de9-2ff0-4a07-b746-31902471cd17)

This change to `DocumentationNode` removes the leading whitespace, allowing Swift Markdown to parse the comment as simple text, separating the abstract and discussion:

![Screenshot 2025-04-04 at 3 52 14 PM](https://github.com/user-attachments/assets/c6551275-6389-4a1c-a227-539a8830b7ff)

The algorithm for removing leading whitespace finds the text line with the least amount of leading whitespace, skipping empty or blank lines, and removes that amount from all of the comment's lines.

## Dependencies

- None

## Testing

Create an Objective-C project that uses a doc comment like the first example above, with missing asterisks. Then build documentation using docc from the CLI or via Xcode and the DOCC_EXEC environment variable.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x ] Added tests
- [x ] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~
