### PR TITLE
Avoid a crash when using external link support with certain unexpected inputs.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
@@ -37,9 +37,11 @@ extension PathHierarchy.FileRepresentation {
         }
         
         let nodes = [Node](unsafeUninitializedCapacity: lookup.count) { buffer, initializedCount in
-            for node in lookup.values {
+            for (identifier, node) in lookup {
+                assert(identifier == node.identifier, "Every node lookup should match a node with that identifier.")
+                
                 buffer.initializeElement(
-                    at: identifierMap[node.identifier]!,
+                    at: identifierMap[identifier]!,
                     to: Node(
                         name: node.name,
                         rawSpecialBehavior: node.specialBehaviors.rawValue,


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://148504975

## Summary

This avoids a crash by accessing the identifier that the path hierarchy internally uses as a key rather than the identifier that's saved on the node. These should always be equal but some unexpected input can cause the node to have a different identifier than what the path hierarchy uses to find that node. The root cause of that issue still remains. This only avoids a crash that arises as a symptoms of the real issue.

## Dependencies

None.

## Testing

Because the root cause of this issue is still unknown, I can't provide better testing instructions than:

- Run `docc convert --enable-experimental-external-link-support` with some project that currently reproduces this crash.

## Checklist

It's not possible to write an automated test for this change because any inputs necessary to create a path hierarchy where a node has a different identifier than the key in the lookup would fail to construct due to [this assertion][1]:

```swift
assert(
    lookup.allSatisfy({ $0.key == $0.value.identifier }),
    "Every node lookup should match a node with that identifier."
)
```

[1]: https://github.com/swiftlang/swift-docc/blob/main/Sources/SwiftDocC/Infrastructure/Link%20Resolution/PathHierarchy.swift#L384-L387

- ~[ ] Added tests~ See above. 
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ Not applicable
