### PR TITLE
Fix crash caused by repeatedly cloning the same path hierarchy node

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -319,7 +319,6 @@ struct PathHierarchy {
                         parent.children[components.first!] == nil,
                         "Shouldn't create a new sparse node when symbol node already exist. This is an indication that a symbol is missing a relationship."
                     )
-                    print("Creating sparse node for \(components.first! )")
                     
                     guard knownDisambiguatedPathComponents != nil else {
                         // If the path hierarchy wasn't passed any "known disambiguated path components" then the sparse/placeholder nodes won't contain any disambiguation.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -169,7 +169,7 @@ struct PathHierarchy {
                         sourceNode.languages.remove(language!)
 
                         // Make sure that the clone's children can all line up with symbols from this symbol graph.
-                        for (childName, children) in sourceNode.children {
+                        for children in sourceNode.children.values {
                             for child in children.storage {
                                 guard let childSymbol = child.node.symbol else {
                                     // We shouldn't come across any non-symbol nodes here,

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -299,12 +299,13 @@ struct PathHierarchy {
                     // FIXME:
                     // This code path is both expected (when `knownDisambiguatedPathComponents` is non-nil) and unexpected (when the symbol graph is missing data or contains extra relationships).
                     // It would be good to restructure this code to better distinguish what's supported behavior and what's a best-effort attempt at gracefully handle invalid symbol graphs.
-                    if let existing = parent.children[components.first!] {
-                        //
+                    if let existing = parent.children[component] {
+                        // This code tries to repair incomplete symbol graph files by guessing that the symbol with the most overlapping languages is the intended container.
+                        // Valid symbol graph files we should never end up here.
                         var bestLanguageMatch: (node: Node, count: Int)?
                         for element in existing.storage {
                             let numberOfMatchingLanguages = node.languages.intersection(element.node.languages).count
-                            if numberOfMatchingLanguages < (bestLanguageMatch?.count ?? .max) {
+                            if (bestLanguageMatch?.count ?? .min) < numberOfMatchingLanguages {
                                 bestLanguageMatch = (node: element.node, count: numberOfMatchingLanguages)
                             }
                         }
@@ -316,7 +317,7 @@ struct PathHierarchy {
                     }
                     
                     assert(
-                        parent.children[components.first!] == nil,
+                        parent.children[component] == nil,
                         "Shouldn't create a new sparse node when symbol node already exist. This is an indication that a symbol is missing a relationship."
                     )
                     

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -367,7 +367,7 @@ struct PathHierarchy {
                 Array(sequence(first: node, next: \.parent)).last!.symbol!.kind.identifier == .module })
             }), """
             Every node should reach a root node by following its parents up. \
-            This wasn't true for \(allNodes.filter({ $0.value.allSatisfy({ Array(sequence(first: $0, next: \.parent)).last!.symbol!.kind.identifier != .module }) }).map(\.key).sorted())
+            This wasn't true for \(allNodes.filter({ $0.value.contains(where: { Array(sequence(first: $0, next: \.parent)).last!.symbol!.kind.identifier != .module }) }).map(\.key).sorted())
             """
         )
         

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -77,7 +77,7 @@ struct PathHierarchy {
                 
         // To try to handle certain invalid symbol graph files gracefully, we track symbols that don't have a place in the hierarchy so that we can look for a place for those symbols.
         // Because this is a last resort, we only want to do this processing after all the symbol graphs have already been processed.
-        var identifiersForSymbolsOutsideOfHierarchyByModule: [String: Set<String>] = [:]
+        var symbolNodesOutsideOfHierarchyByModule: [String: [Node]] = [:]
 
         for (url, graph, language) in symbolGraphs {
             let moduleName = graph.module.name
@@ -205,8 +205,13 @@ struct PathHierarchy {
                     // If the source was added in an extension symbol graph file, then its target won't be found in the same symbol graph file (in `nodes`).
                     
                     // We may have encountered multiple language representations of the target symbol. Try to find the best matching representation of the target to add the source to.
-                    // Remove any targets that don't match the source symbol's path components (see comment above for more details).
-                    targetNodes.removeAll(where: { $0.name != expectedContainerName })
+                    // Remove any targets that don't match the source symbol's path components (see comment above for more details) and languages (see comments below).
+                    targetNodes.removeAll(where: { $0.name != expectedContainerName || $0.languages.isDisjoint(with: sourceNode.languages) })
+                    guard !targetNodes.isEmpty else {
+                        // If none of the symbol graphs contain a matching node it's likely a bug in the tool that generated the symbol graph.
+                        // If this happens we leave the source node in `topLevelCandidates` to try and let a later fallback code path recover from the symbol graph issue.
+                        continue
+                    }
                     
                     // Prefer the symbol that matches the relationship's language.
                     if let targetNode = targetNodes.first(where: { $0.symbol!.identifier.interfaceLanguage == language?.id }) {
@@ -215,7 +220,7 @@ struct PathHierarchy {
                         // It's not clear which target to add the source to, so we add it to all of them.
                         // This will likely hit a _debug_ assertion (later in this initializer) about inconsistent traversal through the hierarchy,
                         // but in release builds DocC will "repair" the inconsistent hierarchy.
-                        for targetNode in targetNodes {
+                        for targetNode in targetNodes where !sourceNode.languages.isDisjoint(with: targetNode.languages) {
                             targetNode.add(symbolChild: sourceNode)
                         }
                     }
@@ -266,15 +271,14 @@ struct PathHierarchy {
             assertAllNodes(in: topLevelCandidates.values.filter { $0.symbol!.pathComponents.count > 1 }, satisfy: { $0.parent == nil },
                            "Top-level candidates shouldn't already exist in the hierarchy.")
             
-            for (symbolID, node) in topLevelCandidates where node.symbol!.pathComponents.count > 1 && node.parent == nil {
-                identifiersForSymbolsOutsideOfHierarchyByModule[moduleNode.symbol!.identifier.precise, default: []].insert(symbolID)
+            for node in topLevelCandidates.values where node.symbol!.pathComponents.count > 1 && node.parent == nil {
+                symbolNodesOutsideOfHierarchyByModule[moduleNode.symbol!.identifier.precise, default: []].append(node)
             }
         }
         
-        for (moduleID, symbolIDs) in identifiersForSymbolsOutsideOfHierarchyByModule {
+        for (moduleID, nodes) in symbolNodesOutsideOfHierarchyByModule {
             let moduleNode = roots[moduleID]!
-            for id in symbolIDs {
-            for node in allNodes[id] ?? [] where node.parent == nil {
+            for node in nodes where node.parent == nil {
                 var parent = moduleNode
                 var components = { (symbol: SymbolGraph.Symbol) -> [String] in
                     let original = symbol.pathComponents
@@ -292,6 +296,25 @@ struct PathHierarchy {
                     components = components.dropFirst()
                 }
                 for component in components {
+                    // FIXME:
+                    // This code path is both expected (when `knownDisambiguatedPathComponents` is non-nil) and unexpected (when the symbol graph is missing data or contains extra relationships).
+                    // It would be good to restructure this code to better distinguish what's supported behavior and what's a best-effort attempt at gracefully handle invalid symbol graphs.
+                    if let existing = parent.children[components.first!] {
+                        //
+                        var bestLanguageMatch: (node: Node, count: Int)?
+                        for element in existing.storage {
+                            let numberOfMatchingLanguages = node.languages.intersection(element.node.languages).count
+                            if numberOfMatchingLanguages < (bestLanguageMatch?.count ?? .max) {
+                                bestLanguageMatch = (node: element.node, count: numberOfMatchingLanguages)
+                            }
+                        }
+                        if let bestLanguageMatch {
+                            // If there's a real symbol that matches this node's languages, use that node instead of creating a placeholder node
+                            parent = bestLanguageMatch.node
+                            continue
+                        }
+                    }
+                    
                     assert(
                         parent.children[components.first!] == nil,
                         "Shouldn't create a new sparse node when symbol node already exist. This is an indication that a symbol is missing a relationship."
@@ -323,7 +346,6 @@ struct PathHierarchy {
                 }
                 parent.add(symbolChild: node)
             }
-        }
         }
 
         // Overload group don't exist in the individual symbol graphs.

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -2843,7 +2843,7 @@ class PathHierarchyTests: XCTestCase {
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
-                    ],
+                    ]
                 ))
             }),
 
@@ -3174,7 +3174,7 @@ class PathHierarchyTests: XCTestCase {
                         makeSymbol(id: containerID, kind: .struct, pathComponents: ["ContainerName"], availability: platform.availability),
                         makeSymbol(id: memberID, kind: .property, pathComponents: ["ContainerName", "memberName"], availability: platform.availability),
                     ],
-                    relationships: [/* the memberOf relationship is missing */],
+                    relationships: [/* the memberOf relationship is missing */]
                 ))
             })
         ])

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3185,8 +3185,6 @@ class PathHierarchyTests: XCTestCase {
         let container = try tree.findNode(path: "/ModuleName/ContainerName-struct", onlyFindSymbols: true)
         XCTAssertEqual(container.languages, [.swift])
         
-        try assertFindsPath("/ModuleName/ContainerName", in: tree, asSymbolID: containerID)
-
         let member = try tree.findNode(path: "/ModuleName/ContainerName/memberName", onlyFindSymbols: true)
         XCTAssertEqual(member.languages, [.swift])
 
@@ -3260,6 +3258,11 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertNotEqual(swiftSpecificNode.parent?.identifier, objcSpecificNode.parent?.identifier)
         XCTAssertNotEqual(swiftSpecificNode.parent?.parent?.identifier, objcSpecificNode.parent?.parent?.identifier)
         XCTAssertNotEqual(swiftSpecificNode.parent?.parent?.parent?.identifier, objcSpecificNode.parent?.parent?.parent?.identifier)
+
+        // Check the each language representation maps to the other language representation
+        XCTAssertEqual(swiftSpecificNode.parent?.counterpart?.identifier, objcSpecificNode.parent?.identifier)
+        XCTAssertEqual(swiftSpecificNode.parent?.parent?.counterpart?.identifier, objcSpecificNode.parent?.parent?.identifier)
+        XCTAssertEqual(swiftSpecificNode.parent?.parent?.parent?.counterpart?.identifier, objcSpecificNode.parent?.parent?.parent?.identifier)
         
         // Check that neither path require disambiguation
         let paths = tree.caseInsensitiveDisambiguatedPaths()

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -2827,32 +2827,38 @@ class PathHierarchyTests: XCTestCase {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"
 
+        // Repeat the same symbols in both languages for many platforms.
+        let platforms = (1...10).map {
+            let name = "Platform\($0)"
+            return (name: name, availability: [makeAvailabilityItem(domainName: name)])
+        }
+        
         let catalog = Folder(name: "unit-test.docc", content: [
-            Folder(name: "clang", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+            Folder(name: "clang", content: platforms.map { platform in
+                JSONFile(name: "ModuleName-\(platform.name).symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
                     symbols: [
-                        makeSymbol(id: containerID, language: .objectiveC, kind: .union, pathComponents: ["ContainerName"]),
-                        makeSymbol(id: memberID, language: .objectiveC, kind: .property, pathComponents: ["ContainerName", "MemberName"]),
+                        makeSymbol(id: containerID, language: .objectiveC, kind: .union, pathComponents: ["ContainerName"], availability: platform.availability),
+                        makeSymbol(id: memberID, language: .objectiveC, kind: .property, pathComponents: ["ContainerName", "MemberName"], availability: platform.availability),
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
-                    ]
-                )),
-            ]),
+                    ],
+                ))
+            }),
 
-            Folder(name: "swift", content: [
-                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+            Folder(name: "swift", content: platforms.map { platform in
+                JSONFile(name: "ModuleName-\(platform.name).symbols.json", content: makeSymbolGraph(
                     moduleName: "ModuleName",
                     symbols: [
-                        makeSymbol(id: containerID, kind: .struct, pathComponents: ["ContainerName"]),
-                        makeSymbol(id: memberID, kind: .property, pathComponents: ["ContainerName", "MemberName"]),
+                        makeSymbol(id: containerID, kind: .struct, pathComponents: ["ContainerName"], availability: platform.availability),
+                        makeSymbol(id: memberID, kind: .property, pathComponents: ["ContainerName", "MemberName"], availability: platform.availability),
                     ],
                     relationships: [
                         .init(source: memberID, target: containerID, kind: .memberOf, targetFallback: nil)
                     ]
-                )),
-            ])
+                ))
+            })
         ])
 
         let (_, context) = try loadBundle(catalog: catalog)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://150706871&148247074 

## Summary

This primarily fixes a crash caused by repeatedly cloning the same path hierarchy node. (https://github.com/swiftlang/swift-docc/commit/e161b2ab775a67a1ff065a6ffd6661b9261eb278)

Then if fixes additional crashes that were made more common due to cloned nodes (https://github.com/swiftlang/swift-docc/commit/4187f62992ae1673dbfc44c73882ce372b590ec0 and https://github.com/swiftlang/swift-docc/commit/c12c7d1e1563800e4d12fdeb2addd9f8b010226b)

Seeing these changes in aggregate I would like to take some time to reorganize the path hierarchy initializer to better distinguish the expected code paths from the code paths that try to gracefully handle incomplete symbol graph files. However, I would want to cherry-pick these crash fixes into the 6.2 release and I'm not yet sure about the scope of the other code cleanup so I'd prefer to open a separate PR for that.

## Dependencies

None.

## Testing

Because most of these issues are related to unexpectedly incomplete symbol graph files it's fairly difficult to test this all the way from symbol graph generation. I could manually craft a symbol graph file that is based on one of the added unit tests, but I don't find that that would provide any more assurances than running the tests which the CI already does.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
