### PR TITLE
use found disambiguation to calculate diagnostic range if present

### DIFF
--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -44,6 +44,12 @@ func unresolvedReferenceProblem(source: URL?, range: SourceRange?, severity: Dia
     let diagnosticRange: SourceRange?
     if var rangeAdjustment = errorInfo.rangeAdjustment, let referenceSourceRange {
         rangeAdjustment.offsetWithRange(referenceSourceRange)
+        assert(rangeAdjustment.lowerBound.column >= 0 && rangeAdjustment.upperBound.column >= 0, """
+            Unresolved topic reference range adjustment created range with negative column.
+            Source: \(source?.absoluteString ?? "nil")
+            Range: \(rangeAdjustment.lowerBound.description):\(rangeAdjustment.upperBound.description)
+            Summary: \(errorInfo.message)
+            """)
         diagnosticRange = rangeAdjustment
     } else {
         diagnosticRange = referenceSourceRange

--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -44,7 +44,7 @@ func unresolvedReferenceProblem(source: URL?, range: SourceRange?, severity: Dia
     let diagnosticRange: SourceRange?
     if var rangeAdjustment = errorInfo.rangeAdjustment, let referenceSourceRange {
         rangeAdjustment.offsetWithRange(referenceSourceRange)
-        assert(rangeAdjustment.lowerBound.column >= 0 && rangeAdjustment.upperBound.column >= 0, """
+        assert(rangeAdjustment.lowerBound.column >= 0, """
             Unresolved topic reference range adjustment created range with negative column.
             Source: \(source?.absoluteString ?? "nil")
             Range: \(rangeAdjustment.lowerBound.description):\(rangeAdjustment.upperBound.description)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5270,51 +5270,52 @@ let expected = """
     func testContextDiagnosesInsufficientDisambiguationWithCorrectRange() throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        let symbolKindID = SymbolGraph.Symbol.KindIdentifier.allCases.first { !$0.isOverloadableKind }!
-        // Generate a 4 symbols with the same name for every non overloadable symbol kind
-        let symbols: [SymbolGraph.Symbol] = [
-            makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "second-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "third-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
-            makeSymbol(id: "fourth-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
-        ]
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+            // Generate a 4 symbols with the same name for every non overloadable symbol kind
+            let symbols: [SymbolGraph.Symbol] = [
+                makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "second-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "third-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "fourth-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
+            ]
 
-        let catalog =
-            Folder(name: "unit-test.docc", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
-                    moduleName: "ModuleName",
-                    symbols: symbols
-                )),
+            let catalog =
+                Folder(name: "unit-test.docc", content: [
+                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: symbols
+                    )),
 
-                TextFile(name: "ModuleName.md", utf8Content: """
-                # ``ModuleName``
+                    TextFile(name: "ModuleName.md", utf8Content: """
+                    # ``ModuleName``
 
-                This is a test file for ModuleName.
+                    This is a test file for ModuleName.
 
-                ## Topics
+                    ## Topics
 
-                - ``SymbolName-\(symbolKindID.identifier)``
-                """)
-            ])
+                    - ``SymbolName-\(symbolKindID.identifier)``
+                    """)
+                ])
 
-        let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try loadBundle(catalog: catalog)
 
-        let problems = context.problems.sorted(by: \.diagnostic.summary)
-        XCTAssertEqual(problems.count, 1)
+            let problems = context.problems.sorted(by: \.diagnostic.summary)
+            XCTAssertEqual(problems.count, 1)
 
-        let problem = try XCTUnwrap(problems.first)
+            let problem = try XCTUnwrap(problems.first)
 
-        XCTAssertEqual(problem.diagnostic.summary, "'SymbolName-\(symbolKindID.identifier)' is ambiguous at '/ModuleName'")
+            XCTAssertEqual(problem.diagnostic.summary, "'SymbolName-\(symbolKindID.identifier)' is ambiguous at '/ModuleName'")
 
-        for solution in problem.possibleSolutions {
-            XCTAssertEqual(solution.replacements.count, 1)
-            let replacement = try XCTUnwrap(solution.replacements.first)
+            for solution in problem.possibleSolutions {
+                XCTAssertEqual(solution.replacements.count, 1)
+                let replacement = try XCTUnwrap(solution.replacements.first)
 
-            XCTAssertEqual(replacement.range.lowerBound, .init(line: 7, column: 15, source: nil))
-            XCTAssertEqual(
-                replacement.range.upperBound,
-                .init(line: 7, column: 16 + symbolKindID.identifier.count, source: nil)
-            )
+                XCTAssertEqual(replacement.range.lowerBound, .init(line: 7, column: 15, source: nil))
+                XCTAssertEqual(
+                    replacement.range.upperBound,
+                    .init(line: 7, column: 16 + symbolKindID.identifier.count, source: nil)
+                )
+            }
         }
     }
 

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5306,6 +5306,8 @@ let expected = """
 
             XCTAssertEqual(problem.diagnostic.summary, "'SymbolName-\(symbolKindID.identifier)' is ambiguous at '/ModuleName'")
 
+            XCTAssertEqual(problem.possibleSolutions.count, 4)
+
             for solution in problem.possibleSolutions {
                 XCTAssertEqual(solution.replacements.count, 1)
                 let replacement = try XCTUnwrap(solution.replacements.first)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5321,6 +5321,110 @@ let expected = """
         }
     }
 
+    func testContextDiagnosesIncorrectDisambiguationWithCorrectRange() throws {
+        // This test deliberately does not turn on the overloads feature
+        // to ensure the symbol link below does not accidentally resolve correctly.
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+            // Generate a 4 symbols with the same name for every non overloadable symbol kind
+            let symbols: [SymbolGraph.Symbol] = [
+                makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "second-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "third-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "fourth-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
+            ]
+
+            let catalog =
+                Folder(name: "unit-test.docc", content: [
+                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: symbols
+                    )),
+
+                    TextFile(name: "ModuleName.md", utf8Content: """
+                    # ``ModuleName``
+
+                    This is a test file for ModuleName.
+
+                    ## Topics
+
+                    - ``SymbolName-abc123``
+                    """)
+                ])
+
+            let (_, context) = try loadBundle(catalog: catalog)
+
+            let problems = context.problems.sorted(by: \.diagnostic.summary)
+            XCTAssertEqual(problems.count, 1)
+
+            let problem = try XCTUnwrap(problems.first)
+
+            XCTAssertEqual(problem.diagnostic.summary, "'abc123' isn't a disambiguation for 'SymbolName' at '/ModuleName'")
+
+            XCTAssertEqual(problem.possibleSolutions.count, 4)
+
+            for solution in problem.possibleSolutions {
+                XCTAssertEqual(solution.replacements.count, 1)
+                let replacement = try XCTUnwrap(solution.replacements.first)
+
+                // "Replace '-abc123' with '-(hash)'" where 'abc123' is at 7:15-7:22
+                XCTAssertEqual(replacement.range.lowerBound, .init(line: 7, column: 15, source: nil))
+                XCTAssertEqual(replacement.range.upperBound, .init(line: 7, column: 22, source: nil))
+            }
+        }
+    }
+
+    func testContextDiagnosesIncorrectSymbolNameWithCorrectRange() throws {
+        // This test deliberately does not turn on the overloads feature
+        // to ensure the symbol link below does not accidentally resolve correctly.
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+            // Generate a 4 symbols with the same name for every non overloadable symbol kind
+            let symbols: [SymbolGraph.Symbol] = [
+                makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "second-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "third-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
+                makeSymbol(id: "fourth-\(symbolKindID.identifier)-id", kind: symbolKindID, pathComponents: ["SymbolName"]),
+            ]
+
+            let catalog =
+                Folder(name: "unit-test.docc", content: [
+                    JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                        moduleName: "ModuleName",
+                        symbols: symbols
+                    )),
+
+                    TextFile(name: "ModuleName.md", utf8Content: """
+                    # ``ModuleName``
+
+                    This is a test file for ModuleName.
+
+                    ## Topics
+
+                    - ``Symbol``
+                    """)
+                ])
+
+            let (_, context) = try loadBundle(catalog: catalog)
+
+            let problems = context.problems.sorted(by: \.diagnostic.summary)
+            XCTAssertEqual(problems.count, 1)
+
+            let problem = try XCTUnwrap(problems.first)
+
+            XCTAssertEqual(problem.diagnostic.summary, "'Symbol' doesn't exist at '/ModuleName'")
+
+            XCTAssertEqual(problem.possibleSolutions.count, 1)
+            let solution = try XCTUnwrap(problem.possibleSolutions.first)
+
+            XCTAssertEqual(solution.summary, "Replace 'Symbol' with 'SymbolName'")
+
+            XCTAssertEqual(solution.replacements.count, 1)
+            let replacement = try XCTUnwrap(solution.replacements.first)
+
+            XCTAssertEqual(replacement.range.lowerBound, .init(line: 7, column: 5, source: nil))
+            XCTAssertEqual(replacement.range.upperBound, .init(line: 7, column: 11, source: nil))
+        }
+    }
+
     func testResolveExternalLinkFromTechnologyRoot() throws {
         enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://150207195

## Summary

The link resolver emits diagnostics for symbol links that require a disambiguation suffix (or a more precise suffix) to resolve to a single symbol. The diagnostic also includes fix-it solutions suggesting the available suffixes for the conflicting symbols. However, the logic for reporting the ranges of these possible replacements has a flaw when reporting on a curated symbol link: it always uses the full name of the symbol as the base instead of the written symbol or just the suffix.

This PR updates the diagnostic logic to handle the case of a found disambiguation suffix separately when reporting the diagnostic solutions.

## Dependencies

None

## Testing

The functionality is difficult to test outside of a unit test environment, as it requires non-overloadable symbols to have conflicting names. This is primarily only going to happen with errors in symbol graph generation that cause separate sets of symbols to exist. Nonetheless, the unit test captures the behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
