### PR TITLE
Omit whitespace from suggested disambiguations in the link completion tools

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
@@ -131,8 +131,8 @@ public enum LinkCompletionTools {
                 node,
                 kind: symbol.kind,
                 hash: symbol.symbolIDHash,
-                parameterTypes: symbol.parameterTypes,
-                returnTypes: symbol.returnTypes
+                parameterTypes: symbol.parameterTypes?.map { $0.withoutWhitespace() },
+                returnTypes: symbol.returnTypes?.map { $0.withoutWhitespace() }
             )
         }
         
@@ -234,5 +234,11 @@ private extension PathHierarchy.PathComponent.Disambiguation {
         case .none, ._nonFrozenEnum_useDefaultCase:
             return nil
         }
+    }
+}
+
+private extension String {
+    func withoutWhitespace() -> String {
+        filter { !$0.isWhitespace }
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
@@ -237,4 +237,25 @@ class LinkCompletionToolsTests: XCTestCase {
             "->_",        // The only overload that returns something
         ])
     }
+    
+    func testRemovesWhitespaceFromTypeSignatureDisambiguation() {
+        let overloads = [
+            // The caller included whitespace in these closure type spellings but the DocC disambiguation won't include this whitespace.
+            (parameters: ["(Int) -> Int"],  returns: []), // ((Int)  -> Int)  -> Void
+            (parameters: ["(Bool) -> ()"], returns: []),  // ((Bool) -> () )  -> Void
+        ].map {
+            LinkCompletionTools.SymbolInformation(
+                kind: "func",
+                symbolIDHash: "\($0)".stableHashString,
+                parameterTypes: $0.parameters,
+                returnTypes: $0.returns
+            )
+        }
+        
+        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: overloads), [
+            // Both parameters require the only parameter type as disambiguation. The suggested disambiguation shouldn't contain extra whitespace.
+            "-((Int)->Int)",
+            "-((Bool)->())",
+        ])
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://152496072

## Summary

This removes whitespace from the callers' parameter and return type strings when suggesting disambiguation for ambiguous links through the `LinkCompletionTools`.

## Dependencies

_Describe any dependencies this PR might have, such as an associated branch in another repository._

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
1. _Provide setup instructions._
2. _Explain in detail how the functionality can be tested._

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
