### PR TITLE
Fix error when merging a single archive

### DIFF
--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -36,7 +36,10 @@ extension MergeAction {
     
     func readRootNodeRenderReferencesIn(dataDirectory: URL) throws -> RootRenderReferences {
         func inner(url: URL) throws -> [RootRenderReferences.Information] {
-            try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
+            // Path might not exist (e.g. tutorials for a reference-only archive)
+            guard let contents = try? fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])
+            else { return [] }
+            return try contents
                 .compactMap {
                     guard $0.pathExtension == "json" else {
                         return nil

--- a/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Merge/MergeAction.swift
@@ -65,6 +65,8 @@ struct MergeAction: AsyncAction {
                 let fromDirectory = archive.appendingPathComponent(directoryToCopy, isDirectory: true)
                 let toDirectory = targetURL.appendingPathComponent(directoryToCopy, isDirectory: true)
 
+                guard fileManager.directoryExists(atPath: fromDirectory.path) else { continue }
+
                 // Ensure that the destination directory exist in case the first archive didn't have that kind of pages.
                 // This is necessary when merging a reference-only archive with a tutorial-only archive.
                 try? fileManager.createDirectory(at: toDirectory, withIntermediateDirectories: false, attributes: nil)

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -996,14 +996,13 @@ class MergeActionTests: XCTestCase {
         Output.doccarchive/
         ├─ data/
         │  ├─ documentation.json
-        │  ├─ documentation/
-        │  │  ├─ first.json
-        │  │  ├─ first/
-        │  │  │  ╰─ article.json
-        │  │  ├─ second.json
-        │  │  ╰─ second/
-        │  │     ╰─ article.json
-        │  ╰─ tutorials/
+        │  ╰─ documentation/
+        │     ├─ first.json
+        │     ├─ first/
+        │     │  ╰─ article.json
+        │     ├─ second.json
+        │     ╰─ second/
+        │        ╰─ article.json
         ├─ downloads/
         │  ├─ First/
         │  ╰─ Second/


### PR DESCRIPTION
Bug/issue #, if applicable:

## Summary

Currently, when trying to merge a single doccarchive that contains either only references or only tutorials, the command fails because it tries to read from a directory that does not exist (e.g. `tutorials` in case of a reference-only archive).
While this is a rather special use case, the action _basically_ supports it (except for this error) and we use it to have a unified documentation setup for our packages by generating the doccarchive for each target and then merging them together. For multi-target packages this works fine, but for single-target packages it currently fails.

This fixes the source of this error. Alongside, I've also added a small check to not create directories that are not needed - even when merging multiple archives. With that check, merging two reference-only archives will not create an empty `tutorials` directory.

## Dependencies

_None_

## Testing

Steps:
1. Create a single `doccarchive` (with only tutorials or references)
2. `docs merge /path/to/archive.doccarchive --output-path ./combined.doccarchive`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
