### PR TITLE
update swift-markdown and swift-cmark for 6.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
-        "branch" : "gfm",
-        "revision" : "2c47322cb32cbed555f13bf5cbfaa488cc30a785"
+        "branch" : "release/6.2",
+        "revision" : "b97d09472e847a416629f026eceae0e2afcfad65"
       }
     },
     {
@@ -87,7 +87,7 @@
       "location" : "https://github.com/swiftlang/swift-markdown.git",
       "state" : {
         "branch" : "release/6.2",
-        "revision" : "e62a44fd1f2764ba8807db3b6f257627449bbb8c"
+        "revision" : "bc668ada42187e6c18eac420d66050a76d4ed764"
       }
     },
     {


### PR DESCRIPTION
https://github.com/swiftlang/swift-docc/pull/1196 was landed before Swift-Markdown was properly set up for 6.2. Now that https://github.com/swiftlang/swift-markdown/pull/219 is landed, this PR updates the Package.resolved file in Swift-DocC to correctly use the `release/6.2` branch for swift-cmark.