### PR TITLE
[6.1.1] Include fix for DocC permissions issue when Swift toolchain is installed as root

### DIFF
--- a/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
+++ b/Sources/SwiftDocCTestUtilities/TestFileSystem.swift
@@ -160,7 +160,7 @@ package class TestFileSystem: FileManagerProtocol {
         return files.keys.contains(path)
     }
     
-    package func copyItem(at source: URL, to destination: URL) throws {
+    package func _copyItem(at source: URL, to destination: URL) throws {
         guard !disableWriting else { return }
         
         filesLock.lock()
@@ -185,7 +185,7 @@ package class TestFileSystem: FileManagerProtocol {
 
         let srcPath = srcURL.path
 
-        try copyItem(at: srcURL, to: dstURL)
+        try _copyItem(at: srcURL, to: dstURL)
         files.removeValue(forKey: srcPath)
         
         for (path, _) in files where path.hasPrefix(srcPath) {

--- a/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Action+MoveOutput.swift
@@ -26,7 +26,7 @@ extension AsyncAction {
             // If a template directory has been provided, create the temporary build folder with its contents
             // Ensure that the container exists
             try? fileManager.createDirectory(at: targetURL.deletingLastPathComponent(), withIntermediateDirectories: false, attributes: nil)
-            try fileManager.copyItem(at: template, to: targetURL)
+            try fileManager._copyItem(at: template, to: targetURL)
         } else {
             // Otherwise, create an empty directory
             try fileManager.createDirectory(at: targetURL, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -71,7 +71,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
         func copyAsset(_ asset: DataAsset, to destinationFolder: URL) throws {
             for sourceURL in asset.variants.values where !sourceURL.isAbsoluteWebURL {
                 let assetName = sourceURL.lastPathComponent
-                try fileManager.copyItem(
+                try fileManager._copyItem(
                     at: sourceURL,
                     to: destinationFolder.appendingPathComponent(assetName, isDirectory: false)
                 )
@@ -143,7 +143,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer {
             if fileManager.fileExists(atPath: targetFile.path) {
                 try fileManager.removeItem(at: targetFile)
             }
-            try fileManager.copyItem(at: themeSettings, to: targetFile)
+            try fileManager._copyItem(at: themeSettings, to: targetFile)
         }
     }
     

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -104,7 +104,7 @@ class JSONEncodingRenderNodeWriter {
         )
         
         do {
-            try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL)
+            try fileManager._copyItem(at: indexHTML, to: htmlTargetFileURL)
         } catch let error as NSError where error.code == NSFileWriteFileExistsError {
             // We already have an 'index.html' file at this path. This could be because
             // we're writing to an output directory that already contains built documentation
@@ -112,7 +112,7 @@ class JSONEncodingRenderNodeWriter {
             // have the same path on the filesystem. Either way, we don't want this to error out
             // so just remove the destination item and try the copy operation again.
             try fileManager.removeItem(at: htmlTargetFileURL)
-            try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL)
+            try fileManager._copyItem(at: indexHTML, to: htmlTargetFileURL)
         }
     }
 }

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
@@ -70,7 +70,7 @@ struct MergeAction: AsyncAction {
                 try? fileManager.createDirectory(at: toDirectory, withIntermediateDirectories: false, attributes: nil)
                 for from in (try? fileManager.contentsOfDirectory(at: fromDirectory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)) ?? [] {
                     // Copy each file or subdirectory
-                    try fileManager.copyItem(at: from, to: toDirectory.appendingPathComponent(from.lastPathComponent))
+                    try fileManager._copyItem(at: from, to: toDirectory.appendingPathComponent(from.lastPathComponent))
                 }
             }
             guard let jsonIndexData = fileManager.contents(atPath: archive.appendingPathComponent("index/index.json").path) else {
@@ -125,7 +125,7 @@ struct MergeAction: AsyncAction {
             contents: RenderJSONEncoder.makeEncoder().encode(renderNode)
         )
         // It's expected that this will fail if combined archive doesn't support static hosting.
-        try? fileManager.copyItem(
+        try? fileManager._copyItem(
             at: targetURL.appendingPathComponent("index.html"),
             to: targetURL.appendingPathComponent("/documentation/index.html")
         )

--- a/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/TransformForStaticHostingAction.swift
@@ -61,7 +61,7 @@ struct TransformForStaticHostingAction: AsyncAction {
             // as we want to preserve anything intentionally left in the output URL by `setupOutputDirectory`
             for sourceItem in try fileManager.contentsOfDirectory(at: rootURL, includingPropertiesForKeys: [], options:[.skipsHiddenFiles]) {
                 let targetItem = outputURL.appendingPathComponent(sourceItem.lastPathComponent)
-                try fileManager.copyItem(at: sourceItem, to: targetItem)
+                try fileManager._copyItem(at: sourceItem, to: targetItem)
             }
         }
 
@@ -81,7 +81,7 @@ struct TransformForStaticHostingAction: AsyncAction {
             if fileManager.fileExists(atPath: target.path){
                 try fileManager.removeItem(at: target)
             }
-            try fileManager.copyItem(at: source, to: target)
+            try fileManager._copyItem(at: source, to: target)
         }
         
         // Transform the indexHTML if needed.

--- a/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/Utility/TestFileSystemTests.swift
@@ -106,7 +106,7 @@ class TestFileSystemTests: XCTestCase {
     func testCopyFiles() throws {
         let fs = try makeTestFS()
         
-        try fs.copyItem(at: URL(string: "/main/nested/myfile1.txt")!, to: URL(string: "/main/myfile1.txt")!)
+        try fs._copyItem(at: URL(string: "/main/nested/myfile1.txt")!, to: URL(string: "/main/myfile1.txt")!)
         XCTAssertEqual(fs.dump(), """
         /
         ├─ main/
@@ -121,7 +121,7 @@ class TestFileSystemTests: XCTestCase {
     func testCopyFolders() throws {
         let fs = try makeTestFS()
         
-        try fs.copyItem(at: URL(string: "/main/nested")!, to: URL(string: "/copy")!)
+        try fs._copyItem(at: URL(string: "/main/nested")!, to: URL(string: "/copy")!)
         XCTAssertEqual(fs.dump(), """
         /
         ├─ copy/
@@ -286,7 +286,7 @@ class TestFileSystemTests: XCTestCase {
         XCTAssertEqual(fs.contents(atPath: "/main/test.txt"), Data(base64Encoded: "TEST"))
         
         // Copy a file and test the contents are identical with original
-        try fs.copyItem(at: URL(string: "/main/test.txt")!, to: URL(string: "/main/clone.txt")!)
+        try fs._copyItem(at: URL(string: "/main/test.txt")!, to: URL(string: "/main/clone.txt")!)
         XCTAssertTrue(fs.contentsEqual(atPath: "/main/test.txt", andPath: "/main/clone.txt"))
         
         _ = try fs.createFile(at: URL(string:"/main/notclone.txt")!, contents: Data(base64Encoded: "TESTTEST")!)


### PR DESCRIPTION
- **Explanation**: When Swift was installed as root to a location such as `/` or `/usr/libexec`, attempting to generate or preview documentation with `docc` would result in the error: `Error: Error Domain=NSCocoaErrorDomain Code=513 "You don’t have permission."`. This was cherry-picked from `swiftlang/swift-docc:main`.
- **Scope**: This is a small fix/workaround that is originally caused by a bug in Foundation that has not been fixed yet.
- **GitHub Issue**: https://github.com/swiftlang/swift-docc/issues/1136
- **Risk**: I forsee no risks with this fix.
- **Testing**: Manual testing was performed (https://github.com/swiftlang/swift-docc/pull/1169) along with some test cases added for this scenario.
- **Reviewer**: @d-ronnqvist @patshaughnessy 