### PR TITLE
[6.2] Invalid introduced version

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -317,9 +317,10 @@ struct SymbolGraphLoader {
             
                 // Fill introduced versions when missing.
                 availability.availability = availability.availability.map {
-                    $0.fillingMissingIntroducedVersion(
+                    let availabilityPlatformName = $0.domain.map { PlatformName(operatingSystemName: $0.rawValue) } ?? platformName
+                    return $0.fillingMissingIntroducedVersion(
                         from: defaultAvailabilityVersionByPlatform,
-                        fallbackPlatform: DefaultAvailability.fallbackPlatforms[platformName]?.rawValue
+                        fallbackPlatform: DefaultAvailability.fallbackPlatforms[availabilityPlatformName]?.rawValue
                     )
                 }
                 // Add the module availability information to each of the symbols availability mixin.

--- a/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -45,6 +45,7 @@ class SymbolAvailabilityTests: XCTestCase {
     private func renderNodeAvailability(
         defaultAvailability: [DefaultAvailability.ModuleAvailability] = [],
         symbolGraphOperatingSystemPlatformName: String,
+        symbolGraphEnvironmentName: String? = nil,
         symbols: [SymbolGraph.Symbol],
         symbolName: String
     ) throws -> [AvailabilityRenderItem] {
@@ -56,7 +57,7 @@ class SymbolAvailabilityTests: XCTestCase {
                 ]),
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
-                    platform: SymbolGraph.Platform(architecture: nil, vendor: nil, operatingSystem: SymbolGraph.OperatingSystem(name: symbolGraphOperatingSystemPlatformName), environment: nil),
+                    platform: SymbolGraph.Platform(architecture: nil, vendor: nil, operatingSystem: SymbolGraph.OperatingSystem(name: symbolGraphOperatingSystemPlatformName), environment: symbolGraphEnvironmentName),
                     symbols: symbols,
                     relationships: []
                 )),
@@ -71,7 +72,7 @@ class SymbolAvailabilityTests: XCTestCase {
     
     func testSymbolGraphSymbolWithoutDeprecatedVersionAndIntroducedVersion() throws {
 
-        let availability = try renderNodeAvailability(
+        var availability = try renderNodeAvailability(
             defaultAvailability: [],
             symbolGraphOperatingSystemPlatformName: "ios",
             symbols: [
@@ -90,6 +91,34 @@ class SymbolAvailabilityTests: XCTestCase {
             "iOS <nil> - 1.2.3",
             "iPadOS <nil> - 1.2.3",
             "Mac Catalyst <nil> - 1.2.3",
+        ])
+        
+        availability = try renderNodeAvailability(
+            defaultAvailability: [
+                DefaultAvailability.ModuleAvailability(platformName: PlatformName(operatingSystemName: "iOS"), platformVersion: "1.2.3")
+            ],
+            symbolGraphOperatingSystemPlatformName: "ios",
+            symbolGraphEnvironmentName: "macabi",
+            symbols: [
+                makeSymbol(
+                    id: "platform-1-symbol",
+                    kind: .class,
+                    pathComponents: ["SymbolName"],
+                    availability: [
+                        makeAvailabilityItem(domainName: "iOS", deprecated: SymbolGraph.SemanticVersion(string: "1.2.3")),
+                        makeAvailabilityItem(domainName: "visionOS", deprecated: SymbolGraph.SemanticVersion(string: "1.0.0"))
+                    ]
+                )
+            ],
+            symbolName: "SymbolName"
+        )
+        
+        XCTAssertEqual(availability.map { "\($0.name ?? "<nil>") \($0.introduced ?? "<nil>") - \($0.deprecated ?? "<nil>")" }, [
+            // The default availability for iOS shouldnt be copied to visionOS.
+            "iOS 1.2.3 - 1.2.3",
+            "iPadOS 1.2.3 - <nil>",
+            "Mac Catalyst 1.2.3 - 1.2.3",
+            "visionOS <nil> - 1.0",
         ])
     }
     


### PR DESCRIPTION
**Explanation:** Fixes an issue where platforms will inherit availability from other platforms when they shouldn't.
**Scope:** Fixes availability information in edge cases where a SGF contains availability information for all the platforms, and one of the symbols is deprecated without introduced version for a single platform.
**Issues**: rdar://146774862
**Original PRs:** https://github.com/swiftlang/swift-docc/pull/1208
**Risk:** Low.
Testing: Automated tests have been added and manual test has been made.
**Reviewers:** @anferbui 