### PR TITLE
Sort equal weighted "Mentioned In" articles alphabetically

### DIFF
--- a/Sources/SwiftDocC/Semantics/Article/ArticleSymbolMentions.swift
+++ b/Sources/SwiftDocC/Semantics/Article/ArticleSymbolMentions.swift
@@ -32,7 +32,14 @@ struct ArticleSymbolMentions {
         // Mentions are sorted on demand based on the number of mentions.
         // This could change in the future.
         return mentions[symbol, default: [:]].sorted {
-            $0.value > $1.value
+            // If a pair of articles have the same number of mentions, sort
+            // them alphabetically.
+            if $0.value == $1.value {
+                return $0.key.description < $1.key.description
+            }
+
+            // Otherwise, sort articles with more mentions first.
+            return $0.value > $1.value
         }
         .map { $0.key }
     }

--- a/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
@@ -36,6 +36,56 @@ class ArticleSymbolMentionsTests: XCTestCase {
         XCTAssertEqual(gottenArticle, article)
     }
 
+    // Test the sorting of articles mentioning a given symbol
+    func testArticlesMentioningSorting() throws {
+        let bundleID: DocumentationBundle.Identifier = "org.swift.test"
+        let articles = ["a", "b", "c", "d", "e", "f"].map { letter in
+            ResolvedTopicReference(
+                bundleID: bundleID,
+                path: "/\(letter)",
+                sourceLanguage: .swift
+            )
+        }
+        let symbol = ResolvedTopicReference(
+            bundleID: bundleID,
+            path: "/z",
+            sourceLanguage: .swift
+        )
+
+        var mentions = ArticleSymbolMentions()
+        XCTAssertTrue(mentions.articlesMentioning(symbol).isEmpty)
+
+        // test that mentioning articles are sorted by weight
+        mentions.article(articles[0], didMention: symbol, weight: 10)
+        mentions.article(articles[1], didMention: symbol, weight: 42)
+        mentions.article(articles[2], didMention: symbol, weight: 1)
+        mentions.article(articles[3], didMention: symbol, weight: 14)
+        mentions.article(articles[4], didMention: symbol, weight: 2)
+        mentions.article(articles[5], didMention: symbol, weight: 6)
+        XCTAssertEqual(mentions.articlesMentioning(symbol), [
+            articles[1],
+            articles[3],
+            articles[0],
+            articles[5],
+            articles[4],
+            articles[2],
+        ])
+
+        // test that mentioning articles w/ same weights are sorted alphabetically
+        //
+        // note: this test is done multiple times with a shuffled list to ensure
+        // that it isn't just passing by pure chance due to the unpredictable
+        // order of Swift dictionaries
+        for _ in 1...10 {
+            mentions = ArticleSymbolMentions()
+            XCTAssertTrue(mentions.articlesMentioning(symbol).isEmpty)
+            for article in articles.shuffled() {
+                mentions.article(article, didMention: symbol, weight: 1)
+            }
+            XCTAssertEqual(mentions.articlesMentioning(symbol), articles)
+        }
+    }
+
     func testSymbolLinkCollectorEnabled() throws {
         let (bundle, context) = try createMentionedInTestBundle()
 


### PR DESCRIPTION
Bug/issue #, if applicable: 150870055

## Summary

This improves the stability of the sorting for the "Mentioned In" list of articles in the case where any pair of articles have mentioned a given symbol the same number of times.

This list is already sorted by weight where an article that mentions a symbol more times will appear closer to the top of the list. However in the scenario where two articles have the same given weight, the order is not deterministic due to the fact that the backing data structure is a Swift Dictionary where the items are not enumerated in a deterministic order. This addresses that by falling back to alphabetical order for articles with the same number of mentions for a given symbol.

## Testing

Steps:
1. Configure a DocC catalog with a single symbol and 2 articles which both have one reference to the symbol.
2. Use this branch to verify that the "Mentioned In" list for the symbol always includes the articles sorted alphabetically.
3. Compare the behavior with the main branch where occasionally the order of the list may differ between compilations.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
