### PR TITLE
resolving mismatches in RenderNode OpenAPI output spec

### DIFF
--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -360,8 +360,7 @@
                 "type": "object",
                 "required": [
                     "kind",
-                    "tiles",
-                    "content"
+                    "tiles"
                 ],
                 "properties": {
                     "kind": {
@@ -526,8 +525,7 @@
                     "kind",
                     "content",
                     "media",
-                    "mediaPosition",
-                    "layout"
+                    "mediaPosition"
                 ],
                 "properties": {
                     "kind": {
@@ -1795,7 +1793,7 @@
                 "type": "object",
                 "required": [
                     "type",
-                    "identifier"
+                    "reference"
                 ],
                 "properties": {
                     "type": {
@@ -1956,7 +1954,7 @@
                 "type": "object",
                 "required": [
                     "reference",
-                    "kind"
+                    "sections"
                 ],
                 "properties": {
                     "reference": {
@@ -2499,7 +2497,6 @@
             },
             "MentionsRenderSection": {
                 "required": [
-                    "kind",
                     "mentions"
                 ],
                 "type": "object",


### PR DESCRIPTION
Resolves: #1222 

## Summary

Updates the OpenAPI spec files for the outputs used in DocC archive to resolve warnings in mismatches between required fields and available properties defined in those fields

Updates:
- LinkableEntities.json
- RenderNode.spec.json

## Dependencies

none

## Testing

Manually verified the output doesn't present warnings when code generation is run with OpenAPI generator:

An example command:
```
git clone https://github.com/apple/swift-openapi-generator
cd swift-openapi-generator
swift run swift-openapi-generator generate --mode types --output-directory ~/foo /Users/joeheck/src/swift-docc/Sources/SwiftDocC/SwiftDocC.docc/Resources/LinkableEntities.json
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
