### PR TITLE
merge sparse nodes if a matching symbol node is found later

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -65,6 +65,7 @@ struct PathHierarchy {
     ) {
         var roots: [String: Node] = [:]
         var allNodes: [String: [Node]] = [:]
+        // FIXME: These should not be tracked. Move sparse node creation to after all symbol graphs are loaded.
         var sparseNodes: [[String]: Node] = [:]
 
         let symbolGraphs = loader.symbolGraphs


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://150706871

## Summary

In the path hierarchy, symbols who have a parent/child relationship with a parent that is missing from their symbol graph get synthesized a "sparse node" chain of parents based on the symbol's path components, to ensure that there is still a proper chain of parent/child relationships keeping the symbol attached to the module root. However, if a later symbol graph then finds a symbol that otherwise matches the sparse node, the two are not combined and create a duplicate hierarchy between the sparse node and the symbol node.

This was exacerbated by https://github.com/swiftlang/swift-docc/pull/1203, which now clones the child nodes in this situation too. This ultimately can cause a crash in DocC when the sparse-node parent is deallocated before the initializer is finished, and the child node is trying to access its parent.

This PR works around this by keeping track of sparse nodes created during hierarchy initialization and merging them with a matching symbol node if one is later found. This way the children of the sparse node correctly point their parent relationship to the symbol parent, creating a consistent hierarchy.

## Dependencies

None

## Testing

This demo catalog, taken from the included unit test, contains two symbols, a parent and child, where the parent is only present in one of the symbol graphs: [unit-test.docc.zip](https://github.com/user-attachments/files/20070833/unit-test.docc.zip)

Steps:
1. Expand the attached zip file.
2. `swift run docc convert /path/to/unit-test.docc`
3. Ensure that Swift-DocC completes conversion without crashing. (This may require a few iterations to be certain; the failure depends on the order that the files are read off the filesystem, which may be nondeterministic.)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
