### PR TITLE
[6.2] Avoid a crash when using external link support with certain unexpected inputs.

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Serialization.swift
@@ -37,9 +37,11 @@ extension PathHierarchy.FileRepresentation {
         }
         
         let nodes = [Node](unsafeUninitializedCapacity: lookup.count) { buffer, initializedCount in
-            for node in lookup.values {
+            for (identifier, node) in lookup {
+                assert(identifier == node.identifier, "Every node lookup should match a node with that identifier.")
+                
                 buffer.initializeElement(
-                    at: identifierMap[node.identifier]!,
+                    at: identifierMap[identifier]!,
                     to: Node(
                         name: node.name,
                         rawSpecialBehavior: node.specialBehaviors.rawValue,


### PR DESCRIPTION
- **Explanation:** This avoids a crash by accessing the identifier that the path hierarchy internally uses as a key rather than the identifier that's saved on the node. These should always be equal but some unexpected input can cause the node to have a different identifier than what the path hierarchy uses to find that node. 
- **Scope:** Crash for certain unexpected inputs.
- **Issue:** <rdar://148504975>
- **Risk:** Low. 
- **Testing:** Manually tested with the impacted projects. Existing automated tests pass. It's not possible to write an automated test for this change because any inputs necessary to create a path hierarchy where a node has a different identifier than the key in the lookup would fail to construct due to [this assertion](https://github.com/swiftlang/swift-docc/blob/main/Sources/SwiftDocC/Infrastructure/Link%20Resolution/PathHierarchy.swift#L384-L387).
- **Reviewer:** @QuietMisdreavus 
- **Original PR:** #1200 
