### PR TITLE
Don't omit "Type" suffix from disambiguation for Swift metatypes

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -136,6 +136,11 @@ extension PathHierarchy {
                     // For example: "[", "?", "<", "...", ",", "(", "->" etc. contribute to the type spellings like
                     // `[Name]`, `Name?`, "Name<T>", "Name...", "()", "(Name, Name)", "(Name)->Name" and more.
                     let utf8Spelling = fragment.spelling.utf8
+                    guard !utf8Spelling.elementsEqual(".Type".utf8) else {
+                        // Once exception to that is "Name.Type" which is different from just "Name" (and we don't want a trailing ".")
+                        accumulated.append(contentsOf: utf8Spelling)
+                        continue
+                    }
                     for index in utf8Spelling.indices {
                         let char = utf8Spelling[index]
                         switch char {

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3772,6 +3772,42 @@ class PathHierarchyTests: XCTestCase {
             ])
         }
         
+        // The second overload refers to the metatype of the parameter
+        do {
+            func makeSignature(first: DeclToken...) -> SymbolGraph.Symbol.FunctionSignature {
+                .init(
+                    parameters: [.init(name: "first",  externalName: "with", declarationFragments: makeFragments(first),  children: []),],
+                    returns: makeFragments([voidType])
+                )
+            }
+            
+            let someGenericTypeID = "some-generic-type-id"
+            let catalog = Folder(name: "unit-test.docc", content: [
+                JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    symbols: [
+                        makeSymbol(id: "function-overload-1", kind: .func, pathComponents: ["doSomething(with:)"], signature: makeSignature(
+                            // GenericName
+                            first: .typeIdentifier("GenericName", precise: someGenericTypeID),
+                        )),
+                        
+                        makeSymbol(id: "function-overload-2", kind: .func, pathComponents: ["doSomething(with:)"], signature: makeSignature(
+                            // GenericName.Type
+                            first: .typeIdentifier("GenericName", precise: someGenericTypeID), ".Type",
+                        )),
+                    ]
+                ))
+            ])
+            
+            let (_, context) = try loadBundle(catalog: catalog)
+            let tree = context.linkResolver.localResolver.pathHierarchy
+            
+            try assertPathCollision("ModuleName/doSomething(with:)", in: tree, collisions: [
+                (symbolID: "function-overload-1", disambiguation: "-(GenericName)"),      //  GenericName
+                (symbolID: "function-overload-2", disambiguation: "-(GenericName.Type)"), //  GenericName.Type
+            ])
+        }
+        
         // Second overload requires combination of two non-unique types to disambiguate
         do {
             //  String   Set<Int>  (Double)->Void

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -3788,12 +3788,12 @@ class PathHierarchyTests: XCTestCase {
                     symbols: [
                         makeSymbol(id: "function-overload-1", kind: .func, pathComponents: ["doSomething(with:)"], signature: makeSignature(
                             // GenericName
-                            first: .typeIdentifier("GenericName", precise: someGenericTypeID),
+                            first: .typeIdentifier("GenericName", precise: someGenericTypeID)
                         )),
                         
                         makeSymbol(id: "function-overload-2", kind: .func, pathComponents: ["doSomething(with:)"], signature: makeSignature(
                             // GenericName.Type
-                            first: .typeIdentifier("GenericName", precise: someGenericTypeID), ".Type",
+                            first: .typeIdentifier("GenericName", precise: someGenericTypeID), ".Type"
                         )),
                     ]
                 ))


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://152496046

## Summary

This makes a small bug fix to type signature disambiguation for parameters or return values that are Swift metatypes (`Something.Type`). 

## Dependencies

None.

## Testing

- Define some overloads where one of the parameters or return values necessary for disambiguation is a metatype. For example:
  ```
  public func doSomething(with value: Int) {}
  public func doSomething(with type: BinaryInteger.Type) {}
  ```

- Write an ambiguous link to these overloads:
  ```
  /// ``doSomething(with:)``
  public enum Something {}
  ```

- The suggestions for what disambiguation to add to should use `BinaryInteger.Type` instead of just `BinaryInteger.` (with the trailing `.`)


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
