### PR TITLE
[6.2] Omit whitespace from suggested link completion disambiguations

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
@@ -131,8 +131,8 @@ public enum LinkCompletionTools {
                 node,
                 kind: symbol.kind,
                 hash: symbol.symbolIDHash,
-                parameterTypes: symbol.parameterTypes,
-                returnTypes: symbol.returnTypes
+                parameterTypes: symbol.parameterTypes?.map { $0.withoutWhitespace() },
+                returnTypes: symbol.returnTypes?.map { $0.withoutWhitespace() }
             )
         }
         
@@ -234,5 +234,11 @@ private extension PathHierarchy.PathComponent.Disambiguation {
         case .none, ._nonFrozenEnum_useDefaultCase:
             return nil
         }
+    }
+}
+
+private extension String {
+    func withoutWhitespace() -> String {
+        filter { !$0.isWhitespace }
     }
 }

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
@@ -237,4 +237,25 @@ class LinkCompletionToolsTests: XCTestCase {
             "->_",        // The only overload that returns something
         ])
     }
+    
+    func testRemovesWhitespaceFromTypeSignatureDisambiguation() {
+        let overloads = [
+            // The caller included whitespace in these closure type spellings but the DocC disambiguation won't include this whitespace.
+            (parameters: ["(Int) -> Int"],  returns: []), // ((Int)  -> Int)  -> Void
+            (parameters: ["(Bool) -> ()"], returns: []),  // ((Bool) -> () )  -> Void
+        ].map {
+            LinkCompletionTools.SymbolInformation(
+                kind: "func",
+                symbolIDHash: "\($0)".stableHashString,
+                parameterTypes: $0.parameters,
+                returnTypes: $0.returns
+            )
+        }
+        
+        XCTAssertEqual(LinkCompletionTools.suggestedDisambiguation(forCollidingSymbols: overloads), [
+            // Both parameters require the only parameter type as disambiguation. The suggested disambiguation shouldn't contain extra whitespace.
+            "-((Int)->Int)",
+            "-((Bool)->())",
+        ])
+    }
 }


### PR DESCRIPTION
- **Explanation:** Avoid suggesting incorrect disambiguation in LinkCompletionTools when the caller passes symbol information with whitespace in the type signature.
- **Scope:** Incorrect suggested disambiguations in some cases.
- **Issue:** rdar://152496072
- **Risk:** Low. 
- **Testing:**  Added test that the LinkCompletionTools omit whitespace from its suggested disambiguations. Existing automated tests pass.
- **Reviewer:** @patshaughnessy 
- **Original PR:** #1232
