### PR TITLE
Update to a newer version of the Swift-DocC Plugin

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin.git",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin.git",
       "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
+        "revision" : "d1691545d53581400b1de9b0472d45eb25c19fed",
+        "version" : "1.4.4"
       }
     },
     {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This only updates the resolved version of the swift-docc-plugin dependency to 1.4+ so that both DocC and the plugin depend on the "github.com/**swiftlang**/swift-docc-symbolkit" link to SymbolKit rather than the "github.com/**apple**/swift-docc-symbolkit" link. 

This fixes a warning when building DocC:
> Conflicting identity for swift-docc-symbolkit: dependency 'github.com/apple/swift-docc-symbolkit' and dependency 'github.com/swiftlang/swift-docc-symbolkit' both point to the same package identity 'swift-docc-symbolkit'.

Because the 1.3 dependency was previously specified in the Package.resolved file. Anyone who cloned DocC and built it would encounter this warning.

## Dependencies

Update to a newer version of the swift-docc-plugin dependency.

## Testing

Nothing in particular. This isn't a user facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
