### PR TITLE
clone path hierarchy nodes when their parent has a language-specific counterpart

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -148,9 +148,9 @@ struct PathHierarchy {
                 // would require that we redundantly create multiple nodes for the same symbol in many common cases and then merge them. To avoid doing that, we instead check
                 // the source symbol's path components to find the correct target symbol by matching its name.
                 if let targetNode = nodes[relationship.target], targetNode.name == expectedContainerName {
-                    if sourceNode.parent == nil || sourceNode.parent === targetNode {
+                    if sourceNode.parent == nil {
                         targetNode.add(symbolChild: sourceNode)
-                    } else {
+                    } else if sourceNode.parent !== targetNode {
                         // If the node we have for the child has an existing parent that doesn't
                         // match the parent from this symbol graph, we need to clone the child to
                         // ensure that the hierarchy remains consistent.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -148,7 +148,48 @@ struct PathHierarchy {
                 // would require that we redundantly create multiple nodes for the same symbol in many common cases and then merge them. To avoid doing that, we instead check
                 // the source symbol's path components to find the correct target symbol by matching its name.
                 if let targetNode = nodes[relationship.target], targetNode.name == expectedContainerName {
-                    targetNode.add(symbolChild: sourceNode)
+                    if sourceNode.parent == nil || sourceNode.parent === targetNode {
+                        targetNode.add(symbolChild: sourceNode)
+                    } else {
+                        // If the node we have for the child has an existing parent that doesn't
+                        // match the parent from this symbol graph, we need to clone the child to
+                        // ensure that the hierarchy remains consistent.
+                        let clonedSourceNode = Node(cloning: sourceNode, children: [:])
+
+                        // Because we're creating a new node to represent this language's counterpart symbol,
+                        // clean up the languages sets for the original and clone node.
+                        sourceNode.languages.remove(language!)
+                        clonedSourceNode.languages = .init([language!])
+
+                        // Also make sure that the symbol data is updated with this graph's symbol.
+                        clonedSourceNode.symbol = graph.symbols[relationship.source]
+
+                        // Make sure that the clone's children can all line up with symbols from this symbol graph.
+                        for (childName, children) in sourceNode.children {
+                            for child in children.storage {
+                                guard let childSymbol = child.node.symbol else {
+                                    // We shouldn't come across any non-symbol nodes here,
+                                    // but assume they can work as child of both variants.
+                                    clonedSourceNode.add(child: child.node, kind: child.kind, hash: child.hash)
+                                    continue
+                                }
+                                if nodes[childSymbol.identifier.precise] === child.node {
+                                    clonedSourceNode.add(symbolChild: child.node)
+                                }
+                            }
+                        }
+
+                        nodes[relationship.source] = clonedSourceNode
+                        if let existingNodes = allNodes[relationship.source] {
+                            clonedSourceNode.counterpart = existingNodes.first
+                            for other in existingNodes {
+                                other.counterpart = clonedSourceNode
+                            }
+                        }
+                        allNodes[relationship.source, default: []].append(clonedSourceNode)
+
+                        targetNode.add(symbolChild: clonedSourceNode)
+                    }
                     topLevelCandidates.removeValue(forKey: relationship.source)
                 } else if var targetNodes = allNodes[relationship.target] {
                     // If the source was added in an extension symbol graph file, then its target won't be found in the same symbol graph file (in `nodes`).
@@ -532,7 +573,19 @@ extension PathHierarchy {
             self.children = [:]
             self.specialBehaviors = []
         }
-        
+
+        /// Initializes a node with a new identifier but the data from an existing node.
+        fileprivate init(
+            cloning source: Node,
+            children: [String: DisambiguationContainer]? = nil
+        ) {
+            self.symbol = source.symbol
+            self.name = source.name
+            self.children = children ?? source.children
+            self.specialBehaviors = source.specialBehaviors
+            self.languages = source.languages
+        }
+
         /// Adds a descendant to this node, providing disambiguation information from the node's symbol.
         fileprivate func add(symbolChild: Node) {
             precondition(symbolChild.symbol != nil)
@@ -558,6 +611,8 @@ extension PathHierarchy {
                 )
                 return
             }
+
+            assert(child.parent == nil, "Nodes that already have a parent should not be added to a different parent.")
             // If the name was passed explicitly, then the node could have spaces in its name
             child.parent = self
             children[child.name, default: .init()].add(child, kind: kind, hash: hash, parameterTypes: parameterTypes, returnTypes: returnTypes)

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -2629,7 +2629,85 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[containerID], "/ModuleName/ContainerName")
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/memberName") // The Swift spelling is preferred
     }
-    
+
+    func testLanguageRepresentationsWithDifferentParentKinds() throws {
+        enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
+
+        let containerID = "some-container-symbol-id"
+        let memberID = "some-member-symbol-id"
+
+        let catalog = Folder(name: "unit-test.docc", content: [
+            Folder(name: "clang", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    symbols: [
+                        makeSymbol(id: containerID, language: .objectiveC, kind: .union, pathComponents: ["ContainerName"]),
+                        makeSymbol(id: memberID, language: .objectiveC, kind: .property, pathComponents: ["ContainerName", "MemberName"]),
+                    ],
+                    relationships: [
+                        .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
+                    ]
+                )),
+            ]),
+
+            Folder(name: "swift", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    symbols: [
+                        makeSymbol(id: containerID, kind: .struct, pathComponents: ["ContainerName"]),
+                        makeSymbol(id: memberID, kind: .property, pathComponents: ["ContainerName", "MemberName"]),
+                    ],
+                    relationships: [
+                        .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
+                    ]
+                )),
+            ])
+        ])
+
+        let (_, context) = try loadBundle(catalog: catalog)
+        let tree = context.linkResolver.localResolver.pathHierarchy
+
+        let resolvedSwiftContainerID = try tree.find(path: "/ModuleName/ContainerName-struct", onlyFindSymbols: true)
+        let resolvedSwiftContainer = try XCTUnwrap(tree.lookup[resolvedSwiftContainerID])
+        XCTAssertEqual(resolvedSwiftContainer.name, "ContainerName")
+        XCTAssertEqual(resolvedSwiftContainer.symbol?.identifier.precise, containerID)
+        XCTAssertEqual(resolvedSwiftContainer.symbol?.kind.identifier, .struct)
+        XCTAssertEqual(resolvedSwiftContainer.languages, [.swift])
+
+        let resolvedObjcContainerID = try tree.find(path: "/ModuleName/ContainerName-union", onlyFindSymbols: true)
+        let resolvedObjcContainer = try XCTUnwrap(tree.lookup[resolvedObjcContainerID])
+        XCTAssertEqual(resolvedObjcContainer.name, "ContainerName")
+        XCTAssertEqual(resolvedObjcContainer.symbol?.identifier.precise, containerID)
+        XCTAssertEqual(resolvedObjcContainer.symbol?.kind.identifier, .union)
+        XCTAssertEqual(resolvedObjcContainer.languages, [.objectiveC])
+
+        let resolvedContainerID = try tree.find(path: "/ModuleName/ContainerName", onlyFindSymbols: true)
+        XCTAssertEqual(resolvedContainerID, resolvedSwiftContainerID)
+
+        let resolvedSwiftMemberID = try tree.find(path: "/ModuleName/ContainerName-struct/MemberName", onlyFindSymbols: true)
+        let resolvedSwiftMember = try XCTUnwrap(tree.lookup[resolvedSwiftMemberID])
+        XCTAssertEqual(resolvedSwiftMember.name, "MemberName")
+        XCTAssertEqual(resolvedSwiftMember.parent?.identifier, resolvedSwiftContainerID)
+        XCTAssertEqual(resolvedSwiftMember.symbol?.identifier.precise, memberID)
+        XCTAssertEqual(resolvedSwiftMember.symbol?.kind.identifier, .property)
+        XCTAssertEqual(resolvedSwiftMember.languages, [.swift])
+
+        let resolvedObjcMemberID = try tree.find(path: "/ModuleName/ContainerName-union/MemberName", onlyFindSymbols: true)
+        let resolvedObjcMember = try XCTUnwrap(tree.lookup[resolvedObjcMemberID])
+        XCTAssertEqual(resolvedObjcMember.name, "MemberName")
+        XCTAssertEqual(resolvedObjcMember.parent?.identifier, resolvedObjcContainerID)
+        XCTAssertEqual(resolvedObjcMember.symbol?.identifier.precise, memberID)
+        XCTAssertEqual(resolvedObjcMember.symbol?.kind.identifier, .property)
+        XCTAssertEqual(resolvedObjcMember.languages, [.objectiveC])
+
+        let resolvedMemberID = try tree.find(path: "/ModuleName/ContainerName/MemberName", onlyFindSymbols: true)
+        XCTAssertEqual(resolvedMemberID, resolvedSwiftMemberID)
+
+        let paths = tree.caseInsensitiveDisambiguatedPaths()
+        XCTAssertEqual(paths[containerID], "/ModuleName/ContainerName")
+        XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/MemberName")
+    }
+
     func testMixedLanguageSymbolAndItsExtendingModuleWithDifferentContainerNames() throws {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://144862231

## Summary

When C unions are imported into Swift, they are converted into structs with computed properties to preserve union semantics. That means that the same symbol has different symbol kinds depending on the source language. This causes problems for the path hierarchy when associating those fields/properties with their parent, since there are now two separate hierarchy nodes that they could be associated with. This causes Swift-DocC to trigger a number of assertions due to the inconsistent state. (In release builds when debug assertions are compiled out, the issue is papered over with backup code, but the issue can still cause problems as evidenced with the need for workarounds like https://github.com/swiftlang/swift-docc/pull/1200.)

This PR updates the `PathHierarchy` initializer to clone children of these split parents to ensure that the hierarchy tree remains in a consistent state.

## Dependencies

None

## Testing

This is a catalog that contains Clang and Swift symbol graphs for a simple union with one field: [DemoFramework.docc.zip](https://github.com/user-attachments/files/19839709/DemoFramework.docc.zip)

Steps:
1. Build a debug build of Swift-DocC (to ensure assertions are enabled)
2. `docc convert DemoFramework.docc`
3. Ensure that conversion completes without errors.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
