### PR TITLE
[6.2] use found disambiguation to calculate diagnostic range if present

### DIFF
--- a/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/ReferenceResolver.swift
@@ -44,6 +44,12 @@ func unresolvedReferenceProblem(source: URL?, range: SourceRange?, severity: Dia
     let diagnosticRange: SourceRange?
     if var rangeAdjustment = errorInfo.rangeAdjustment, let referenceSourceRange {
         rangeAdjustment.offsetWithRange(referenceSourceRange)
+        assert(rangeAdjustment.lowerBound.column >= 0, """
+            Unresolved topic reference range adjustment created range with negative column.
+            Source: \(source?.absoluteString ?? "nil")
+            Range: \(rangeAdjustment.lowerBound.description):\(rangeAdjustment.upperBound.description)
+            Summary: \(errorInfo.message)
+            """)
         diagnosticRange = rangeAdjustment
     } else {
         diagnosticRange = referenceSourceRange


### PR DESCRIPTION
- **Explanation**: Updates diagnostic solution ranges when a given disambiguation is insufficient to point to a single symbol.
- **Scope**: Prevents diagnostics from being given with wrong/invalid ranges, including negative column indices.
- **Issues**: rdar://150207195
- **Original PRs**: https://github.com/swiftlang/swift-docc/pull/1213
- **Risk**: Low. The change is limited to diagnostic reporting code and shouldn't cause new errors in documentation processing. A new assertion is added but toolchain distributions of Swift-DocC turn assertions off so it shouldn't cause a problem for production uses.
- **Testing**: An automated test was added, and manual testing proved the change works with a larger set of triggering cases.
- **Reviewers**: @d-ronnqvist 
