### PR TITLE
[6.2] Support `Any` Swift keyword in type signature disambiguation

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -129,6 +129,9 @@ extension PathHierarchy {
                     // Accumulate all of the identifier tokens' spelling.
                     accumulated.append(contentsOf: fragment.spelling.utf8)
                     
+                case .keyword where fragment.spelling == "Any":
+                    accumulated.append(contentsOf: fragment.spelling.utf8)
+                    
                 case .text: // In Swift, we're only want some `text` tokens characters in the type disambiguation.
                     // For example: "[", "?", "<", "...", ",", "(", "->" etc. contribute to the type spellings like
                     // `[Name]`, `Name?`, "Name<T>", "Name...", "()", "(Name, Name)", "(Name)->Name" and more.

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -1408,6 +1408,19 @@ class PathHierarchyTests: XCTestCase {
             .init(kind: .text, spelling: ">", preciseIdentifier: nil),
         ]))
         
+        // Any
+        XCTAssertEqual("Any", functionSignatureParameterTypeName([
+            .init(kind: .keyword, spelling: "Any", preciseIdentifier: nil),
+        ]))
+        
+        // Array<Any>
+        XCTAssertEqual("[Any]", functionSignatureParameterTypeName([
+            .init(kind: .typeIdentifier, spelling: "Array", preciseIdentifier: "s:Sa"),
+            .init(kind: .text, spelling: "<", preciseIdentifier: nil),
+            .init(kind: .keyword, spelling: "Any", preciseIdentifier: nil),
+            .init(kind: .text, spelling: ">", preciseIdentifier: nil),
+        ]))
+        
         // some Sequence<Int>
         XCTAssertEqual("Sequence<Int>", functionSignatureParameterTypeName([
             .init(kind: .keyword, spelling: "some", preciseIdentifier: nil),
@@ -1773,7 +1786,7 @@ class PathHierarchyTests: XCTestCase {
                     .init(name: "someName", externalName: nil, declarationFragments: [
                         .init(kind: .identifier, spelling: "someName", preciseIdentifier: nil),
                         .init(kind: .text, spelling: ": ((", preciseIdentifier: nil),
-                        .init(kind: .typeIdentifier, spelling: "Int", preciseIdentifier: "s:Si"),
+                        .init(kind: .keyword, spelling: "Any", preciseIdentifier: nil),
                         .init(kind: .text, spelling: ", ", preciseIdentifier: nil),
                         .init(kind: .typeIdentifier, spelling: "String", preciseIdentifier: "s:SS"),
                         .init(kind: .text, spelling: "), ", preciseIdentifier: nil),
@@ -1789,10 +1802,10 @@ class PathHierarchyTests: XCTestCase {
                     .init(kind: .text, spelling: "?)", preciseIdentifier: nil),
                 ])
             )
-            XCTAssertEqual(tupleArgument?.parameterTypeNames, ["((Int,String),Date)"])
+            XCTAssertEqual(tupleArgument?.parameterTypeNames, ["((Any,String),Date)"])
             XCTAssertEqual(tupleArgument?.returnTypeNames, ["[Int]", "String?"])
             
-             // func doSomething() -> ((Double, Double) -> Double, [Int: (Int, Int)], (Bool, Bool), String?)
+            // func doSomething() -> ((Double, Double) -> Double, [Int: (Int, Int)], (Bool, Any), String?)
             let bigTupleReturnType = functionSignatureTypeNames(.init(
                 parameters: [],
                 returns: [
@@ -1811,7 +1824,7 @@ class PathHierarchyTests: XCTestCase {
                     .init(kind: .text, spelling: ")], (", preciseIdentifier: nil),
                     .init(kind: .typeIdentifier, spelling: "Bool", preciseIdentifier: "s:Si"),
                     .init(kind: .text, spelling: ", ", preciseIdentifier: nil),
-                    .init(kind: .typeIdentifier, spelling: "Bool", preciseIdentifier: "s:Si"),
+                    .init(kind: .keyword, spelling: "Any", preciseIdentifier: nil),
                     .init(kind: .text, spelling: "), ", preciseIdentifier: nil),
                     .init(kind: .typeIdentifier, spelling: "Optional", preciseIdentifier: "s:Sq"),
                     .init(kind: .text, spelling: "<", preciseIdentifier: nil),
@@ -1820,7 +1833,7 @@ class PathHierarchyTests: XCTestCase {
                 ])
             )
             XCTAssertEqual(bigTupleReturnType?.parameterTypeNames, [])
-            XCTAssertEqual(bigTupleReturnType?.returnTypeNames, ["(Double,Double)->Double", "[Int:(Int,Int)]", "(Bool,Bool)", "String?"])
+            XCTAssertEqual(bigTupleReturnType?.returnTypeNames, ["(Double,Double)->Double", "[Int:(Int,Int)]", "(Bool,Any)", "String?"])
             
             // func doSomething(with someName: [Int?: String??])
             let dictionaryWithOptionalsArgument = functionSignatureTypeNames(.init(
@@ -1916,6 +1929,112 @@ class PathHierarchyTests: XCTestCase {
             )
             XCTAssertEqual(complicatedClosureArgument?.parameterTypeNames, ["(Int?,Double,(String,Value))->((Int)->Value)"])
         }
+    }
+    
+    func testParameterDisambiguationWithAnyType() throws {
+        // Create two overloads with different parameter types
+        let parameterTypes: [SymbolGraph.Symbol.DeclarationFragments.Fragment] = [
+            // Any (swift)
+            .init(kind: .keyword, spelling: "Any", preciseIdentifier: nil),
+            // AnyObject (swift)
+            .init(kind: .typeIdentifier, spelling: "AnyObject", preciseIdentifier: "s:s9AnyObjecta"),
+        ]
+        
+        let catalog = Folder(name: "CatalogName.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: parameterTypes.map { parameterTypeFragment in
+                makeSymbol(id: "some-function-id-\(parameterTypeFragment.spelling)", kind: .func, pathComponents: ["doSomething(with:)"], signature: .init(
+                    parameters: [
+                        .init(name: "something", externalName: "with", declarationFragments: [
+                            .init(kind: .identifier, spelling: "something", preciseIdentifier: nil),
+                            .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
+                            parameterTypeFragment
+                        ], children: [])
+                    ],
+                    returns: [
+                        .init(kind: .text, spelling: "()", preciseIdentifier: nil) // 'Void' in text representation
+                    ]
+                ))
+            })),
+        ])
+        let (_, context) = try loadBundle(catalog: catalog)
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
+        
+        let paths = tree.caseInsensitiveDisambiguatedPaths()
+        
+        XCTAssertEqual(paths["some-function-id-Any"],       "/ModuleName/doSomething(with:)-(Any)")
+        XCTAssertEqual(paths["some-function-id-AnyObject"], "/ModuleName/doSomething(with:)-(AnyObject)")
+        
+        try assertPathCollision("doSomething(with:)", in: tree, collisions: [
+            ("some-function-id-Any",       "-(Any)"),
+            ("some-function-id-AnyObject", "-(AnyObject)"),
+        ])
+        
+        try assertPathRaisesErrorMessage("doSomething(with:)", in: tree, context: context, expectedErrorMessage: "'doSomething(with:)' is ambiguous at '/ModuleName'") { error in
+            XCTAssertEqual(error.solutions.count, 2)
+            
+            // These test symbols don't have full declarations. A real solution would display enough information to distinguish these.
+            XCTAssertEqual(error.solutions.dropFirst(0).first, .init(summary: "Insert '-(Any)' for \n'doSomething(with:)'" , replacements: [("-(Any)", 18, 18)]))
+            XCTAssertEqual(error.solutions.dropFirst(1).first, .init(summary: "Insert '-(AnyObject)' for \n'doSomething(with:)'" /* the test symbols don't have full declarations */, replacements: [("-(AnyObject)", 18, 18)]))
+        }
+        
+        try assertFindsPath("doSomething(with:)-(Any)", in: tree, asSymbolID: "some-function-id-Any")
+        try assertFindsPath("doSomething(with:)-(Any)->()", in: tree, asSymbolID: "some-function-id-Any")
+        try assertFindsPath("doSomething(with:)-5gdco", in: tree, asSymbolID: "some-function-id-Any")
+        
+        try assertFindsPath("doSomething(with:)-(AnyObject)", in: tree, asSymbolID: "some-function-id-AnyObject")
+        try assertFindsPath("doSomething(with:)-(AnyObject)->()", in: tree, asSymbolID: "some-function-id-AnyObject")
+        try assertFindsPath("doSomething(with:)-9kd0v", in: tree, asSymbolID: "some-function-id-AnyObject")
+    }
+    
+    func testReturnDisambiguationWithAnyType() throws {
+        // Create two overloads with different return types
+        let returnTypes: [SymbolGraph.Symbol.DeclarationFragments.Fragment] = [
+            // Any (swift)
+            .init(kind: .keyword, spelling: "Any", preciseIdentifier: nil),
+            // AnyObject (swift)
+            .init(kind: .typeIdentifier, spelling: "AnyObject", preciseIdentifier: "s:s9AnyObjecta"),
+        ]
+        
+        let catalog = Folder(name: "CatalogName.docc", content: [
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: returnTypes.map { parameterTypeFragment in
+                makeSymbol(id: "some-function-id-\(parameterTypeFragment.spelling)", kind: .func, pathComponents: ["doSomething()"], signature: .init(
+                    parameters: [],
+                    returns: [parameterTypeFragment]
+                ))
+            })),
+        ])
+        let (_, context) = try loadBundle(catalog: catalog)
+        let tree = context.linkResolver.localResolver.pathHierarchy
+        
+        XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
+        
+        let paths = tree.caseInsensitiveDisambiguatedPaths()
+        
+        XCTAssertEqual(paths["some-function-id-Any"],       "/ModuleName/doSomething()->Any")
+        XCTAssertEqual(paths["some-function-id-AnyObject"], "/ModuleName/doSomething()->AnyObject")
+        
+        try assertPathCollision("doSomething()", in: tree, collisions: [
+            ("some-function-id-Any",       "->Any"),
+            ("some-function-id-AnyObject", "->AnyObject"),
+        ])
+        
+        try assertPathRaisesErrorMessage("doSomething()", in: tree, context: context, expectedErrorMessage: "'doSomething()' is ambiguous at '/ModuleName'") { error in
+            XCTAssertEqual(error.solutions.count, 2)
+            
+            // These test symbols don't have full declarations. A real solution would display enough information to distinguish these.
+            XCTAssertEqual(error.solutions.dropFirst(0).first, .init(summary: "Insert '->Any' for \n'doSomething()'" , replacements: [("->Any", 13, 13)]))
+            XCTAssertEqual(error.solutions.dropFirst(1).first, .init(summary: "Insert '->AnyObject' for \n'doSomething()'" /* the test symbols don't have full declarations */, replacements: [("->AnyObject", 13, 13)]))
+        }
+        
+        try assertFindsPath("doSomething()->Any", in: tree, asSymbolID: "some-function-id-Any")
+        try assertFindsPath("doSomething()-()->Any", in: tree, asSymbolID: "some-function-id-Any")
+        try assertFindsPath("doSomething()-5gdco", in: tree, asSymbolID: "some-function-id-Any")
+        
+        try assertFindsPath("doSomething()->AnyObject", in: tree, asSymbolID: "some-function-id-AnyObject")
+        try assertFindsPath("doSomething()-()->AnyObject", in: tree, asSymbolID: "some-function-id-AnyObject")
+        try assertFindsPath("doSomething()-9kd0v", in: tree, asSymbolID: "some-function-id-AnyObject")
     }
     
     func testOverloadGroupSymbolsResolveLinksWithoutHash() throws {


### PR DESCRIPTION
- **Explanation:** This fixes a bug where DocC would suggest incorrect type signature disambiguation for Swift symbols that include Swift's `Any` as a parameter or return value.
- **Scope:** Incorrect (unusable) link disambiguation for certain overloads.
- **Issue:** <rdar://148522712>
- **Risk:** Low. 
- **Testing:** Added tests verify that type signatures with Swift's `Any` keyword are processed correctly in parameters and return values including when `Any` is nested in tuples types, closures types, dictionary types, generics, etc. Existing automated tests pass.
- **Reviewer:** @QuietMisdreavus 
- **Original PR:** #1201
