### PR TITLE
[6.2] Crawl the curation of auto-curated articles

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -2428,18 +2428,17 @@ public class DocumentationContext {
         
         // Crawl the rest of the symbols that haven't been crawled so far in hierarchy pre-order.
         allCuratedReferences = try crawlSymbolCuration(in: automaticallyCurated.map(\.symbol), bundle: bundle, initial: allCuratedReferences)
-
-        // Remove curation paths that have been created automatically above
-        // but we've found manual curation for in the second crawl pass.
-        removeUnneededAutomaticCuration(automaticallyCurated)
         
         // Automatically curate articles that haven't been manually curated
         // Article curation is only done automatically if there is only one root module
         if let rootNode = rootNodeForAutomaticCuration {
             let articleReferences = try autoCurateArticles(otherArticles, startingFrom: rootNode)
-            preResolveExternalLinks(references: articleReferences, localBundleID: bundle.id)
-            resolveLinks(curatedReferences: Set(articleReferences), bundle: bundle)
+            allCuratedReferences = try crawlSymbolCuration(in: articleReferences, bundle: bundle, initial: allCuratedReferences)
         }
+        
+        // Remove curation paths that have been created automatically above
+        // but we've found manual curation for in the second crawl pass.
+        removeUnneededAutomaticCuration(automaticallyCurated)
 
         // Remove any empty "Extended Symbol" pages whose children have been curated elsewhere.
         for module in rootModules {

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/TopicGraph.swift
@@ -330,7 +330,7 @@ struct TopicGraph {
         }
         
         var result = ""
-        result.append("\(decorator) \(node[keyPath: keyPath])\r\n")
+        result.append("\(decorator) \(node[keyPath: keyPath])\n")
         if let childEdges = edges[node.reference]?.sorted(by: { $0.path < $1.path }) {
             for (index, childRef) in childEdges.enumerated() {
                 var decorator = decorator


### PR DESCRIPTION
- **Explanation:** This ensures that curation inside of auto-curated API Collections (articles) are also visited.
- **Scope:** Redundant automatic curation of pages curated in an API Collection (article) that itself is auto-curated.
- **Issue:** <rdar://151731131>
- **Risk:** Low. 
- **Testing:**  Added a test that there's no duplicate curation in this setup. Manually verified with the project that originally reported this bug. Existing automated tests pass.
- **Reviewer:** @patshaughnessy 
- **Original PR:** #1236 
