### PR TITLE
corrects schema version property name in RenderIndex.spec.json

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderIndex.spec.json
@@ -15,7 +15,7 @@
                     "interfaceLanguages"
                 ],
                 "properties": {
-                    "identifier": {
+                    "schemaVersion": {
                         "$ref": "#/components/schemas/SchemaVersion"
                     },
                     "interfaceLanguages": {


### PR DESCRIPTION
Bug/issue #, if applicable: #1223

## Summary

I grabbed the SlothCreator sample project and rendered it using swift-docc, reviewing the JSON it generated to see what might be correct for issue #1223 - and it seems that the correct propertyName is `schemaVersion`. This makes that change directly, but there's no existing tests to validate that I spotted, including even validating the the provided OpenAPI spec files  are able to be validated.

## Dependencies

none

## Testing

Manual - I ran OpenAPI generator externally to create models for the JSON data structures, and verified the warnings are resolved.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
