### PR TITLE
Update DocumentationContext initializer to be async

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -323,7 +323,7 @@ public class DocumentationContext {
         dataProvider: any DataProvider,
         diagnosticEngine: DiagnosticEngine = .init(),
         configuration: Configuration = .init()
-    ) throws {
+    ) async throws {
         self.bundle = bundle
         self.dataProvider = .new(dataProvider)
         self.diagnosticEngine = diagnosticEngine

--- a/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/Convert/ConvertAction.swift
@@ -288,9 +288,9 @@ public struct ConvertAction: AsyncAction {
 
         let indexer = try Indexer(outputURL: temporaryFolder, bundleID: bundle.id)
 
-        let context = try signposter.withIntervalSignpost("Register", id: signposter.makeSignpostID()) {
-            try DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
-        }
+        let registerInterval = signposter.beginInterval("Register", id: signposter.makeSignpostID())
+        let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
+        signposter.endInterval("Register", registerInterval)
         
         let outputConsumer = ConvertFileWritingConsumer(
             targetFolder: temporaryFolder,

--- a/Sources/SwiftDocCUtilities/Action/Actions/EmitGeneratedCurationAction.swift
+++ b/Sources/SwiftDocCUtilities/Action/Actions/EmitGeneratedCurationAction.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,7 +50,7 @@ struct EmitGeneratedCurationAction: AsyncAction {
                 additionalSymbolGraphFiles: symbolGraphFiles(in: additionalSymbolGraphDirectory)
             )
         )
-        let context = try DocumentationContext(bundle: bundle, dataProvider: dataProvider)
+        let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider)
 
         let writer = GeneratedCurationWriter(context: context, catalogURL: catalogURL, outputURL: outputURL)
         let curation = try writer.generateDefaultCurationContents(fromSymbol: startingPointSymbolLink, depthLimit: depthLimit)

--- a/Tests/SwiftDocCTests/Benchmark/ExternalTopicsHashTests.swift
+++ b/Tests/SwiftDocCTests/Benchmark/ExternalTopicsHashTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -37,9 +37,9 @@ class ExternalTopicsGraphHashTests: XCTestCase {
         }
     }
     
-    func testNoMetricAddedIfNoExternalTopicsAreResolved() throws {
+    func testNoMetricAddedIfNoExternalTopicsAreResolved() async throws {
         // Load bundle without using external resolvers
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         XCTAssertTrue(context.externallyResolvedLinks.isEmpty)
         
         // Try adding external topics metrics
@@ -50,12 +50,12 @@ class ExternalTopicsGraphHashTests: XCTestCase {
         XCTAssertNil(testBenchmark.metrics.first?.result, "Metric was added but there was no external links or symbols")
     }
     
-    func testExternalLinksSameHash() throws {
+    func testExternalLinksSameHash() async throws {
         let externalResolver = self.externalResolver
         
         // Add external links and verify the checksum is always the same
-        let hashes: [String] = try (0...10).map { _ -> MetricValue? in
-            let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
+        func computeTopicHash(file: StaticString = #filePath, line: UInt = #line) async throws -> String {
+            let (_, _, context) = try await self.testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
             try """
             # ``SideKit/SideClass``
 
@@ -74,26 +74,24 @@ class ExternalTopicsGraphHashTests: XCTestCase {
             let testBenchmark = Benchmark()
             benchmark(add: Benchmark.ExternalTopicsHash(context: context), benchmarkLog: testBenchmark)
             
-            // Verify that a metric was added
-            XCTAssertNotNil(testBenchmark.metrics[0].result)
-            return testBenchmark.metrics[0].result
-        }
-        .compactMap { value -> String? in
-            guard let value,
-                case MetricValue.checksum(let hash) = value else { return nil }
-            return hash
+            return try TopicAnchorHashTests.extractChecksumHash(from: testBenchmark)
         }
         
+        let expectedHash = try await computeTopicHash()
+        
         // Verify the produced topic graph hash is repeatedly the same
-        XCTAssertTrue(hashes.allSatisfy({ $0 == hashes.first }))
+        for _ in 0 ..< 10 {
+            let hash = try await computeTopicHash()
+            XCTAssertEqual(hash, expectedHash)
+        }
     }
 
-    func testLinksAndSymbolsSameHash() throws {
+    func testLinksAndSymbolsSameHash() async throws {
         let externalResolver = self.externalResolver
         
         // Add external links and verify the checksum is always the same
-        let hashes: [String] = try (0...10).map { _ -> MetricValue? in
-            let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [externalResolver.bundleID: externalResolver], externalSymbolResolver: externalSymbolResolver) { url in
+        func computeTopicHash(file: StaticString = #filePath, line: UInt = #line) async throws -> String {
+            let (_, _, context) = try await self.testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [externalResolver.bundleID: externalResolver], externalSymbolResolver: self.externalSymbolResolver) { url in
             try """
             # ``SideKit/SideClass``
 
@@ -113,25 +111,23 @@ class ExternalTopicsGraphHashTests: XCTestCase {
             let testBenchmark = Benchmark()
             benchmark(add: Benchmark.ExternalTopicsHash(context: context), benchmarkLog: testBenchmark)
             
-            // Verify that a metric was added
-            XCTAssertNotNil(testBenchmark.metrics[0].result)
-            return testBenchmark.metrics[0].result
-        }
-        .compactMap { value -> String? in
-            guard let value,
-                case MetricValue.checksum(let hash) = value else { return nil }
-            return hash
+            return try TopicAnchorHashTests.extractChecksumHash(from: testBenchmark)
         }
         
+        let expectedHash = try await computeTopicHash()
+        
         // Verify the produced topic graph hash is repeatedly the same
-        XCTAssertTrue(hashes.allSatisfy({ $0 == hashes.first }))
+        for _ in 0 ..< 10 {
+            let hash = try await computeTopicHash()
+            XCTAssertEqual(hash, expectedHash)
+        }
     }
     
-    func testExternalTopicsDetectsChanges() throws {
+    func testExternalTopicsDetectsChanges() async throws {
         let externalResolver = self.externalResolver
 
         // Load a bundle with external links
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [externalResolver.bundleID: externalResolver]) { url in
         try """
         # ``SideKit/SideClass``
 

--- a/Tests/SwiftDocCTests/Catalog Processing/GeneratedCurationWriterTests.swift
+++ b/Tests/SwiftDocCTests/Catalog Processing/GeneratedCurationWriterTests.swift
@@ -14,8 +14,8 @@ import XCTest
 class GeneratedCurationWriterTests: XCTestCase {
     private let testOutputURL = URL(fileURLWithPath: "/unit-test/output-dir") // Nothing is written to this path in this test
     
-    func testWriteTopLevelSymbolCuration() throws {
-        let (url, _, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testWriteTopLevelSymbolCuration() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let contentsToWrite = try writer.generateDefaultCurationContents(depthLimit: 0)
@@ -110,8 +110,8 @@ class GeneratedCurationWriterTests: XCTestCase {
         """)
     }
     
-    func testWriteSymbolCurationFromTopLevelSymbol() throws {
-        let (url, _, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testWriteSymbolCurationFromTopLevelSymbol() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         
@@ -141,8 +141,8 @@ class GeneratedCurationWriterTests: XCTestCase {
         """)
     }
     
-    func testWriteSymbolCurationWithLimitedDepth() throws {
-        let (url, _, context) = try testBundleAndContext(named: "BundleWithSameNameForSymbolAndContainer")
+    func testWriteSymbolCurationWithLimitedDepth() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "BundleWithSameNameForSymbolAndContainer")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let depthLevelsToTest = [nil, 0, 1, 2, 3, 4, 5]
@@ -252,8 +252,8 @@ class GeneratedCurationWriterTests: XCTestCase {
         }
     }
     
-    func testSkipsManuallyCuratedPages() throws {
-        let (url, _, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+    func testSkipsManuallyCuratedPages() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "MixedManualAutomaticCuration")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let contentsToWrite = try writer.generateDefaultCurationContents()
@@ -282,8 +282,8 @@ class GeneratedCurationWriterTests: XCTestCase {
         """)
     }
     
-    func testAddsCommentForDisambiguatedLinks() throws {
-        let (url, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
+    func testAddsCommentForDisambiguatedLinks() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let contentsToWrite = try writer.generateDefaultCurationContents(fromSymbol: "OverloadedProtocol")
@@ -308,8 +308,8 @@ class GeneratedCurationWriterTests: XCTestCase {
         """)
     }
     
-    func testLinksSupportNonPathCharacters() throws {
-        let (url, _, context) = try testBundleAndContext(named: "InheritedOperators")
+    func testLinksSupportNonPathCharacters() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "InheritedOperators")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let contentsToWrite = try writer.generateDefaultCurationContents(fromSymbol: "MyNumber")
@@ -346,8 +346,8 @@ class GeneratedCurationWriterTests: XCTestCase {
         """)
     }
     
-    func testGeneratingLanguageSpecificCuration() throws {
-        let (url, _, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testGeneratingLanguageSpecificCuration() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "GeometricalShapes")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let contentsToWrite = try writer.generateDefaultCurationContents()
@@ -439,8 +439,8 @@ class GeneratedCurationWriterTests: XCTestCase {
     }
     
     
-    func testCustomOutputLocation() throws {
-        let (url, _, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testCustomOutputLocation() async throws {
+        let (url, _, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         
         let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
         let contentsToWrite = try writer.generateDefaultCurationContents()

--- a/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -177,17 +177,17 @@ func aBlackListedFunc() {
      - item three
     """
 
-    func testDisabledByDefault() throws {
+    func testDisabledByDefault() async throws {
         // Create a test bundle with some non-inclusive content.
         let catalog = Folder(name: "unit-test.docc", content: [
             TextFile(name: "Root.md", utf8Content: nonInclusiveContent)
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 0) // Non-inclusive content is an info-level diagnostic, so it's filtered out.
     }
 
-    func testEnablingTheChecker() throws {
+    func testEnablingTheChecker() async throws {
         // The expectations of the checker being run, depending on the diagnostic level
         // set to to the documentation context for the compilation.
         let expectations: [(DiagnosticSeverity, Bool)] = [
@@ -203,7 +203,7 @@ func aBlackListedFunc() {
             ])
             var configuration = DocumentationContext.Configuration()
             configuration.externalMetadata.diagnosticLevel = severity
-            let (_, context) = try loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: severity), configuration: configuration)
+            let (_, context) = try await loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: severity), configuration: configuration)
             
             // Verify that checker diagnostics were emitted or not, depending on the diagnostic level set.
             XCTAssertEqual(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.NonInclusiveLanguage" }), enabled)

--- a/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
+++ b/Tests/SwiftDocCTests/Converter/DocumentationContextConverterTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import XCTest
 @testable import SwiftDocC
 
 class DocumentationContextConverterTests: XCTestCase {
-    func testRenderNodesAreIdentical() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderNodesAreIdentical() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         // We'll use this to convert nodes ad-hoc
         let perNodeConverter = DocumentationNodeConverter(bundle: bundle, context: context)
@@ -40,8 +40,8 @@ class DocumentationContextConverterTests: XCTestCase {
         }
     }
     
-    func testSymbolLocationsAreOnlyIncludedWhenRequested() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testSymbolLocationsAreOnlyIncludedWhenRequested() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         
         let fillIntroducedSymbolNode = try XCTUnwrap(
@@ -70,8 +70,8 @@ class DocumentationContextConverterTests: XCTestCase {
         }
     }
     
-    func testSymbolAccessLevelsAreOnlyIncludedWhenRequested() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testSymbolAccessLevelsAreOnlyIncludedWhenRequested() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         
         let fillIntroducedSymbolNode = try XCTUnwrap(

--- a/Tests/SwiftDocCTests/Converter/RenderContextTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderContextTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import XCTest
 @testable import SwiftDocC
 
 class RenderContextTests: XCTestCase {
-    func testCreatesRenderReferences() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCreatesRenderReferences() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         

--- a/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
+++ b/Tests/SwiftDocCTests/Converter/RenderNodeCodableTests.swift
@@ -169,8 +169,8 @@ class RenderNodeCodableTests: XCTestCase {
         XCTAssertEqual(renderNode.topicSectionsStyle, .list)
     }
     
-    func testEncodeRenderNodeWithCustomTopicSectionStyle() throws {
-        let (bundle, context) = try testBundleAndContext()
+    func testEncodeRenderNodeWithCustomTopicSectionStyle() async throws {
+        let (bundle, context) = try await testBundleAndContext()
         var problems = [Problem]()
         
         let source = """

--- a/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
+++ b/Tests/SwiftDocCTests/Converter/TopicRenderReferenceEncoderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -157,8 +157,8 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
     
     /// Verifies that when JSON encoder should sort keys, the custom render reference cache
     /// respects that setting and prints the referencs in alphabetical order.
-    func testSortedReferences() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testSortedReferences() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
 
         // Create a JSON encoder
@@ -217,8 +217,8 @@ class TopicRenderReferenceEncoderTests: XCTestCase {
     }
     
     // Verifies that there is no extra comma at the end of the references list.
-    func testRemovesLastReferencesListDelimiter() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRemovesLastReferencesListDelimiter() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
 
         // Create a JSON encoder

--- a/Tests/SwiftDocCTests/DeprecatedDiagnosticsDigestWarningTests.swift
+++ b/Tests/SwiftDocCTests/DeprecatedDiagnosticsDigestWarningTests.swift
@@ -14,7 +14,7 @@ import SwiftDocCTestUtilities
 import XCTest
 
 class DeprecatedDiagnosticsDigestWarningTests: XCTestCase {
-    func testNoDeprecationWarningWhenThereAreNoOtherWarnings() throws {
+    func testNoDeprecationWarningWhenThereAreNoOtherWarnings() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             TextFile(name: "Root.md", utf8Content: """
             # Root
@@ -22,7 +22,7 @@ class DeprecatedDiagnosticsDigestWarningTests: XCTestCase {
             An empty root page
             """)
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         let outputConsumer = TestOutputConsumer()
         
@@ -38,7 +38,7 @@ class DeprecatedDiagnosticsDigestWarningTests: XCTestCase {
         XCTAssert(outputConsumer.problems.isEmpty, "Unexpected problems: \(outputConsumer.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
     }
     
-    func testDeprecationWarningWhenThereAreOtherWarnings() throws {
+    func testDeprecationWarningWhenThereAreOtherWarnings() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             TextFile(name: "Root.md", utf8Content: """
             # Root
@@ -48,7 +48,7 @@ class DeprecatedDiagnosticsDigestWarningTests: XCTestCase {
             This link will result in a warning: ``NotFound``.
             """)
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         let outputConsumer = TestOutputConsumer()
         

--- a/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
+++ b/Tests/SwiftDocCTests/Diagnostics/DiagnosticTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -78,8 +78,8 @@ class DiagnosticTests: XCTestCase {
     }
     
     /// Test offsetting diagnostic ranges
-    func testOffsetDiagnostics() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+    func testOffsetDiagnostics() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName"))
         ]))
 

--- a/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
+++ b/Tests/SwiftDocCTests/DocumentationService/ConvertService/ConvertServiceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -1487,14 +1487,14 @@ class ConvertServiceTests: XCTestCase {
         )
     }
     
-    func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithUncuratedArticles() throws {
+    func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithUncuratedArticles() async throws {
         #if os(Linux)
         throw XCTSkip("""
         Skipped on Linux due to an issue in Foundation.Codable where dictionaries are sometimes getting encoded as \
         arrays. (github.com/apple/swift/issues/57363)
         """)
         #else
-        let (testBundleURL, _, _) = try testBundleAndContext(
+        let (testBundleURL, _, _) = try await testBundleAndContext(
             copying: "LegacyBundle_DoNotUseInNewTests",
             excludingPaths: [
                 "sidekit.symbols.json",
@@ -1616,14 +1616,14 @@ class ConvertServiceTests: XCTestCase {
         #endif
     }
     
-    func testNoRenderReferencesToNonLinkableNodes() throws {
+    func testNoRenderReferencesToNonLinkableNodes() async throws {
         #if os(Linux)
         throw XCTSkip("""
         Skipped on Linux due to an issue in Foundation.Codable where dictionaries are sometimes getting encoded as \
         arrays. (github.com/apple/swift/issues/57363)
         """)
         #else
-        let (testBundleURL, _, _) = try testBundleAndContext(
+        let (testBundleURL, _, _) = try await testBundleAndContext(
             copying: "LegacyBundle_DoNotUseInNewTests",
             excludingPaths: [
                 "mykit-iOS.symbols.json",
@@ -1658,14 +1658,14 @@ class ConvertServiceTests: XCTestCase {
         #endif
     }
     
-    func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithCuratedArticles() throws {
+    func testReturnsRenderReferenceStoreWhenRequestedForOnDiskBundleWithCuratedArticles() async throws {
         #if os(Linux)
         throw XCTSkip("""
         Skipped on Linux due to an issue in Foundation.Codable where dictionaries are sometimes getting encoded as \
         arrays. (github.com/apple/swift/issues/57363)
         """)
         #else
-        let (testBundleURL, _, _) = try testBundleAndContext(
+        let (testBundleURL, _, _) = try await testBundleAndContext(
             // Use a bundle that contains only articles, one of which is declared as the TechnologyRoot and curates the
             // other articles.
             copying: "BundleWithTechnologyRoot"

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -13,7 +13,7 @@ import XCTest
 @_spi(ExternalLinks) @testable import SwiftDocC
 
 class ExternalRenderNodeTests: XCTestCase {
-    func generateExternalResover() -> TestMultiResultExternalReferenceResolver {
+    private func generateExternalResolver() -> TestMultiResultExternalReferenceResolver {
         let externalResolver = TestMultiResultExternalReferenceResolver()
         externalResolver.bundleID = "com.test.external"
         externalResolver.entitiesToReturn["/path/to/external/swiftArticle"] = .success(
@@ -53,7 +53,7 @@ class ExternalRenderNodeTests: XCTestCase {
         
     func testExternalRenderNode() async throws {
         
-        let externalResolver = generateExternalResover()
+        let externalResolver = generateExternalResolver()
         let (_, bundle, context) = try await testBundleAndContext(
             copying: "MixedLanguageFramework",
             externalResolvers: [externalResolver.bundleID: externalResolver]
@@ -155,7 +155,7 @@ class ExternalRenderNodeTests: XCTestCase {
     }
     
     func testNavigatorWithExternalNodes() async throws {
-        let externalResolver = generateExternalResover()
+        let externalResolver = generateExternalResolver()
         let (_, bundle, context) = try await testBundleAndContext(
             copying: "MixedLanguageFramework",
             externalResolvers: [externalResolver.bundleID: externalResolver]
@@ -211,7 +211,7 @@ class ExternalRenderNodeTests: XCTestCase {
     }
     
     func testNavigatorWithExternalNodesOnlyAddsCuratedNodesToNavigator() async throws {
-        let externalResolver = generateExternalResover()
+        let externalResolver = generateExternalResolver()
         
         let (_, bundle, context) = try await testBundleAndContext(
             copying: "MixedLanguageFramework",

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -18,19 +18,19 @@ class ExternalRenderNodeTests: XCTestCase {
         externalResolver.bundleID = "com.test.external"
         externalResolver.entitiesToReturn["/path/to/external/swiftArticle"] = .success(
             .init(
-                    referencePath: "/path/to/external/swiftArticle",
-                    title: "SwiftArticle",
-                    kind: .article,
-                    language: .swift
-                )
+                referencePath: "/path/to/external/swiftArticle",
+                title: "SwiftArticle",
+                kind: .article,
+                language: .swift
+            )
         )
         externalResolver.entitiesToReturn["/path/to/external/objCArticle"] = .success(
             .init(
-                    referencePath: "/path/to/external/objCArticle",
-                    title: "ObjCArticle",
-                    kind: .article,
-                    language: .objectiveC
-                )
+                referencePath: "/path/to/external/objCArticle",
+                title: "ObjCArticle",
+                kind: .article,
+                language: .objectiveC
+            )
         )
         externalResolver.entitiesToReturn["/path/to/external/swiftSymbol"] = .success(
             .init(

--- a/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/IndexingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import XCTest
 class IndexingTests: XCTestCase {
     
     // MARK: - Tutorial
-    func testTutorial() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testTutorial() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let tutorialReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         let node = try context.entity(with: tutorialReference)
         let tutorial = node.semantic as! Tutorial
@@ -88,8 +88,8 @@ class IndexingTests: XCTestCase {
     
     // MARK: - Article
     
-    func testArticle() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testArticle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let articleReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! TutorialArticle
@@ -186,8 +186,8 @@ class IndexingTests: XCTestCase {
         XCTAssertEqual("Hello, world!", aside.rawIndexableTextContent(references: [:]))
     }
     
-    func testRootPageIndexingRecord() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRootPageIndexingRecord() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let articleReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift)
         let node = try context.entity(with: articleReference)
         let article = node.semantic as! Symbol
@@ -206,8 +206,8 @@ class IndexingTests: XCTestCase {
                        indexingRecords[0])
     }
     
-    func testSymbolIndexingRecord() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testSymbolIndexingRecord() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             // Modify the documentaion to have default availability for MyKit so that there is platform availability
             // information for MyProtocol (both in the render node and in the indexing record.
             let plistURL = url.appendingPathComponent("Info.plist")

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -396,8 +396,8 @@ Root
         XCTAssertNotNil(builder.navigatorIndex)
     }
     
-    func testNavigatorIndexGeneration() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexGeneration() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         var results = Set<String>()
@@ -455,7 +455,7 @@ Root
         assertEqualDumps(results.first ?? "", try testTree(named: "testNavigatorIndexGeneration"))
     }
     
-    func testNavigatorIndexGenerationWithCyclicCuration() throws {
+    func testNavigatorIndexGenerationWithCyclicCuration() async throws {
         // This is a documentation hierarchy where every page exist in more than one place in the navigator,
         // through a mix of automatic and manual curation, with a cycle between the two "leaf" nodes:
         //
@@ -586,7 +586,7 @@ Root
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
@@ -633,8 +633,8 @@ Root
         """)
     }
     
-    func testNavigatorWithDifferentSwiftAndObjectiveCHierarchies() throws {
-        let (_, bundle, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testNavigatorWithDifferentSwiftAndObjectiveCHierarchies() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(named: "GeometricalShapes")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
@@ -831,8 +831,8 @@ Root
         try FileManager.default.removeItem(at: targetURL)
     }
 
-    func testDoesNotCurateUncuratedPagesInLanguageThatAreCuratedInAnotherLanguage() throws {
-        let navigatorIndex = try generatedNavigatorIndex(for: "MixedLanguageFramework", bundleIdentifier: "org.swift.mixedlanguageframework")
+    func testDoesNotCurateUncuratedPagesInLanguageThatAreCuratedInAnotherLanguage() async throws {
+        let navigatorIndex = try await generatedNavigatorIndex(for: "MixedLanguageFramework", bundleIdentifier: "org.swift.mixedlanguageframework")
 
         XCTAssertEqual(
             navigatorIndex.navigatorTree.root.children
@@ -864,8 +864,8 @@ Root
         )
     }
     
-    func testMultiCuratesChildrenOfMultiCuratedPages() throws {
-        let navigatorIndex = try generatedNavigatorIndex(for: "MultiCuratedSubtree", bundleIdentifier: "org.swift.MultiCuratedSubtree")
+    func testMultiCuratesChildrenOfMultiCuratedPages() async throws {
+        let navigatorIndex = try await generatedNavigatorIndex(for: "MultiCuratedSubtree", bundleIdentifier: "org.swift.MultiCuratedSubtree")
         
         XCTAssertEqual(
             navigatorIndex.navigatorTree.root.dumpTree(),
@@ -894,8 +894,8 @@ Root
         )
     }
     
-    func testNavigatorIndexUsingPageTitleGeneration() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexUsingPageTitleGeneration() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         var results = Set<String>()
@@ -943,8 +943,8 @@ Root
         assertEqualDumps(results.first ?? "", try testTree(named: "testNavigatorIndexPageTitleGeneration"))
     }
     
-    func testNavigatorIndexGenerationNoPaths() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexGenerationNoPaths() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         var results = Set<String>()
         
@@ -1000,8 +1000,8 @@ Root
         assertEqualDumps(results.first ?? "", try testTree(named: "testNavigatorIndexGeneration"))
     }
     
-    func testNavigatorIndexGenerationWithLanguageGrouping() throws {
-        let navigatorIndex = try generatedNavigatorIndex(for: "LegacyBundle_DoNotUseInNewTests", bundleIdentifier: testBundleIdentifier)
+    func testNavigatorIndexGenerationWithLanguageGrouping() async throws {
+        let navigatorIndex = try await generatedNavigatorIndex(for: "LegacyBundle_DoNotUseInNewTests", bundleIdentifier: testBundleIdentifier)
         
         XCTAssertEqual(navigatorIndex.availabilityIndex.platforms, [.watchOS, .macCatalyst, .iOS, .tvOS, .macOS, .iPadOS])
         XCTAssertEqual(navigatorIndex.availabilityIndex.versions(for: .iOS), Set([
@@ -1020,8 +1020,8 @@ Root
     }
 
     
-    func testNavigatorIndexGenerationWithCuratedFragment() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexGenerationWithCuratedFragment() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         var results = Set<String>()
@@ -1083,8 +1083,8 @@ Root
         assertEqualDumps(results.first ?? "", try testTree(named: "testNavigatorIndexGeneration"))
     }
     
-    func testNavigatorIndexAvailabilityGeneration() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexAvailabilityGeneration() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
@@ -1187,8 +1187,8 @@ Root
         XCTAssertNil(availabilityDB.get(type: String.self, forKey: "content"))
     }
     
-    func testCustomIconsInNavigator() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BookLikeContent") // This content has a @PageImage with the "icon" purpose
+    func testCustomIconsInNavigator() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BookLikeContent") // This content has a @PageImage with the "icon" purpose
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
@@ -1213,8 +1213,8 @@ Root
         ])
     }
     
-    func testNavigatorIndexDifferentHasherGeneration() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexDifferentHasherGeneration() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
@@ -1662,8 +1662,8 @@ Root
         #endif
     }
     
-    func testNavigatorIndexAsReadOnlyFile() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorIndexAsReadOnlyFile() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         let targetURL = try createTemporaryDirectory()
@@ -1902,8 +1902,8 @@ Root
         )
     }
     
-    func testAnonymousTopicGroups() throws {
-        let navigatorIndex = try generatedNavigatorIndex(
+    func testAnonymousTopicGroups() async throws {
+        let navigatorIndex = try await generatedNavigatorIndex(
             for: "AnonymousTopicGroups",
             bundleIdentifier: "org.swift.docc.example"
         )
@@ -1923,10 +1923,10 @@ Root
         )
     }
 
-    func testNavigatorDoesNotContainOverloads() throws {
+    func testNavigatorDoesNotContainOverloads() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let navigatorIndex = try generatedNavigatorIndex(
+        let navigatorIndex = try await generatedNavigatorIndex(
             for: "OverloadedSymbols",
             bundleIdentifier: "com.shapes.ShapeKit")
 
@@ -1977,8 +1977,8 @@ Root
         )
     }
 
-    func generatedNavigatorIndex(for testBundleName: String, bundleIdentifier: String) throws -> NavigatorIndex {
-        let (bundle, context) = try testBundleAndContext(named: testBundleName)
+    func generatedNavigatorIndex(for testBundleName: String, bundleIdentifier: String) async throws -> NavigatorIndex {
+        let (bundle, context) = try await testBundleAndContext(named: testBundleName)
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
 
@@ -2004,7 +2004,7 @@ Root
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation], timeout: 10.0)
+        await fulfillment(of: [expectation], timeout: 10.0)
 
         return navigatorIndex
     }

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import SwiftDocCTestUtilities
 @testable import SwiftDocC
 
 final class RenderIndexTests: XCTestCase {
-    func testTestBundleRenderIndexGeneration() throws {
+    func testTestBundleRenderIndexGeneration() async throws {
         let expectedIndexURL = try XCTUnwrap(
             Bundle.module.url(
                 forResource: "TestBundle-RenderIndex",
@@ -22,16 +22,14 @@ final class RenderIndexTests: XCTestCase {
                 subdirectory: "Test Resources"
             )
         )
-        
-        try XCTAssertEqual(
-            generatedRenderIndex(for: "LegacyBundle_DoNotUseInNewTests", with: "org.swift.docc.example"),
-            RenderIndex.fromURL(expectedIndexURL)
-        )
+        let renderIndex = try await generatedRenderIndex(for: "LegacyBundle_DoNotUseInNewTests", with: "org.swift.docc.example")
+        try XCTAssertEqual(renderIndex, RenderIndex.fromURL(expectedIndexURL))
     }
     
-    func testRenderIndexGenerationForBundleWithTechnologyRoot() throws {
+    func testRenderIndexGenerationForBundleWithTechnologyRoot() async throws {
+        let renderIndex = try await generatedRenderIndex(for: "BundleWithTechnologyRoot", with: "org.swift.docc.example")
         try XCTAssertEqual(
-            generatedRenderIndex(for: "BundleWithTechnologyRoot", with: "org.swift.docc.example"),
+            renderIndex,
             RenderIndex.fromString(#"""
                 {
                   "interfaceLanguages": {
@@ -62,8 +60,8 @@ final class RenderIndexTests: XCTestCase {
         )
     }
     
-    func testRenderIndexGenerationForMixedLanguageFramework() throws {
-        let renderIndex = try generatedRenderIndex(for: "MixedLanguageFramework", with: "org.swift.MixedLanguageFramework")
+    func testRenderIndexGenerationForMixedLanguageFramework() async throws {
+        let renderIndex = try await generatedRenderIndex(for: "MixedLanguageFramework", with: "org.swift.MixedLanguageFramework")
 
         XCTAssertEqual(
             renderIndex,
@@ -629,7 +627,7 @@ final class RenderIndexTests: XCTestCase {
         try assertRoundTripCoding(renderIndexFromJSON)
     }
     
-    func testRenderIndexGenerationWithDeprecatedSymbol() throws {
+    func testRenderIndexGenerationWithDeprecatedSymbol() async throws {
         let swiftWithDeprecatedSymbolGraphFile = Bundle.module.url(
                 forResource: "Deprecated",
                 withExtension: "symbols.json",
@@ -650,7 +648,7 @@ final class RenderIndexTests: XCTestCase {
         )
         try bundle.write(to: bundleDirectory)
 
-        let (_, loadedBundle, context) = try loadBundle(from: bundleDirectory)
+        let (_, loadedBundle, context) = try await loadBundle(from: bundleDirectory)
 
         XCTAssertEqual(
             try generatedRenderIndex(for: loadedBundle, withIdentifier: "com.test.example", withContext: context),
@@ -682,9 +680,10 @@ final class RenderIndexTests: XCTestCase {
             """#))
     }
     
-    func testRenderIndexGenerationWithCustomIcon() throws {
+    func testRenderIndexGenerationWithCustomIcon() async throws {
+        let renderIndex = try await generatedRenderIndex(for: "BookLikeContent", with: "org.swift.docc.Book")
         try XCTAssertEqual(
-            generatedRenderIndex(for: "BookLikeContent", with: "org.swift.docc.Book"),
+            renderIndex,
             RenderIndex.fromString(#"""
                 {
                   "interfaceLanguages" : {
@@ -737,8 +736,8 @@ final class RenderIndexTests: XCTestCase {
         )
     }
     
-    func generatedRenderIndex(for testBundleName: String, with bundleIdentifier: String) throws -> RenderIndex {
-        let (bundle, context) = try testBundleAndContext(named: testBundleName)
+    func generatedRenderIndex(for testBundleName: String, with bundleIdentifier: String) async throws -> RenderIndex {
+        let (bundle, context) = try await testBundleAndContext(named: testBundleName)
         return try generatedRenderIndex(for: bundle, withIdentifier: bundleIdentifier, withContext: context)
     }
     

--- a/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AnchorSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,8 +16,8 @@ import Markdown
 
 class AnchorSectionTests: XCTestCase {
         
-    func testResolvingArticleSubsections() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testResolvingArticleSubsections() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         
         // Verify the sub-sections of the article have been collected in the context
         [
@@ -74,8 +74,8 @@ class AnchorSectionTests: XCTestCase {
         XCTAssertEqual(sectionReference.url, "/documentation/technologyx/article#Article-Sub-Section")
     }
 
-    func testResolvingSymbolSubsections() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testResolvingSymbolSubsections() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         
         // Verify the sub-sections of the article have been collected in the context
         [
@@ -132,8 +132,8 @@ class AnchorSectionTests: XCTestCase {
         XCTAssertEqual(sectionReference.url, "/documentation/coolframework/coolclass#Symbol-Sub-Section")
     }
 
-    func testResolvingRootPageSubsections() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testResolvingRootPageSubsections() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         
         // Verify the sub-sections of the article have been collected in the context
         [
@@ -190,8 +190,8 @@ class AnchorSectionTests: XCTestCase {
         XCTAssertEqual(sectionReference.url, "/documentation/coolframework#Module-Sub-Section")
     }
     
-    func testWarnsWhenCuratingSections() throws {
-        let (_, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testWarnsWhenCuratingSections() async throws {
+        let (_, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         
         // The module page has 3 section links in a Topics group,
         // the context should contain the three warnings about those links

--- a/Tests/SwiftDocCTests/Infrastructure/AutoCapitalizationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/AutoCapitalizationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -42,7 +42,7 @@ class AutoCapitalizationTests: XCTestCase {
     
     // MARK: End-to-end integration tests
     
-    func testParametersCapitalization() throws {
+    func testParametersCapitalization() async throws {
         let symbolGraph = makeSymbolGraph(
             docComment: """
             Some symbol description.
@@ -60,7 +60,7 @@ class AutoCapitalizationTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 0)
         
@@ -88,7 +88,7 @@ class AutoCapitalizationTests: XCTestCase {
             [SwiftDocC.RenderBlockContent.paragraph(SwiftDocC.RenderBlockContent.Paragraph(inlineContent: [SwiftDocC.RenderInlineContent.text("a`nother invalid capitalization")]))]])
     }
     
-    func testIndividualParametersCapitalization() throws {
+    func testIndividualParametersCapitalization() async throws {
         let symbolGraph = makeSymbolGraph(
             docComment: """
             Some symbol description.
@@ -105,7 +105,7 @@ class AutoCapitalizationTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 0)
         
@@ -133,7 +133,7 @@ class AutoCapitalizationTests: XCTestCase {
             [SwiftDocC.RenderBlockContent.paragraph(SwiftDocC.RenderBlockContent.Paragraph(inlineContent: [SwiftDocC.RenderInlineContent.text("a`nother invalid capitalization")]))]])
     }
     
-    func testReturnsCapitalization() throws {
+    func testReturnsCapitalization() async throws {
         let symbolGraph = makeSymbolGraph(
             docComment: """
             Some symbol description.
@@ -146,7 +146,7 @@ class AutoCapitalizationTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 0)
         

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageLinkResolutionTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageLinkResolutionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import XCTest
 
 class DocumentationContext_MixedLanguageLinkResolutionTests: XCTestCase {
     
-    func testResolvingLinksWhenSymbolHasSameNameInBothLanguages() throws {
-         let (_, _, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkComplexLinks") { url in
+    func testResolvingLinksWhenSymbolHasSameNameInBothLanguages() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "MixedLanguageFrameworkComplexLinks") { url in
              let swiftSymbolGraph = url.appendingPathComponent("symbol-graph/swift/ObjCLinks.symbols.json")
              try String(contentsOf: swiftSymbolGraph)
                  .replacingOccurrences(of: "FooSwift", with: "FooObjC")

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageSourceLanguagesTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+MixedLanguageSourceLanguagesTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,22 +12,22 @@ import XCTest
 @testable import SwiftDocC
 
 class DocumentationContext_MixedLanguageSourceLanguagesTests: XCTestCase {
-    func testArticleAvailableSourceLanguagesIsSwiftInSwiftModule() throws {
-        try assertArticleAvailableSourceLanguages(
+    func testArticleAvailableSourceLanguagesIsSwiftInSwiftModule() async throws {
+        try await assertArticleAvailableSourceLanguages(
             moduleAvailableLanguages: [.swift],
             expectedArticleDefaultLanguage: .swift
         )
     }
     
-    func testArticleAvailableSourceLanguagesIsMixedLanguageInMixedLanguageModule() throws {
-        try assertArticleAvailableSourceLanguages(
+    func testArticleAvailableSourceLanguagesIsMixedLanguageInMixedLanguageModule() async throws {
+        try await assertArticleAvailableSourceLanguages(
             moduleAvailableLanguages: [.swift, .objectiveC],
             expectedArticleDefaultLanguage: .swift
         )
     }
     
-    func testArticleAvailableSourceLanguagesIsObjectiveCInObjectiveCModule() throws {
-        try assertArticleAvailableSourceLanguages(
+    func testArticleAvailableSourceLanguagesIsObjectiveCInObjectiveCModule() async throws {
+        try await assertArticleAvailableSourceLanguages(
             moduleAvailableLanguages: [.objectiveC],
             expectedArticleDefaultLanguage: .objectiveC
         )
@@ -38,13 +38,13 @@ class DocumentationContext_MixedLanguageSourceLanguagesTests: XCTestCase {
         expectedArticleDefaultLanguage: SourceLanguage,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws {
+    ) async throws {
         precondition(
             moduleAvailableLanguages.allSatisfy { [.swift, .objectiveC].contains($0) },
             "moduleAvailableLanguages can only contain Swift and Objective-C as languages."
         )
         
-        let (_, _, context) = try testBundleAndContext(copying: "MixedLanguageFramework") { url in
+        let (_, _, context) = try await testBundleAndContext(copying: "MixedLanguageFramework") { url in
             try """
             # MyArticle
             

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContext+RootPageTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import SymbolKit
 import SwiftDocCTestUtilities
 
 class DocumentationContext_RootPageTests: XCTestCase {
-    func testArticleOnlyCatalogWithExplicitTechnologyRoot() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testArticleOnlyCatalogWithExplicitTechnologyRoot() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "no-sgf-test.docc", content: [
                 // Root page for the collection
                 TextFile(name: "ReleaseNotes.md", utf8Content: """
@@ -50,8 +50,8 @@ class DocumentationContext_RootPageTests: XCTestCase {
                        ["/documentation/TestBundle/ReleaseNotes-1.2"])
     }
 
-    func testWarnsAboutExtensionFileTechnologyRoot() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testWarnsAboutExtensionFileTechnologyRoot() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "no-sgf-test.docc", content: [
                 // Root page for the collection
                 TextFile(name: "ReleaseNotes.md", utf8Content: """
@@ -84,8 +84,8 @@ class DocumentationContext_RootPageTests: XCTestCase {
         XCTAssertEqual(solution.replacements.first?.range.upperBound.line, 3)
     }
     
-    func testSingleArticleWithoutTechnologyRootDirective() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testSingleArticleWithoutTechnologyRootDirective() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "Something.docc", content: [
                 TextFile(name: "Article.md", utf8Content: """
                 # My article
@@ -101,8 +101,8 @@ class DocumentationContext_RootPageTests: XCTestCase {
         XCTAssertEqual(context.problems.count, 0)
     }
     
-    func testMultipleArticlesWithoutTechnologyRootDirective() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testMultipleArticlesWithoutTechnologyRootDirective() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "Something.docc", content: [
                 TextFile(name: "First.md", utf8Content: """
                 # My first article
@@ -135,8 +135,8 @@ class DocumentationContext_RootPageTests: XCTestCase {
         XCTAssertEqual(context.problems.count, 0)
     }
     
-    func testMultipleArticlesWithoutTechnologyRootDirectiveWithOneMatchingTheCatalogName() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testMultipleArticlesWithoutTechnologyRootDirectiveWithOneMatchingTheCatalogName() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "Something.docc", content: [
                 TextFile(name: "Something.md", utf8Content: """
                 # Some article

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -39,10 +39,10 @@ class DocumentationContextTests: XCTestCase {
     // This test checks unregistration of workspace data providers which is deprecated
     // Deprecating the test silences the deprecation warning when running the tests. It doesn't skip the test.
     @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
-    func testResolve() throws {
+    func testResolve() async throws {
         let workspace = DocumentationWorkspace()
         let context = try DocumentationContext(dataProvider: workspace)
-        let bundle = try testBundle(named: "LegacyBundle_DoNotUseInNewTests")
+        let bundle = try await testBundle(named: "LegacyBundle_DoNotUseInNewTests")
         let dataProvider = PrebuiltLocalFileSystemDataProvider(bundles: [bundle])
         try workspace.registerProvider(dataProvider)
         
@@ -82,8 +82,8 @@ class DocumentationContextTests: XCTestCase {
         }
     }
     
-    func testLoadEntity() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testLoadEntity() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         let identifier = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift)
         
@@ -416,13 +416,13 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(expectedDump, node.markup.debugDescription(), diffDescription(lhs: expectedDump, rhs: node.markup.debugDescription()))
     }
         
-    func testThrowsErrorForMissingResource() throws {
-        let (_, context) = try testBundleAndContext()
+    func testThrowsErrorForMissingResource() async throws {
+        let (_, context) = try await testBundleAndContext()
         XCTAssertThrowsError(try context.resource(with: ResourceReference(bundleID: "com.example.missing", path: "/missing.swift")), "Expected requesting an unknown file to result in an error.")
     }
 
-    func testThrowsErrorForQualifiedImagePaths() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+    func testThrowsErrorForQualifiedImagePaths() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             DataFile(name: "figure1.jpg", data: Data())
         ]))
         let id = bundle.id
@@ -434,8 +434,8 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertThrowsError(try context.resource(with: imageFigure), "Images should be registered (and referred to) by their name, not by their path.")
     }
     
-    func testResourceExists() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+    func testResourceExists() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             DataFile(name: "figure1.jpg", data: Data()),
             DataFile(name: "introposter.jpg", data: Data()),
         ]))
@@ -475,7 +475,7 @@ class DocumentationContextTests: XCTestCase {
         )
     }
     
-    func testURLs() throws {
+    func testURLs() async throws {
         let exampleDocumentation = Folder(name: "unit-test.docc", content: [
             Folder(name: "Symbols", content: []),
             Folder(name: "Resources", content: [
@@ -504,7 +504,7 @@ class DocumentationContextTests: XCTestCase {
         ])
 
         // Parse this test content
-        let (_, context) = try loadBundle(catalog: exampleDocumentation)
+        let (_, context) = try await loadBundle(catalog: exampleDocumentation)
         
         // Verify all the reference identifiers for this content
         XCTAssertEqual(context.knownIdentifiers.count, 3)
@@ -518,8 +518,8 @@ class DocumentationContextTests: XCTestCase {
         ])
     }
     
-    func testRegisteredImages() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+    func testRegisteredImages() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             DataFile(name: "figure1.jpg",          data: Data()),
             DataFile(name: "figure1.png",          data: Data()),
             DataFile(name: "figure1~dark.png",     data: Data()),
@@ -558,8 +558,8 @@ class DocumentationContextTests: XCTestCase {
         )
     }
     
-    func testExternalAssets() throws {
-        let (bundle, context) = try testBundleAndContext()
+    func testExternalAssets() async throws {
+        let (bundle, context) = try await testBundleAndContext()
         
         let image = context.resolveAsset(named: "https://example.com/figure.png", in: bundle.rootReference)
         XCTAssertNotNil(image)
@@ -576,8 +576,8 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(video.variants, [DataTraitCollection(userInterfaceStyle: .light, displayScale: .standard): URL(string: "https://example.com/introvideo.mp4")!])
     }
     
-    func testDownloadAssets() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+    func testDownloadAssets() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             DataFile(name: "intro.png", data: Data()),
             DataFile(name: "project.zip", data: Data()),
             
@@ -680,8 +680,8 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(identifiers.count, identifierSet.count, "Found duplicate identifiers.")
     }
     
-    func testDetectsReferenceCollision() throws {
-        let (_, context) = try testBundleAndContext(named: "TestBundleWithDupe")
+    func testDetectsReferenceCollision() async throws {
+        let (_, context) = try await testBundleAndContext(named: "TestBundleWithDupe")
 
         let problemWithDuplicate = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
 
@@ -692,8 +692,8 @@ class DocumentationContextTests: XCTestCase {
 
     }
     
-    func testDetectsMultipleMarkdownFilesWithSameName() throws {
-        let (_, context) = try testBundleAndContext(named: "TestBundleWithDupMD")
+    func testDetectsMultipleMarkdownFilesWithSameName() async throws {
+        let (_, context) = try await testBundleAndContext(named: "TestBundleWithDupMD")
 
         let problemWithDuplicateReference = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
 
@@ -706,7 +706,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(localizedSummarySecond, "Redeclaration of \'overview.md\'; this file will be skipped")
     }
     
-    func testUsesMultipleDocExtensionFilesWithSameName() throws {
+    func testUsesMultipleDocExtensionFilesWithSameName() async throws {
         
         // Generate 2 different symbols with the same name.
         let someSymbol = makeSymbol(id: "someEnumSymbol-id", kind: .init(rawValue: "enum"), pathComponents: ["SomeDirectory", "MyEnum"])
@@ -751,7 +751,7 @@ class DocumentationContextTests: XCTestCase {
                 )
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
 
         // Since documentation extensions' filenames have no impact on the URL of pages, we should not see warnings enforcing unique filenames for them.
         let problemWithDuplicateReference = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateReference" }
@@ -767,7 +767,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertEqual(anotherEnumSymbol.abstract?.plainText, "A documentation extension for an unrelated enum.", "The abstract should be from the symbol's documentation extension.")
     }
 
-    func testGraphChecks() throws {
+    func testGraphChecks() async throws {
         var configuration = DocumentationContext.Configuration()
         configuration.topicAnalysisConfiguration.additionalChecks.append(
             { (context, reference) -> [Problem] in
@@ -780,7 +780,7 @@ class DocumentationContextTests: XCTestCase {
             # Some root page
             """)
         ])
-        let (_, context) = try loadBundle(catalog: catalog, configuration: configuration)
+        let (_, context) = try await loadBundle(catalog: catalog, configuration: configuration)
         
         /// Checks if the custom check added problems to the context.
         let testProblems = context.problems.filter({ (problem) -> Bool in
@@ -804,7 +804,7 @@ class DocumentationContextTests: XCTestCase {
         }
     }
     
-    func testIgnoresUnknownMarkupFiles() throws {
+    func testIgnoresUnknownMarkupFiles() async throws {
         let testCatalog = Folder(name: "TestIgnoresUnknownMarkupFiles.docc", content: [
             InfoPlist(displayName: "TestIgnoresUnknownMarkupFiles", identifier: "com.example.documentation"),
             Folder(name: "Resources", content: [
@@ -813,13 +813,13 @@ class DocumentationContextTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         XCTAssertEqual(context.knownPages.map { $0.path }, ["/tutorials/TestIgnoresUnknownMarkupFiles/Article1"])
         XCTAssertTrue(context.problems.map { $0.diagnostic.identifier }.contains("org.swift.docc.Article.Title.NotFound"))
     }
     
-    func testLoadsSymbolData() throws {
+    func testLoadsSymbolData() async throws {
         let testCatalog = Folder(name: "TestIgnoresUnknownMarkupFiles.docc", content: [
             InfoPlist(displayName: "TestIgnoresUnknownMarkupFiles", identifier: "com.example.documentation"),
             Folder(name: "Resources", content: [
@@ -835,7 +835,7 @@ class DocumentationContextTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         // Symbols are loaded
         XCTAssertFalse(context.documentationCache.isEmpty)
@@ -1057,7 +1057,7 @@ class DocumentationContextTests: XCTestCase {
                        """)
     }
     
-    func testMergesMultipleSymbolDeclarations() throws {
+    func testMergesMultipleSymbolDeclarations() async throws {
         let graphContentiOS = try String(contentsOf: Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json"))
@@ -1078,7 +1078,7 @@ class DocumentationContextTests: XCTestCase {
             ]),
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         // MyClass is loaded
         guard let myClass = context.documentationCache["s:5MyKit0A5ClassC"],
@@ -1094,7 +1094,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertNotNil(myClassSymbol.declaration[[PlatformName(operatingSystemName: "ios"), PlatformName(operatingSystemName: "macos")]] ?? myClassSymbol.declaration[[PlatformName(operatingSystemName: "macos"), PlatformName(operatingSystemName: "ios")]])
     }
     
-    func testMergedMultipleSymbolDeclarationsIncludesPlatformSpecificSymbols() throws {
+    func testMergedMultipleSymbolDeclarationsIncludesPlatformSpecificSymbols() async throws {
         let iOSGraphURL = Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json")
@@ -1135,7 +1135,7 @@ class DocumentationContextTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         // MyFunction is loaded
         XCTAssertNotNil(context.documentationCache[myFunctionSymbolPreciseIdentifier], "myFunction which only exist on iOS should be found in the graph")
@@ -1148,7 +1148,7 @@ class DocumentationContextTests: XCTestCase {
         )
     }
     
-    func testResolvesSymbolsBetweenSymbolGraphs() throws {
+    func testResolvesSymbolsBetweenSymbolGraphs() async throws {
         let testCatalog = Folder(name: "CrossGraphResolving.docc", content: [
             InfoPlist(displayName: "CrossGraphResolving", identifier: "com.example.documentation"),
             Folder(name: "Resources", content: [
@@ -1163,7 +1163,7 @@ class DocumentationContextTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         // SideClass is loaded
         guard let sideClass = context.documentationCache["s:7SideKit0A5ClassC"],
@@ -1178,7 +1178,7 @@ class DocumentationContextTests: XCTestCase {
         })
     }
 
-    func testLoadsDeclarationWithNoOS() throws {
+    func testLoadsDeclarationWithNoOS() async throws {
         var graphContentiOS = try String(contentsOf: Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
             .appendingPathComponent("mykit-iOS.symbols.json"))
@@ -1194,7 +1194,7 @@ class DocumentationContextTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         // MyClass is loaded
         guard let myClass = context.documentationCache["s:5MyKit0A5ClassC"],
@@ -1207,7 +1207,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssertNotNil(myClassSymbol.declaration[[nil]])
     }
     
-    func testDetectsDuplicateSymbolArticles() throws {
+    func testDetectsDuplicateSymbolArticles() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
                 makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
@@ -1226,7 +1226,7 @@ class DocumentationContextTests: XCTestCase {
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
 
         let duplicateExtensionProblems = context.problems.filter { $0.diagnostic.identifier == "org.swift.docc.DuplicateMarkdownTitleSymbolReferences" }
         let diagnostic = try XCTUnwrap(duplicateExtensionProblems.first).diagnostic
@@ -1240,7 +1240,7 @@ class DocumentationContextTests: XCTestCase {
         XCTAssert(missingMarkupURLs.isEmpty, "\(missingMarkupURLs.map(\.lastPathComponent).sorted()) isn't mentioned in the diagnostic.")
     }
     
-    func testCanResolveArticleFromTutorial() throws {
+    func testCanResolveArticleFromTutorial() async throws {
         struct TestData {
             let symbolGraphNames: [String]
             
@@ -1283,7 +1283,7 @@ class DocumentationContextTests: XCTestCase {
                 """),
             ] + testData.symbolGraphFiles)
             
-            let (bundle, context) = try loadBundle(catalog: testCatalog)
+            let (bundle, context) = try await loadBundle(catalog: testCatalog)
             let renderContext = RenderContext(documentationContext: context, bundle: bundle)
             
             let identifier = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
@@ -1305,8 +1305,8 @@ class DocumentationContextTests: XCTestCase {
         }
     }
     
-    func testCuratesSymbolsAndArticlesCorrectly() throws {
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCuratesSymbolsAndArticlesCorrectly() async throws {
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Sort the edges for each node to get consistent results, no matter the order that the symbols were processed.
         for (source, targets) in context.topicGraph.edges {
@@ -1397,11 +1397,11 @@ let expected = """
         return (node, tgNode)
     }
     
-    func testSortingBreadcrumbsOfEqualDistanceToRoot() throws {
+    func testSortingBreadcrumbsOfEqualDistanceToRoot() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName"))
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
         ///
@@ -1433,11 +1433,11 @@ let expected = """
         XCTAssertEqual(["/documentation/SomeModuleName", "/documentation/SomeModuleName/DDD"], canonicalPathFFF.map({ $0.path }))
     }
     
-    func testSortingBreadcrumbsOfDifferentDistancesToRoot() throws {
+    func testSortingBreadcrumbsOfDifferentDistancesToRoot() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName"))
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         let moduleTopicNode = try XCTUnwrap(context.topicGraph.nodeWithReference(moduleReference))
         
@@ -1475,13 +1475,13 @@ let expected = """
     }
 
     // Verify that a symbol that has no parents in the symbol graph is automatically curated under the module node.
-    func testRootSymbolsAreCuratedInModule() throws {
+    func testRootSymbolsAreCuratedInModule() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
                 makeSymbol(id: "some-class-id",    kind: .class,    pathComponents: ["SomeClass"]),
             ])),
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         // Verify the node is a child of the module node when the graph is loaded.
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
@@ -1491,9 +1491,9 @@ let expected = """
     }
     
     /// Tests whether tutorial curated multiple times gets the correct breadcrumbs and hierarchy.
-    func testCurateTutorialMultipleTimes() throws {
+    func testCurateTutorialMultipleTimes() async throws {
         // Curate "TestTutorial" under MyKit as well as TechnologyX.
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             let myKitURL = root.appendingPathComponent("documentation/mykit.md")
             let text = try String(contentsOf: myKitURL).replacingOccurrences(of: "## Topics", with: """
             ## Topics
@@ -1518,9 +1518,9 @@ let expected = """
         XCTAssertEqual(paths, [["/documentation/MyKit"], ["/documentation/MyKit", "/documentation/Test-Bundle/article"], ["/tutorials/TestOverview", "/tutorials/TestOverview/$volume", "/tutorials/TestOverview/Chapter-1"]])
     }
 
-    func testNonOverloadPaths() throws {
+    func testNonOverloadPaths() async throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
             let text = try String(contentsOf: sideKitURL).replacingOccurrences(of: "\"symbols\" : [", with: """
             "symbols" : [
@@ -1571,11 +1571,11 @@ let expected = """
         XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-swift.var", sourceLanguage: .swift)))
     }
     
-    func testModuleLanguageFallsBackToSwiftIfItHasNoSymbols() throws {
+    func testModuleLanguageFallsBackToSwiftIfItHasNoSymbols() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName")),
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(
             context.soleRootModuleReference.map { context.sourceLanguages(for: $0) },
@@ -1584,9 +1584,9 @@ let expected = """
         )
     }
     
-    func testOverloadPlusNonOverloadCollisionPaths() throws {
+    func testOverloadPlusNonOverloadCollisionPaths() async throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
             let text = try String(contentsOf: sideKitURL).replacingOccurrences(of: "\"symbols\" : [", with: """
             "symbols" : [
@@ -1656,14 +1656,14 @@ let expected = """
         XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/SideClass/test-959hd", sourceLanguage: .swift)))
     }
 
-    func testUnknownSymbolKind() throws {
+    func testUnknownSymbolKind() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
                 makeSymbol(id: "some-symbol-id",  kind: .init(identifier: "blip-blop"), pathComponents: ["SomeUnknownSymbol"]),
             ])),
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
         // Get the node, verify its kind is unknown
@@ -1671,8 +1671,8 @@ let expected = """
         XCTAssertEqual(node.kind, .unknown)
     }
     
-    func testCuratingSymbolsWithSpecialCharacters() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "InheritedOperators") { root in
+    func testCuratingSymbolsWithSpecialCharacters() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "InheritedOperators") { root in
             try """
             # ``Operators/MyNumber``
             
@@ -1710,8 +1710,8 @@ let expected = """
         XCTAssertEqual(unresolvedTopicProblems.map(\.diagnostic.summary), [], "All links should resolve without warnings")
     }
     
-    func testOperatorReferences() throws {
-        let (_, context) = try testBundleAndContext(named: "InheritedOperators")
+    func testOperatorReferences() async throws {
+        let (_, context) = try await testBundleAndContext(named: "InheritedOperators")
         
         let pageIdentifiersAndNames = Dictionary(uniqueKeysWithValues: try context.knownPages.map { reference in
             (key: reference.path, value: try context.entity(with: reference).name.description)
@@ -1745,7 +1745,7 @@ let expected = """
         XCTAssertEqual("/=(_:_:)",  pageIdentifiersAndNames["/documentation/Operators/MyNumber/_=(_:_:)"])
     }
     
-    func testFileNamesWithDifferentPunctuation() throws {
+    func testFileNamesWithDifferentPunctuation() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 TextFile(name: "Hello-world.md", utf8Content: """
@@ -1779,7 +1779,7 @@ let expected = """
                 """),
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
 
         XCTAssertEqual(context.problems.map(\.diagnostic.summary), ["Redeclaration of 'Hello world.md'; this file will be skipped"])
         
@@ -1792,7 +1792,7 @@ let expected = """
         ])
     }
     
-    func testSpecialCharactersInLinks() throws {
+    func testSpecialCharactersInLinks() async throws {
         let catalog = Folder(name: "special-characters.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "SomeModuleName",
@@ -1853,7 +1853,7 @@ let expected = """
             """),
         ])
         let bundleURL = try catalog.write(inside: createTemporaryDirectory())
-        let (_, bundle, context) = try loadBundle(from: bundleURL)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL)
 
         let problems = context.problems
         XCTAssertEqual(problems.count, 0, "Unexpected problems: \(problems.map(\.diagnostic.summary).sorted())")
@@ -1982,9 +1982,9 @@ let expected = """
         )
     }
     
-    func testNonOverloadCollisionFromExtension() throws {
+    func testNonOverloadCollisionFromExtension() async throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: ["mykit-iOS.symbols.json"]) { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: ["mykit-iOS.symbols.json"]) { root in
             let sideKitURL = root.appendingPathComponent("something@SideKit.symbols.json")
             let text = """
             {
@@ -2046,7 +2046,7 @@ let expected = """
         XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/SideKit/sideClass-swift.var", sourceLanguage: .swift)))
     }
 
-    func testUnresolvedSidecarDiagnostics() throws {
+    func testUnresolvedSidecarDiagnostics() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
@@ -2068,7 +2068,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         let unmatchedSidecarProblem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.SymbolUnmatched" }))
         XCTAssertNotNil(unmatchedSidecarProblem)
@@ -2084,7 +2084,7 @@ let expected = """
         XCTAssertEqual(unmatchedSidecarDiagnostic.severity, .warning)
     }
     
-    func testExtendingSymbolWithSpaceInName() throws {
+    func testExtendingSymbolWithSpaceInName() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
@@ -2106,7 +2106,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
         
@@ -2116,7 +2116,7 @@ let expected = """
         XCTAssertEqual((node.semantic as? Symbol)?.abstract?.plainText, "Extend a symbol with a space in its name.")
     }
 
-    func testDeprecationSummaryWithLocalLink() throws {
+    func testDeprecationSummaryWithLocalLink() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
@@ -2146,7 +2146,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems:\n\(context.problems.map(\.diagnostic.summary).joined(separator: "\n"))")
         
@@ -2169,7 +2169,7 @@ let expected = """
         }
     }
     
-    func testUncuratedArticleDiagnostics() throws {
+    func testUncuratedArticleDiagnostics() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             // This setup only happens if the developer manually mixes symbol inputs from different builds
             JSONFile(name: "FirstModuleName.symbols.json", content: makeSymbolGraph(moduleName: "FirstModuleName")),
@@ -2184,7 +2184,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: .information))
+        let (bundle, context) = try await loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: .information))
         XCTAssertNil(context.soleRootModuleReference)
         
         let curationDiagnostics = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.ArticleUncurated" }).map(\.diagnostic)
@@ -2194,9 +2194,9 @@ let expected = """
         XCTAssertEqual(sidecarDiagnostic.severity, .information)
     }
     
-    func testUpdatesReferencesForChildrenOfCollisions() throws {
+    func testUpdatesReferencesForChildrenOfCollisions() async throws {
         // Add some symbol collisions to graph
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             let sideKitURL = root.appendingPathComponent("sidekit.symbols.json")
             var text = try String(contentsOf: sideKitURL)
             
@@ -2340,11 +2340,11 @@ let expected = """
         XCTAssertEqual(context.documentationCache.reference(symbolID: "s:5MyKit0A5MyProtocol0Afunc()DefaultImp")?.path, "/documentation/SideKit/SideProtocol/func()-2dxqn")
     }
 
-    func testResolvingArticleLinkBeforeCuratingIt() throws {
+    func testResolvingArticleLinkBeforeCuratingIt() async throws {
         var newArticle1URL: URL!
         
         // Add an article without curating it anywhere
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Curate MyKit -> new-article1
             let myKitURL = root.appendingPathComponent("documentation").appendingPathComponent("mykit.md")
             try """
@@ -2379,8 +2379,8 @@ let expected = """
         XCTAssertEqual(context.problems.filter { $0.diagnostic.source?.path.hasSuffix(newArticle1URL.lastPathComponent) == true }.count, 0)
     }
 
-    func testPrefersNonSymbolsInDocLink() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
+    func testPrefersNonSymbolsInDocLink() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
             // This bundle has a top-level struct named "Wrapper". Adding an article named "Wrapper.md" introduces a possibility for a link collision
             try """
             # An article
@@ -2421,9 +2421,9 @@ let expected = """
     }
     
     // Modules that are being extended should not have their own symbol in the current bundle's graph.
-    func testNoSymbolForTertiarySymbolGraphModules() throws {
+    func testNoSymbolForTertiarySymbolGraphModules() async throws {
         // Add an article without curating it anywhere
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Create an extension only symbol graph.
             let tertiaryURL = root.appendingPathComponent("Tertiary@MyKit.symbols.json")
             try """
@@ -2456,8 +2456,8 @@ let expected = """
         XCTAssertNil(try? context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Tertiary", sourceLanguage: .swift)))
     }
     
-    func testDeclarationTokenKinds() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDeclarationTokenKinds() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         let myFunc = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
@@ -2487,7 +2487,7 @@ let expected = """
     }
     
     // Test reference resolving in symbol graph docs
-    func testReferenceResolvingDiagnosticsInSourceDocs() throws {
+    func testReferenceResolvingDiagnosticsInSourceDocs() async throws {
         for (source, expectedDiagnosticSource) in [
             ("file:///path/to/file.swift", "file:///path/to/file.swift"),
             // Test the scenario where the symbol graph file contains invalid URLs (rdar://77335208).
@@ -2584,7 +2584,7 @@ let expected = """
             try text.write(to: referencesURL, atomically: true, encoding: .utf8)
             
             // Load the bundle & reference resolve symbol graph docs
-            let (_, _, context) = try loadBundle(from: targetURL)
+            let (_, _, context) = try await loadBundle(from: targetURL)
             
             guard context.problems.count == 5 else {
                 XCTFail("Expected 5 problems during reference resolving; got \(context.problems.count)")
@@ -2604,8 +2604,8 @@ let expected = """
         }
     }
     
-    func testNavigatorTitle() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNavigatorTitle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         func renderNodeForPath(path: String) throws -> (DocumentationNode, RenderNode) {
             let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
             let node = try context.entity(with: reference)
@@ -2643,7 +2643,7 @@ let expected = """
         }
     }
     
-    func testCrossSymbolGraphPathCollisions() throws {
+    func testCrossSymbolGraphPathCollisions() async throws {
         // Create temp folder
         let tempURL = try createTemporaryDirectory()
 
@@ -2659,7 +2659,7 @@ let expected = """
         ]).write(inside: tempURL)
         
         // Load test bundle
-        let (_, _, context) = try loadBundle(from: catalogURL)
+        let (_, _, context) = try await loadBundle(from: catalogURL)
         
         let referenceForPath: (String) -> ResolvedTopicReference = { path in
             return ResolvedTopicReference(bundleID: "com.test.collisions", path: "/documentation" + path, sourceLanguage: .swift)
@@ -2678,7 +2678,7 @@ let expected = """
         XCTAssertNotNil(try context.entity(with: referenceForPath("/Collisions/SharedStruct/iOSVar")))
     }
     
-    func testLinkToSymbolWithoutPage() throws {
+    func testLinkToSymbolWithoutPage() async throws {
         let inheritedDefaultImplementationsSGF = Bundle.module.url(
             forResource: "InheritedDefaultImplementations.symbols",
             withExtension: "json",
@@ -2705,18 +2705,18 @@ let expected = """
             ]
         ).write(inside: createTemporaryDirectory())
         
-        let (_, _, context) = try loadBundle(from: testBundle)
+        let (_, _, context) = try await loadBundle(from: testBundle)
         
         let problem = try XCTUnwrap(context.problems.first(where: { $0.diagnostic.identifier == "org.swift.docc.unresolvedTopicReference" }))
         XCTAssertEqual(problem.diagnostic.summary, "'FirstTarget/Comparable/localDefaultImplementation()' has no page and isn't available for linking.")
     }
     
-    func testContextCachesReferences() throws {
+    func testContextCachesReferences() async throws {
         let bundleID: DocumentationBundle.Identifier = #function
         // Verify there is no pool bucket for the bundle we're about to test
         XCTAssertNil(ResolvedTopicReference._numberOfCachedReferences(bundleID: bundleID))
         
-        let (_, _, _) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { rootURL in
+        let (_, _, _) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { rootURL in
             let infoPlistURL = rootURL.appendingPathComponent("Info.plist", isDirectory: false)
             try! String(contentsOf: infoPlistURL)
                 .replacingOccurrences(of: "org.swift.docc.example", with: bundleID.rawValue)
@@ -2743,8 +2743,8 @@ let expected = """
         ResolvedTopicReference.purgePool(for: bundleID)
     }
     
-    func testAbstractAfterMetadataDirective() throws {
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testAbstractAfterMetadataDirective() async throws {
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         // Get the SideKit/SideClass/init() node and verify it has an abstract and no discussion.
         // We're verifying that the metadata directive between the title and the abstract didn't cause
@@ -2759,7 +2759,7 @@ let expected = """
     }
 
     /// rdar://69242313
-    func testLinkResolutionDoesNotSkipSymbolGraph() throws {
+    func testLinkResolutionDoesNotSkipSymbolGraph() async throws {
         let tempURL = try createTemporaryDirectory()
         
         let bundleURL = try Folder(name: "Missing.docc", content: [
@@ -2769,7 +2769,7 @@ let expected = """
                         subdirectory: "Test Resources")!),
         ]).write(inside: tempURL)
         
-        let (_, _, context) = try XCTUnwrap(loadBundle(from: bundleURL))
+        let (_, _, context) = try await loadBundle(from: bundleURL)
         
         // MissingDocs contains a struct that has a link to a non-existent type.
         // If there are no problems, that indicates that symbol graph link
@@ -2794,8 +2794,8 @@ let expected = """
         XCTAssertThrowsError(try DocumentationNode(reference: reference, article: semanticArticle))
     }
     
-    func testTaskGroupsPersistInitialRangesFromMarkup() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testTaskGroupsPersistInitialRangesFromMarkup() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Verify task group ranges are persisted for symbol docs
         let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift)
@@ -2831,8 +2831,8 @@ let expected = """
 
     /// Tests that diagnostics raised during link resolution for symbols have the correct source URLs
     /// - Bug: rdar://63288817
-    func testDiagnosticsForSymbolsHaveCorrectSource() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testDiagnosticsForSymbolsHaveCorrectSource() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             let extensionFile = """
             # ``SideKit/SideClass/myFunction()``
 
@@ -2874,7 +2874,7 @@ let expected = """
         XCTAssertEqual(extensionFileChunks.count, 1)
     }
 
-    func testLinkResolutionDiagnosticsEmittedForTechnologyPages() throws {
+    func testLinkResolutionDiagnosticsEmittedForTechnologyPages() async throws {
         let tempURL = try createTemporaryDirectory()
 
         let bundleURL = try Folder(name: "module-links.docc", content: [
@@ -2902,14 +2902,14 @@ let expected = """
                 """),
         ]).write(inside: tempURL)
 
-        let (_, _, context) = try loadBundle(from: bundleURL)
+        let (_, _, context) = try await loadBundle(from: bundleURL)
         let problems = context.diagnosticEngine.problems
         let linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("sidekit.md") == true }
         XCTAssertEqual(linkResolutionProblems.count, 1)
         XCTAssertEqual(linkResolutionProblems.first?.diagnostic.identifier, "org.swift.docc.unresolvedTopicReference")
     }
     
-    func testLinkDiagnosticsInSynthesizedTechnologyRoots() throws {
+    func testLinkDiagnosticsInSynthesizedTechnologyRoots() async throws {
         // Verify that when synthesizing a technology root, links are resolved in the roots content.
         // Also, if an article is promoted to a root, verify that any existing metadata is preserved.
         
@@ -2942,7 +2942,7 @@ let expected = """
                     - <doc:#NotFoundHeading>
                     """),
                     ])
-                let (_, context) = try loadBundle(catalog: catalog)
+                let (_, context) = try await loadBundle(catalog: catalog)
                 
                 XCTAssertEqual(context.problems.map(\.diagnostic.summary), [
                     "'NotFoundSymbol' doesn't exist at '/Root'",
@@ -2987,7 +2987,7 @@ let expected = """
                         """),
                     ])
                 
-                let (_, context) = try loadBundle(catalog: catalog)
+                let (_, context) = try await loadBundle(catalog: catalog)
                 
                 XCTAssertEqual(context.problems.map(\.diagnostic.summary), [
                     "'NotFoundSymbol' doesn't exist at '/CatalogName'",
@@ -3032,7 +3032,7 @@ let expected = """
                     """),
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.map(\.diagnostic.summary).sorted(), [
             "'NotFoundArticle' doesn't exist at '/CatalogName/Second'",
@@ -3045,7 +3045,7 @@ let expected = """
         XCTAssertNotNil(rootPage.metadata?.technologyRoot)
     }
     
-    func testResolvingLinksToHeaders() throws {
+    func testResolvingLinksToHeaders() async throws {
         let tempURL = try createTemporaryDirectory()
 
         let bundleURL = try Folder(name: "module-links.docc", content: [
@@ -3110,7 +3110,7 @@ let expected = """
                 """),
         ]).write(inside: tempURL)
 
-        let (_, _, context) = try loadBundle(from: bundleURL)
+        let (_, _, context) = try await loadBundle(from: bundleURL)
         
         let articleReference = try XCTUnwrap(context.knownPages.first)
         let node = try context.entity(with: articleReference)
@@ -3135,8 +3135,8 @@ let expected = """
         XCTAssertEqual(node.anchorSections.dropLast().last?.reference.absoluteString, "doc://com.test.docc/documentation/article#Emoji-%F0%9F%92%BB")
     }
 
-    func testResolvingLinksToTopicSections() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testResolvingLinksToTopicSections() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "unit-test.docc", content: [
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
                 
@@ -3277,10 +3277,10 @@ let expected = """
         ])
     }
     
-    func testExtensionCanUseLanguageSpecificRelativeLinks() throws {
+    func testExtensionCanUseLanguageSpecificRelativeLinks() async throws {
         // This test uses a symbol with different names in Swift and Objective-C, each with a member that's only available in that language.
         let symbolID = "some-symbol-id"
-        let (_, context) = try loadBundle(catalog:
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "unit-test.docc", content: [
                 Folder(name: "swift", content: [
                     JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
@@ -3393,7 +3393,7 @@ let expected = """
         ])
     }
     
-    func testWarnOnMultipleMarkdownExtensions() throws {
+    func testWarnOnMultipleMarkdownExtensions() async throws {
         let fileContent = """
         # ``MyKit/MyClass/myFunction()``
 
@@ -3426,7 +3426,7 @@ let expected = """
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
 
         // Parse this test content
-        let (_, _, context) = try loadBundle(from: bundleURL)
+        let (_, _, context) = try await loadBundle(from: bundleURL)
 
         let identifier = "org.swift.docc.DuplicateMarkdownTitleSymbolReferences"
         let duplicateMarkdownProblems = context.problems.filter({ $0.diagnostic.identifier == identifier })
@@ -3439,10 +3439,10 @@ let expected = """
     /// This test verifies that collision nodes and children of collision nodes are correctly
     /// matched with their documentation extension files. Besides verifying the correct content
     /// it verifies also that the curation in these doc extensions is reflected in the topic graph.
-    func testMatchesCorrectlyDocExtensionToChildOfCollisionTopic() throws {
+    func testMatchesCorrectlyDocExtensionToChildOfCollisionTopic() async throws {
         let fifthTestMemberPath = "ShapeKit/OverloadedParentStruct-1jr3p/fifthTestMember"
         
-        let (_, bundle, context) = try testBundleAndContext(copying: "OverloadedSymbols") { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "OverloadedSymbols") { url in
             // Add an article to be curated from collided nodes' doc extensions.
             try """
             # New Article
@@ -3509,8 +3509,8 @@ let expected = """
         XCTAssertTrue(tgNode2.contains(articleReference))
     }
     
-    func testMatchesDocumentationExtensionsAsSymbolLinks() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+    func testMatchesDocumentationExtensionsAsSymbolLinks() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
             // Two colliding symbols that differ by capitalization.
             try """
             # ``MixedFramework/CollisionsWithDifferentCapitalization/someThing``
@@ -3620,8 +3620,8 @@ let expected = """
         }
     }
     
-    func testMatchesDocumentationExtensionsWithSourceLanguageSpecificLinks() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+    func testMatchesDocumentationExtensionsWithSourceLanguageSpecificLinks() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
             // typedef NS_OPTIONS(NSInteger, MyObjectiveCOption) {
             //     MyObjectiveCOptionNone                                      = 0,
             //     MyObjectiveCOptionFirst                                     = 1 << 0,
@@ -3722,8 +3722,8 @@ let expected = """
         }
     }
     
-    func testMatchesDocumentationExtensionsRelativeToModule() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+    func testMatchesDocumentationExtensionsRelativeToModule() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
             // Top level symbols, omitting the module name
             try """
             # ``MyStruct/myStructProperty``
@@ -3765,8 +3765,8 @@ let expected = """
         }
     }
     
-    func testCurationOfSymbolsWithSameNameAsModule() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
+    func testCurationOfSymbolsWithSameNameAsModule() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
             // Top level symbols, omitting the module name
             try """
             # ``Something``
@@ -3795,8 +3795,8 @@ let expected = """
         }
     }
     
-    func testMultipleDocumentationExtensionMatchDiagnostic() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+    func testMultipleDocumentationExtensionMatchDiagnostic() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
             // typedef NS_OPTIONS(NSInteger, MyObjectiveCOption) {
             //     MyObjectiveCOptionNone                                      = 0,
             //     MyObjectiveCOptionFirst                                     = 1 << 0,
@@ -3852,7 +3852,7 @@ let expected = """
         XCTAssertNotEqual(methodMultipleMatchProblem.diagnostic.source, methodMultipleMatchProblem.diagnostic.notes.first?.source, "The warning and the note should refer to different documentation extension files")
     }
     
-    func testAutomaticallyCuratesArticles() throws {
+    func testAutomaticallyCuratesArticles() async throws {
         let articleOne = TextFile(name: "Article1.md", utf8Content: """
             # Article 1
 
@@ -3886,7 +3886,7 @@ let expected = """
                 articleOne,
                 articleTwo,
             ]).write(inside: tempURL)
-            let (_, bundle, context) = try loadBundle(from: bundleURL)
+            let (_, bundle, context) = try await loadBundle(from: bundleURL)
             
             let identifiers = context.problems.map(\.diagnostic.identifier)
             XCTAssertFalse(identifiers.contains(where: { $0 == "org.swift.docc.ArticleUncurated" }))
@@ -3926,7 +3926,7 @@ let expected = """
                 articleOne,
                 articleTwo,
             ]).write(inside: tempURL)
-            let (_, bundle, context) = try loadBundle(from: bundleURL)
+            let (_, bundle, context) = try await loadBundle(from: bundleURL)
             
             let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
             let docNode = try context.entity(with: rootReference)
@@ -3936,7 +3936,7 @@ let expected = """
         }
     }
     
-    func testAutomaticTaskGroupsPlacedAfterManualCuration() throws {
+    func testAutomaticTaskGroupsPlacedAfterManualCuration() async throws {
         let tempURL = try createTemporaryDirectory()
         
         let bundleURL = try Folder(name: "Module.docc", content: [
@@ -3969,7 +3969,7 @@ let expected = """
                 - <doc:Article1>
                 """),
         ]).write(inside: tempURL)
-        let (_, bundle, context) = try loadBundle(from: bundleURL)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL)
         
         let rootReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Module", sourceLanguage: .swift)
         let docNode = try context.entity(with: rootReference)
@@ -3991,8 +3991,8 @@ let expected = """
     }
     
     // Verifies if the context resolves linkable nodes.
-    func testLinkableNodes() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testLinkableNodes() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             try "# Article1".write(to: url.appendingPathComponent("resolvable-article.md"), atomically: true, encoding: .utf8)
             let myKitURL = url.appendingPathComponent("documentation").appendingPathComponent("mykit.md")
             try String(contentsOf: myKitURL)
@@ -4012,9 +4012,9 @@ let expected = """
     }
     
     // Verifies if the context fails to resolve non-resolvable nodes.
-    func testNonLinkableNodes() throws {
+    func testNonLinkableNodes() async throws {
         // Create a bundle with variety absolute and relative links and symbol links to a non linkable node.
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``SideKit/SideClass``
             Abstract.
@@ -4135,7 +4135,7 @@ let expected = """
 
     /// Verify we resolve a relative link to the article if we have
     /// an article, a tutorial, and a symbol with the *same* names.
-    func testResolvePrecedenceArticleOverTutorialOverSymbol() throws {
+    func testResolvePrecedenceArticleOverTutorialOverSymbol() async throws {
         // Verify resolves correctly between a bundle with an article and a tutorial.
         do {
             let infoPlistURL = try XCTUnwrap(Bundle.module.url(forResource: "Info+Availability", withExtension: "plist", subdirectory: "Test Resources"))
@@ -4150,7 +4150,7 @@ let expected = """
             try testBundle.write(to: tempFolderURL)
             
             // Load the bundle
-            let (_, bundle, context) = try loadBundle(from: tempFolderURL)
+            let (_, bundle, context) = try await loadBundle(from: tempFolderURL)
             // Verify the context contains the conflicting topic names
             // Article
             XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
@@ -4187,7 +4187,7 @@ let expected = """
             try testBundle.write(to: tempFolderURL)
             
             // Load the bundle
-            let (_, bundle, context) = try loadBundle(from: tempFolderURL)
+            let (_, bundle, context) = try await loadBundle(from: tempFolderURL)
             // Verify the context contains the conflicting topic names
             // Article
             XCTAssertNotNil(context.documentationCache[ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/Test", sourceLanguage: .swift)])
@@ -4215,7 +4215,7 @@ let expected = """
         }
     }
 
-    func testResolvePrecedenceSymbolInBackticks() throws {
+    func testResolvePrecedenceSymbolInBackticks() async throws {
         // Verify resolves correctly a double-backtick link.
         do {
             let infoPlistURL = try XCTUnwrap(Bundle.module.url(forResource: "Info+Availability", withExtension: "plist", subdirectory: "Test Resources"))
@@ -4248,7 +4248,7 @@ let expected = """
             try testBundle.write(to: tempFolderURL)
             
             // Load the bundle
-            let (_, bundle, context) = try loadBundle(from: tempFolderURL)
+            let (_, bundle, context) = try await loadBundle(from: tempFolderURL)
             
             let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)
             let moduleReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs", sourceLanguage: .swift)
@@ -4301,7 +4301,7 @@ let expected = """
         }
     }
     
-    func testSymbolMatchingModuleName() throws {
+    func testSymbolMatchingModuleName() async throws {
         // Verify as top-level symbol with name matching the module name
         // does not trip the context when building the topic graph
         do {
@@ -4318,7 +4318,7 @@ let expected = """
             try testBundle.write(to: tempFolderURL)
             
             // Load the bundle
-            let (_, bundle, context) = try loadBundle(from: tempFolderURL)
+            let (_, bundle, context) = try await loadBundle(from: tempFolderURL)
             
             // Verify the module and symbol node kinds.
             let symbolReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Minimal_docs", sourceLanguage: .swift)
@@ -4350,7 +4350,7 @@ let expected = """
     ///    public func method(_ param: String) { }
     /// }
     /// ```
-    func testWarningForUnresolvableLinksInInheritedDocs() throws {
+    func testWarningForUnresolvableLinksInInheritedDocs() async throws {
         // Create temp folder
         let tempURL = try createTemporaryDirectory()
 
@@ -4363,7 +4363,7 @@ let expected = """
         ]).write(inside: tempURL)
         
         // Load the test bundle
-        let (_, _, context) = try loadBundle(from: bundleURL)
+        let (_, _, context) = try await loadBundle(from: bundleURL)
         
         // Get the emitted diagnostic and verify it contains a solution and replacement fix-it.
         let problem = try XCTUnwrap(context.problems.first(where: { p in
@@ -4392,8 +4392,8 @@ let expected = """
         XCTAssertEqual(problem.possibleSolutions[0].replacements[0].replacement, "<doc:/documentation/Minimal_docs/A/method(_:)-7mctk>")
     }
     
-    func testCustomModuleKind() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithExecutableModuleKind")
+    func testCustomModuleKind() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithExecutableModuleKind")
         XCTAssertEqual(bundle.info.defaultModuleKind, "Executable")
         
         let moduleSymbol = try XCTUnwrap(context.documentationCache["ExampleDocumentedExecutable"]?.symbol)
@@ -4403,7 +4403,7 @@ let expected = """
     
     /// Verifies that the number of symbols registered in the documentation context is consistent with
     /// the number of symbols in the symbol graph files.
-    func testSymbolsCountIsConsistentWithSymbolGraphData() throws {
+    func testSymbolsCountIsConsistentWithSymbolGraphData() async throws {
         let exampleDocumentation = Folder(name: "unit-test.docc", content: [
             Folder(name: "Symbols", content: [
                 JSONFile(
@@ -4434,7 +4434,7 @@ let expected = """
             InfoPlist(displayName: "TestBundle", identifier: "com.test.example")
         ])
         
-        let (_, context) = try loadBundle(catalog: exampleDocumentation)
+        let (_, context) = try await loadBundle(catalog: exampleDocumentation)
         
         XCTAssertEqual(
             context.documentationCache.count,
@@ -4443,7 +4443,7 @@ let expected = """
         )
     }
     
-    func testDocumentationExtensionURLForReferenceReturnsURLForSymbolReference() throws {
+    func testDocumentationExtensionURLForReferenceReturnsURLForSymbolReference() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
                 makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
@@ -4454,7 +4454,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
         XCTAssertEqual(
@@ -4463,8 +4463,8 @@ let expected = """
         )
     }
     
-    func testDocumentationExtensionURLForReferenceReturnsNilForTutorialReference() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
+    func testDocumentationExtensionURLForReferenceReturnsNilForTutorialReference() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
         
         XCTAssertNil(
             context.documentationExtensionURL(
@@ -4479,14 +4479,14 @@ let expected = """
         )
     }
 
-    func testAddingProtocolExtensionMemberConstraint() throws {
+    func testAddingProtocolExtensionMemberConstraint() async throws {
         // This fixture contains a protocol extension:
         // extension Swift.Collection {
         //   public func fixture() -> String {
         //     return "collection"
         //   }
         // }
-        let (_, _, context) = try testBundleAndContext(copying: "ModuleWithProtocolExtensions")
+        let (_, _, context) = try await testBundleAndContext(copying: "ModuleWithProtocolExtensions")
 
         // The member function of the protocol extension
         // should have a constraint: Self is Collection
@@ -4524,14 +4524,14 @@ let expected = """
         XCTAssertEqual(constraint.rightTypeName, "Hashable")
     }
 
-    func testDiagnosticLocations() throws {
+    func testDiagnosticLocations() async throws {
         // The ObjCFrameworkWithInvalidLink.docc test bundle contains symbol
         // graphs for both Obj-C and Swift, built after setting:
         //   "Build Multi-Language Documentation for Objective-C Only Targets" = true.
         // One doc comment in the Obj-C header file contains an invalid doc
         // link on line 24, columns 56-63:
         // "Log a hello world message. This line contains an ``invalid`` link."
-        let (_, context) = try testBundleAndContext(named: "ObjCFrameworkWithInvalidLink")
+        let (_, context) = try await testBundleAndContext(named: "ObjCFrameworkWithInvalidLink")
         let problems = context.problems
         if FeatureFlags.current.isParametersAndReturnsValidationEnabled {
             XCTAssertEqual(4, problems.count)
@@ -4547,7 +4547,7 @@ let expected = """
         XCTAssertEqual(start..<end, range)
     }
     
-    func testPathsToHandlesCyclicCuration() throws {
+    func testPathsToHandlesCyclicCuration() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 Folder(name: "clang", content: [
@@ -4693,7 +4693,7 @@ let expected = """
                 """),
             ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SomeError/Code-swift.enum/someCase", sourceLanguage: .swift)
         
         XCTAssertEqual(
@@ -4709,7 +4709,7 @@ let expected = """
         )
     }
     
-    func testUnresolvedLinkWarnings() throws {
+    func testUnresolvedLinkWarnings() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
                 makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
@@ -4731,13 +4731,13 @@ let expected = """
             """),
         ])
         
-        var (_, context) = try loadBundle(catalog: catalog)
+        var (_, context) = try await loadBundle(catalog: catalog)
         var problems = context.diagnosticEngine.problems
         var linkResolutionProblems = problems.filter { $0.diagnostic.source?.relativePath.hasSuffix("Extension.md") == true }
         XCTAssertEqual(linkResolutionProblems.count, 2)
         var problem = try XCTUnwrap(linkResolutionProblems.last)
         XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/SomeModuleName/SomeClass\'")
-        (_, _, context) = try testBundleAndContext(copying: "BookLikeContent") { url in
+        (_, _, context) = try await testBundleAndContext(copying: "BookLikeContent") { url in
             let extensionFile = """
             # My Article
 
@@ -4762,7 +4762,7 @@ let expected = """
         XCTAssertEqual(problem.diagnostic.summary, "\'NonExistingDoc\' doesn\'t exist at \'/BestBook/MyArticle\'")
     }
     
-    func testContextRecognizesOverloads() throws {
+    func testContextRecognizesOverloads() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
         
         let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { $0.isOverloadableKind }
@@ -4781,7 +4781,7 @@ let expected = """
                     symbols: symbols
                 ))
             ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         for kindID in overloadableKindIDs {
@@ -4840,7 +4840,7 @@ let expected = """
         }
     }
 
-    func testContextRecognizesOverloadsFromPlistFlag() throws {
+    func testContextRecognizesOverloadsFromPlistFlag() async throws {
         let overloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { $0.isOverloadableKind }
         // Generate a 4 symbols with the same name for every overloadable symbol kind
         let symbols: [SymbolGraph.Symbol] = overloadableKindIDs.flatMap { [
@@ -4868,7 +4868,7 @@ let expected = """
                 </plist>
                 """.utf8))
             ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         for kindID in overloadableKindIDs {
@@ -4887,7 +4887,7 @@ let expected = """
     }
 
     // The overload behavior doesn't apply to symbol kinds that don't support overloading
-    func testContextDoesNotRecognizeNonOverloadableSymbolKinds() throws {
+    func testContextDoesNotRecognizeNonOverloadableSymbolKinds() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
         
         let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { !$0.isOverloadableKind }
@@ -4907,7 +4907,7 @@ let expected = """
                 ))
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         for kindID in nonOverloadableKindIDs {
             // Find the 4 symbols of this specific kind
@@ -4923,7 +4923,7 @@ let expected = """
         }
     }
 
-    func testWarnsOnUnknownPlistFeatureFlag() throws {
+    func testWarnsOnUnknownPlistFeatureFlag() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 DataFile(name: "Info.plist", data: Data("""
@@ -4938,7 +4938,7 @@ let expected = """
                 </plist>
                 """.utf8))
             ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
 
         let unknownFeatureFlagProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.UnknownBundleFeatureFlag" })
         XCTAssertEqual(unknownFeatureFlagProblems.count, 1)
@@ -4948,7 +4948,7 @@ let expected = """
         XCTAssertEqual(problem.diagnostic.summary, "Unknown feature flag in Info.plist: 'NonExistentFeature'")
     }
 
-    func testUnknownFeatureFlagSuggestsOtherFlags() throws {
+    func testUnknownFeatureFlagSuggestsOtherFlags() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 DataFile(name: "Info.plist", data: Data("""
@@ -4963,7 +4963,7 @@ let expected = """
                 </plist>
                 """.utf8))
             ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
 
         let unknownFeatureFlagProblems = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.UnknownBundleFeatureFlag" })
         XCTAssertEqual(unknownFeatureFlagProblems.count, 1)
@@ -4975,7 +4975,7 @@ let expected = """
             "Unknown feature flag in Info.plist: 'ExperimenalOverloadedSymbolPresentation'. Possible suggestions: 'ExperimentalOverloadedSymbolPresentation'")
     }
 
-    func testContextGeneratesUnifiedOverloadGroupsAcrossPlatforms() throws {
+    func testContextGeneratesUnifiedOverloadGroupsAcrossPlatforms() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
@@ -4998,7 +4998,7 @@ let expected = """
                     ])),
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         let overloadGroupNode: DocumentationNode
@@ -5048,7 +5048,7 @@ let expected = """
         }
     }
 
-    func testContextGeneratesOverloadGroupsWhenOnePlatformHasNoOverloads() throws {
+    func testContextGeneratesOverloadGroupsWhenOnePlatformHasNoOverloads() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
@@ -5075,7 +5075,7 @@ let expected = """
                     ])),
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         let overloadGroupNode: DocumentationNode
@@ -5128,7 +5128,7 @@ let expected = """
 
     /// Ensure that overload groups are correctly loaded into the path hierarchy and create nodes,
     /// even when they came from an extension symbol graph.
-    func testContextGeneratesOverloadGroupsForExtensionGraphOverloads() throws {
+    func testContextGeneratesOverloadGroupsForExtensionGraphOverloads() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
@@ -5150,7 +5150,7 @@ let expected = """
                     ])),
             ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         let overloadGroupNode: DocumentationNode
@@ -5198,7 +5198,7 @@ let expected = """
         }
     }
 
-    func testContextGeneratesOverloadGroupsForDisjointOverloads() throws {
+    func testContextGeneratesOverloadGroupsForDisjointOverloads() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolKind = try XCTUnwrap(SymbolGraph.Symbol.KindIdentifier.allCases.filter({ $0.isOverloadableKind }).first)
@@ -5219,7 +5219,7 @@ let expected = """
                         makeSymbol(id: "symbol-2", kind: symbolKind, pathComponents: ["SymbolName"]),
                     ])),
             ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
 
         let overloadGroupNode: DocumentationNode
@@ -5267,7 +5267,7 @@ let expected = """
         }
     }
 
-    func testContextDiagnosesInsufficientDisambiguationWithCorrectRange() throws {
+    func testContextDiagnosesInsufficientDisambiguationWithCorrectRange() async throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
         for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
@@ -5297,7 +5297,7 @@ let expected = """
                     """)
                 ])
 
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
 
             let problems = context.problems.sorted(by: \.diagnostic.summary)
             XCTAssertEqual(problems.count, 1)
@@ -5321,7 +5321,7 @@ let expected = """
         }
     }
 
-    func testContextDiagnosesIncorrectDisambiguationWithCorrectRange() throws {
+    func testContextDiagnosesIncorrectDisambiguationWithCorrectRange() async throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
         for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
@@ -5351,7 +5351,7 @@ let expected = """
                     """)
                 ])
 
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
 
             let problems = context.problems.sorted(by: \.diagnostic.summary)
             XCTAssertEqual(problems.count, 1)
@@ -5373,7 +5373,7 @@ let expected = """
         }
     }
 
-    func testContextDiagnosesIncorrectSymbolNameWithCorrectRange() throws {
+    func testContextDiagnosesIncorrectSymbolNameWithCorrectRange() async throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
         for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
@@ -5403,7 +5403,7 @@ let expected = """
                     """)
                 ])
 
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
 
             let problems = context.problems.sorted(by: \.diagnostic.summary)
             XCTAssertEqual(problems.count, 1)
@@ -5425,13 +5425,13 @@ let expected = """
         }
     }
 
-    func testResolveExternalLinkFromTechnologyRoot() throws {
+    func testResolveExternalLinkFromTechnologyRoot() async throws {
         enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
         
         let externalModuleName = "ExternalModuleName"
         
-        func makeExternalDependencyFiles() throws -> (SerializableLinkResolutionInformation, [LinkDestinationSummary]) {
-            let (bundle, context) = try loadBundle(
+        func makeExternalDependencyFiles() async throws -> (SerializableLinkResolutionInformation, [LinkDestinationSummary]) {
+            let (bundle, context) = try await loadBundle(
                 catalog: Folder(name: "Dependency.docc", content: [
                     JSONFile(name: "\(externalModuleName).symbols.json", content: makeSymbolGraph(moduleName: externalModuleName)),
                     TextFile(name: "Extension.md", utf8Content: """
@@ -5465,14 +5465,14 @@ let expected = """
             """),
         ])
         
-        let (linkResolutionInformation, linkSummaries) = try makeExternalDependencyFiles()
+        let (linkResolutionInformation, linkSummaries) = try await makeExternalDependencyFiles()
         
         var configuration = DocumentationContext.Configuration()
         configuration.externalDocumentationConfiguration.dependencyArchives = [
             URL(fileURLWithPath: "/path/to/SomeDependency.doccarchive")
         ]
         
-        let (bundle, context) = try loadBundle(
+        let (bundle, context) = try await loadBundle(
             catalog: catalog,
             otherFileSystemDirectories: [
                 Folder(name: "path", content: [
@@ -5515,8 +5515,8 @@ let expected = """
         XCTAssertEqual(externalRenderReference.abstract, [.text("Some description of this module.")])
     }
 
-    func testResolvesAlternateDeclarations() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(
+    func testResolvesAlternateDeclarations() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(
             name: "unit-test.docc",
             content: [
                 TextFile(name: "Symbol.md", utf8Content: """
@@ -5593,8 +5593,8 @@ let expected = """
         XCTAssertEqual(problem.diagnostic.summary, "Can't resolve 'MissingSymbol'")
     }
         
-    func testDiagnosesSymbolAlternateDeclarations() throws {
-        let (_, context) = try loadBundle(catalog: Folder(
+    func testDiagnosesSymbolAlternateDeclarations() async throws {
+        let (_, context) = try await loadBundle(catalog: Folder(
             name: "unit-test.docc",
             content: [
                 TextFile(name: "Symbol.md", utf8Content: """
@@ -5664,8 +5664,8 @@ let expected = """
         XCTAssertEqual(solution.replacements.first?.replacement, "")
     }
     
-    func testDiagnosesArticleAlternateDeclarations() throws {
-        let (_, context) = try loadBundle(catalog: Folder(
+    func testDiagnosesArticleAlternateDeclarations() async throws {
+        let (_, context) = try await loadBundle(catalog: Folder(
             name: "unit-test.docc",
             content: [
                 TextFile(name: "Symbol.md", utf8Content: """

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationCuratorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -27,8 +27,8 @@ class DocumentationCuratorTests: XCTestCase {
         }
     }
     
-    func testCrawl() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCrawl() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var crawler = DocumentationCurator.init(in: context, bundle: bundle)
         let mykit = try context.entity(with: ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", sourceLanguage: .swift))
@@ -74,8 +74,8 @@ class DocumentationCuratorTests: XCTestCase {
         )
     }
     
-    func testCrawlDiagnostics() throws {
-        let (tempCatalogURL, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testCrawlDiagnostics() async throws {
+        let (tempCatalogURL, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             let extensionFile = url.appendingPathComponent("documentation/myfunction.md")
             
             try """
@@ -136,8 +136,8 @@ class DocumentationCuratorTests: XCTestCase {
             """)
     }
     
-    func testCyclicCurationDiagnostic() throws {
-        let (_, context) = try loadBundle(catalog:
+    func testCyclicCurationDiagnostic() async throws {
+        let (_, context) = try await loadBundle(catalog:
             Folder(name: "unit-test.docc", content: [
                 // A number of articles with this cyclic curation:
                 //
@@ -201,7 +201,7 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssertEqual(curationProblem.possibleSolutions.map(\.summary), ["Remove '- <doc:First>'"])
     }
     
-    func testCurationInUncuratedAPICollection() throws {
+    func testCurationInUncuratedAPICollection() async throws {
         // Everything should behave the same when an API Collection is automatically curated as when it is explicitly curated
         for shouldCurateAPICollection in [true, false] {
             let assertionMessageDescription = "when the API collection is \(shouldCurateAPICollection ? "explicitly curated" : "auto-curated as an article under the module")."
@@ -228,7 +228,7 @@ class DocumentationCuratorTests: XCTestCase {
                 - ``NotFound``
                 """),
             ])
-            let (bundle, context) = try loadBundle(catalog: catalog)
+            let (bundle, context) = try await loadBundle(catalog: catalog)
             XCTAssertEqual(
                 context.problems.map(\.diagnostic.summary),
                 [
@@ -285,8 +285,8 @@ class DocumentationCuratorTests: XCTestCase {
         }
     }
     
-    func testModuleUnderTechnologyRoot() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "SourceLocations") { url in
+    func testModuleUnderTechnologyRoot() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "SourceLocations") { url in
             try """
             # Root curating a module
 
@@ -319,8 +319,8 @@ class DocumentationCuratorTests: XCTestCase {
             
     }
         
-    func testModuleUnderAncestorOfTechnologyRoot() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "SourceLocations") { url in
+    func testModuleUnderAncestorOfTechnologyRoot() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "SourceLocations") { url in
             try """
             # Root with ancestor curating a module
             
@@ -361,8 +361,8 @@ class DocumentationCuratorTests: XCTestCase {
         XCTAssertEqual(root.path, "/documentation/Root")
     }
 
-    func testSymbolLinkResolving() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testSymbolLinkResolving() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         let crawler = DocumentationCurator.init(in: context, bundle: bundle)
         
@@ -414,8 +414,8 @@ class DocumentationCuratorTests: XCTestCase {
         }
     }
     
-    func testLinkResolving() throws {
-        let (sourceRoot, bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testLinkResolving() async throws {
+        let (sourceRoot, bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var crawler = DocumentationCurator.init(in: context, bundle: bundle)
         
@@ -469,8 +469,8 @@ class DocumentationCuratorTests: XCTestCase {
         }
     }
     
-    func testGroupLinkValidation() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { root in
+    func testGroupLinkValidation() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { root in
             // Create a sidecar with invalid group links
             try! """
             # ``SideKit``
@@ -563,8 +563,8 @@ class DocumentationCuratorTests: XCTestCase {
     ///      +-- SecondLevelNesting (Manually curated)
     ///        +-- MyArticle ( <--- This should be crawled even if we've mixed manual and automatic curation)
     /// ```
-    func testMixedManualAndAutomaticCuration() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+    func testMixedManualAndAutomaticCuration() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedManualAutomaticCuration")
         
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/TopClass/NestedEnum/SecondLevelNesting", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
@@ -599,8 +599,8 @@ class DocumentationCuratorTests: XCTestCase {
     
     /// In case a symbol has automatically curated children and is manually curated multiple times,
     /// the hierarchy should be created as it's authored. rdar://75453839
-    func testMultipleManualCurationIsPreserved() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+    func testMultipleManualCurationIsPreserved() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedManualAutomaticCuration")
         
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/TestBed/DoublyManuallyCuratedClass/type()", sourceLanguage: .swift)
         

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalPathHierarchyResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,8 +23,8 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
     
     // These tests resolve absolute symbol links in both a local and external context to verify that external links work the same local links.
     
-    func testUnambiguousAbsolutePaths() throws {
-        let linkResolvers = try makeLinkResolversForTestBundle(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testUnambiguousAbsolutePaths() async throws {
+        let linkResolvers = try await makeLinkResolversForTestBundle(named: "MixedLanguageFrameworkWithLanguageRefinements")
         
         try linkResolvers.assertSuccessfullyResolves(authoredLink: "/MixedFramework")
         
@@ -408,8 +408,8 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         )
     }
     
-    func testAmbiguousPaths() throws {
-        let linkResolvers = try makeLinkResolversForTestBundle(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testAmbiguousPaths() async throws {
+        let linkResolvers = try await makeLinkResolversForTestBundle(named: "MixedLanguageFrameworkWithLanguageRefinements")
         
         // public enum CollisionsWithDifferentKinds {
         //     case something
@@ -577,8 +577,8 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         )
     }
     
-    func testRedundantDisambiguations() throws {
-        let linkResolvers = try makeLinkResolversForTestBundle(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testRedundantDisambiguations() async throws {
+        let linkResolvers = try await makeLinkResolversForTestBundle(named: "MixedLanguageFrameworkWithLanguageRefinements")
         
         try linkResolvers.assertSuccessfullyResolves(authoredLink: "/MixedFramework")
         
@@ -685,7 +685,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         )
     }
     
-    func testSymbolLinksInDeclarationsAndRelationships() throws {
+    func testSymbolLinksInDeclarationsAndRelationships() async throws {
         // Build documentation for the dependency first
         let symbols = [("First", .class), ("Second", .protocol), ("Third", .struct), ("Fourth", .enum)].map { (name: String, kind: SymbolGraph.Symbol.KindIdentifier) in
             return SymbolGraph.Symbol(
@@ -699,7 +699,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
             )
         }
         
-        let (dependencyBundle, dependencyContext) = try loadBundle(
+        let (dependencyBundle, dependencyContext) = try await loadBundle(
             catalog: Folder(name: "Dependency.docc", content: [
                 InfoPlist(identifier: "com.example.dependency"), // This isn't necessary but makes it easier to distinguish the identifier from the module name in the external references.
                 JSONFile(name: "Dependency.symbols.json", content: makeSymbolGraph(moduleName: "Dependency", symbols: symbols))
@@ -724,7 +724,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         configuration.externalDocumentationConfiguration.dependencyArchives = [URL(fileURLWithPath: "/Dependency.doccarchive")]
         
         // After building the dependency,
-        let (mainBundle, mainContext) = try loadBundle(
+        let (mainBundle, mainContext) = try await loadBundle(
             catalog: Folder(name: "Main.docc", content: [
                 JSONFile(name: "Main.symbols.json", content: makeSymbolGraph(
                     moduleName: "Main",
@@ -851,10 +851,10 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         }
     }
 
-    func testOverloadGroupSymbolsResolveWithoutHash() throws {
+    func testOverloadGroupSymbolsResolveWithoutHash() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let linkResolvers = try makeLinkResolversForTestBundle(named: "OverloadedSymbols")
+        let linkResolvers = try await makeLinkResolversForTestBundle(named: "OverloadedSymbols")
 
         // The enum case should continue to resolve by kind, since it has no hash collision
         try linkResolvers.assertSuccessfullyResolves(authoredLink: "/ShapeKit/OverloadedEnum/firstTestMemberName(_:)-swift.enum.case")
@@ -872,7 +872,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         )
     }
     
-    func testBetaInformationPreserved() throws {
+    func testBetaInformationPreserved() async throws {
         let platformMetadata = [
             "macOS": PlatformVersion(VersionTriplet(1, 0, 0), beta: true),
             "watchOS": PlatformVersion(VersionTriplet(2, 0, 0), beta: true),
@@ -884,7 +884,7 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         var configuration = DocumentationContext.Configuration()
 
         configuration.externalMetadata.currentPlatforms = platformMetadata
-        let linkResolvers = try makeLinkResolversForTestBundle(named: "AvailabilityBetaBundle", configuration: configuration)
+        let linkResolvers = try await makeLinkResolversForTestBundle(named: "AvailabilityBetaBundle", configuration: configuration)
         
         // MyClass is only available on beta platforms (macos=1.0.0, watchos=2.0.0, tvos=3.0.0, ios=4.0.0)
         try linkResolvers.assertBetaStatus(authoredLink: "/MyKit/MyClass", isBeta: true)
@@ -989,9 +989,9 @@ class ExternalPathHierarchyResolverTests: XCTestCase {
         }
     }
     
-    private func makeLinkResolversForTestBundle(named testBundleName: String, configuration: DocumentationContext.Configuration = .init()) throws -> LinkResolvers {
+    private func makeLinkResolversForTestBundle(named testBundleName: String, configuration: DocumentationContext.Configuration = .init()) async throws -> LinkResolvers {
         let bundleURL = try XCTUnwrap(Bundle.module.url(forResource: testBundleName, withExtension: "docc", subdirectory: "Test Bundles"))
-        let (_, bundle, context) = try loadBundle(from: bundleURL, configuration: configuration)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL, configuration: configuration)
         
         let localResolver = try XCTUnwrap(context.linkResolver.localResolver)
         

--- a/Tests/SwiftDocCTests/Infrastructure/InheritIntroducedAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/InheritIntroducedAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -37,9 +37,9 @@ class InheritIntroducedAvailabilityTests: XCTestCase {
     var testBundle: DocumentationBundle!
     var context: DocumentationContext!
     
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        (testBundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    override func setUp() async throws {
+        try await super.setUp()
+        (testBundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
     }
     
     override func tearDown() {

--- a/Tests/SwiftDocCTests/Infrastructure/NodeTagsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/NodeTagsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import XCTest
 import SwiftDocCTestUtilities
 
 class NodeTagsTests: XCTestCase {
-    func testSPIMetadata() throws {
+    func testSPIMetadata() async throws {
         let spiSGURL = Bundle.module.url(
             forResource: "SPI.symbols", withExtension: "json", subdirectory: "Test Resources")!
         
@@ -24,7 +24,7 @@ class NodeTagsTests: XCTestCase {
         let tempURL = try createTemporaryDirectory().appendingPathComponent("unit-tests.docc")
         try bundleFolder.write(to: tempURL)
         
-        let (_, bundle, context) = try loadBundle(from: tempURL)
+        let (_, bundle, context) = try await loadBundle(from: tempURL)
         
         // Verify that `Test` is marked as SPI.
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Minimal_docs/Test", sourceLanguage: .swift)

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyBasedLinkResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyBasedLinkResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,10 +13,10 @@ import XCTest
 
 class PathHierarchyBasedLinkResolverTests: XCTestCase {
     
-    func testOverloadedSymbolsWithOverloadGroups() throws {
+    func testOverloadedSymbolsWithOverloadGroups() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
         
-        let (_, context) = try testBundleAndContext(named: "OverloadedSymbols")
+        let (_, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
         // Returns nil for all non-overload groups

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -16,8 +16,8 @@ import Markdown
 
 class PathHierarchyTests: XCTestCase {
     
-    func testFindingUnambiguousAbsolutePaths() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testFindingUnambiguousAbsolutePaths() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MixedFramework", in: tree, asSymbolID: "MixedFramework")
@@ -286,10 +286,10 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("/MixedFramework/MyTypedObjectiveCExtensibleEnumSecond", in: tree, asSymbolID: "c:@MyTypedObjectiveCExtensibleEnumSecond")
     }
     
-    func testAmbiguousPaths() throws {
+    func testAmbiguousPaths() async throws {
         enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
         
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // Symbol name not found. Suggestions only include module names (search is not relative to a known page)
@@ -574,8 +574,8 @@ class PathHierarchyTests: XCTestCase {
         try assertPathNotFound("MixedFramework/MyTypedObjectiveCExtensibleEnum-typealias/second", in: tree)
     }
     
-    func testRedundantKindDisambiguation() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testRedundantKindDisambiguation() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MixedFramework-module", in: tree, asSymbolID: "MixedFramework")
@@ -626,8 +626,8 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("/MixedFramework/myTopLevelVariable-var", in: tree, asSymbolID: "s:14MixedFramework18myTopLevelVariableSbvp")
     }
     
-    func testBothRedundantDisambiguations() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testBothRedundantDisambiguations() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MixedFramework-module-9r7pl", in: tree, asSymbolID: "MixedFramework")
@@ -678,7 +678,7 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("/MixedFramework-module-9r7pl/myTopLevelVariable-var-520ez", in: tree, asSymbolID: "s:14MixedFramework18myTopLevelVariableSbvp")
     }
     
-    func testDefaultImplementationWithCollidingTargetSymbol() throws {
+    func testDefaultImplementationWithCollidingTargetSymbol() async throws {
  
         // ---- Inner
         // public protocol Something {
@@ -691,7 +691,7 @@ class PathHierarchyTests: XCTestCase {
         // ---- Outer
         // @_exported import Inner
         // public typealias Something = Inner.Something
-        let (_, context) = try testBundleAndContext(named: "DefaultImplementationsWithExportedImport")
+        let (_, context) = try await testBundleAndContext(named: "DefaultImplementationsWithExportedImport")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // The @_export imported protocol can be found
@@ -712,8 +712,8 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("DefaultImplementationsWithExportedImport/Something-protocol/doSomething()-scj9", in: tree, asSymbolID: "s:5Inner9SomethingPAAE02doB0yyF")
     }
     
-    func testDisambiguatedPaths() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testDisambiguatedPaths() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -849,8 +849,8 @@ class PathHierarchyTests: XCTestCase {
             "/MixedFramework/CollisionsWithDifferentSubscriptArguments/subscript(_:)-757cj")
     }
     
-    func testDisambiguatedOperatorPaths() throws {
-        let (_, context) = try testBundleAndContext(named: "InheritedOperators")
+    func testDisambiguatedOperatorPaths() async throws {
+        let (_, context) = try await testBundleAndContext(named: "InheritedOperators")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -919,8 +919,8 @@ class PathHierarchyTests: XCTestCase {
         
     }
     
-    func testFindingRelativePaths() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testFindingRelativePaths() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let moduleID = try tree.find(path: "/MixedFramework", onlyFindSymbols: true)
@@ -1091,8 +1091,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "second", parent: myTypedExtensibleEnumID).identifier.precise, "c:@MyTypedObjectiveCExtensibleEnumSecond")
     }
     
-    func testPathWithDocumentationPrefix() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
+    func testPathWithDocumentationPrefix() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let moduleID = try tree.find(path: "/MixedFramework", onlyFindSymbols: true)
@@ -1106,8 +1106,8 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("/documentation/MixedFramework/MyEnum", [("documentation", nil), ("MixedFramework", nil), ("MyEnum", nil)])
     }
     
-    func testUnrealisticMixedTestCatalog() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testUnrealisticMixedTestCatalog() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let linkResolver = try XCTUnwrap(context.linkResolver.localResolver)
         let tree = try XCTUnwrap(linkResolver.pathHierarchy)
         
@@ -1172,8 +1172,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(tree.lookup[symbolPageTaskGroupID]!.name, "Task-Group-Exercising-Symbol-Links")
     }
     
-    func testMixedLanguageFramework() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+    func testMixedLanguageFramework() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFramework")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("MixedLanguageFramework/Bar/myStringFunction(_:)", in: tree, asSymbolID: "c:objc(cs)Bar(cm)myStringFunction:error:")
@@ -1226,8 +1226,8 @@ class PathHierarchyTests: XCTestCase {
                        "/MixedLanguageFramework/SwiftOnlyStruct/tada()")
     }
     
-    func testArticleAndSymbolCollisions() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "MixedLanguageFramework") { url in
+    func testArticleAndSymbolCollisions() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "MixedLanguageFramework") { url in
             try """
             # An article
             
@@ -1243,8 +1243,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertNil(articleNode.symbol, "General documentation link find the article")
     }
     
-    func testArticleSelfAnchorLinks() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "MixedLanguageFramework") { url in
+    func testArticleSelfAnchorLinks() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "MixedLanguageFramework") { url in
             try """
             # ArticleWithHeading
 
@@ -1266,8 +1266,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertNotNil(anchorLinkNode)
     }
 
-    func testOverloadedSymbols() throws {
-        let (_, context) = try testBundleAndContext(named: "OverloadedSymbols")
+    func testOverloadedSymbols() async throws {
+        let (_, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -1328,10 +1328,10 @@ class PathHierarchyTests: XCTestCase {
         ])
     }
 
-    func testOverloadedSymbolsWithOverloadGroups() throws {
+    func testOverloadedSymbolsWithOverloadGroups() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let (_, context) = try testBundleAndContext(named: "OverloadedSymbols")
+        let (_, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         let tree = context.linkResolver.localResolver.pathHierarchy
 
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -1931,7 +1931,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testParameterDisambiguationWithAnyType() throws {
+    func testParameterDisambiguationWithAnyType() async throws {
         // Create two overloads with different parameter types
         let parameterTypes: [SymbolGraph.Symbol.DeclarationFragments.Fragment] = [
             // Any (swift)
@@ -1956,7 +1956,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             })),
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
@@ -1988,7 +1988,7 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("doSomething(with:)-9kd0v", in: tree, asSymbolID: "some-function-id-AnyObject")
     }
     
-    func testReturnDisambiguationWithAnyType() throws {
+    func testReturnDisambiguationWithAnyType() async throws {
         // Create two overloads with different return types
         let returnTypes: [SymbolGraph.Symbol.DeclarationFragments.Fragment] = [
             // Any (swift)
@@ -2005,7 +2005,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             })),
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
@@ -2037,10 +2037,10 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("doSomething()-9kd0v", in: tree, asSymbolID: "some-function-id-AnyObject")
     }
     
-    func testOverloadGroupSymbolsResolveLinksWithoutHash() throws {
+    func testOverloadGroupSymbolsResolveLinksWithoutHash() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let (_, context) = try testBundleAndContext(named: "OverloadedSymbols")
+        let (_, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         let tree = context.linkResolver.localResolver.pathHierarchy
 
         // The enum case should continue to resolve by kind, since it has no hash collision
@@ -2056,9 +2056,9 @@ class PathHierarchyTests: XCTestCase {
 
     }
 
-    func testAmbiguousPathsForOverloadedGroupSymbols() throws {
+    func testAmbiguousPathsForOverloadedGroupSymbols() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
-        let (_, context) = try testBundleAndContext(named: "OverloadedSymbols")
+        let (_, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         let tree = context.linkResolver.localResolver.pathHierarchy
         try assertPathRaisesErrorMessage("/ShapeKit/OverloadedProtocol/fourthTestMemberName(test:)-abc123", in: tree, context: context, expectedErrorMessage: """
         'abc123' isn't a disambiguation for 'fourthTestMemberName(test:)' at '/ShapeKit/OverloadedProtocol'
@@ -2075,7 +2075,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
 
-    func testDoesNotSuggestBundleNameForSymbolLink() throws {
+    func testDoesNotSuggestBundleNameForSymbolLink() async throws {
         let exampleDocumentation = Folder(name: "Something.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
             
@@ -2089,7 +2089,7 @@ class PathHierarchyTests: XCTestCase {
             """),
         ])
         let catalogURL = try exampleDocumentation.write(inside: createTemporaryDirectory())
-        let (_, _, context) = try loadBundle(from: catalogURL)
+        let (_, _, context) = try await loadBundle(from: catalogURL)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // This link is intentionally misspelled
@@ -2101,8 +2101,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(linkProblem.possibleSolutions.map(\.summary), ["Replace 'ModuleNaem' with 'ModuleName'"])
     }
         
-    func testSymbolsWithSameNameAsModule() throws {
-        let (_, context) = try testBundleAndContext(named: "SymbolsWithSameNameAsModule")
+    func testSymbolsWithSameNameAsModule() async throws {
+        let (_, context) = try await testBundleAndContext(named: "SymbolsWithSameNameAsModule")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // /* in a module named "Something "*/
@@ -2148,7 +2148,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "Something/second", parent: topLevelSymbolID).identifier.precise, "s:9SomethingAAV6secondSivp")
     }
     
-    func testSymbolsWithSameNameAsExtendedModule() throws {
+    func testSymbolsWithSameNameAsExtendedModule() async throws {
         // ---- Inner
         // public struct InnerStruct {}
         // public class InnerClass {}
@@ -2163,7 +2163,7 @@ class PathHierarchyTests: XCTestCase {
         // public extension InnerClass {
         //     func something() {}
         // }
-        let (_, context) = try testBundleAndContext(named: "ShadowExtendedModuleWithLocalSymbol")
+        let (_, context) = try await testBundleAndContext(named: "ShadowExtendedModuleWithLocalSymbol")
         let tree = context.linkResolver.localResolver.pathHierarchy
 
         try assertPathCollision("Outer/Inner", in: tree, collisions: [
@@ -2191,7 +2191,7 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("Inner/InnerClass/something()", in: tree, asSymbolID: "s:5Inner0A5ClassC5OuterE9somethingyyF")
     }
     
-    func testExtensionSymbolsWithSameNameAsExtendedModule() throws {
+    func testExtensionSymbolsWithSameNameAsExtendedModule() async throws {
         // ---- ExtendedModule
         // public struct SomeStruct {
         //     public struct SomeNestedStruct {}
@@ -2238,7 +2238,7 @@ class PathHierarchyTests: XCTestCase {
             ),
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
 
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -2263,7 +2263,7 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("ExtendedModule/SomeStruct/SomeNestedStruct/doSomething()", in: tree, asSymbolID: extendedMethodSymbolID)
     }
     
-    func testContinuesSearchingIfNonSymbolMatchesSymbolLink() throws {
+    func testContinuesSearchingIfNonSymbolMatchesSymbolLink() async throws {
         let exampleDocumentation = Folder(name: "CatalogName.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
                 makeSymbol(id: "some-class-id", kind: .class, pathComponents: ["SomeClass"])
@@ -2282,7 +2282,7 @@ class PathHierarchyTests: XCTestCase {
              """),
         ])
         let catalogURL = try exampleDocumentation.write(inside: createTemporaryDirectory())
-        let (_, _, context) = try loadBundle(from: catalogURL)
+        let (_, _, context) = try await loadBundle(from: catalogURL)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
@@ -2306,7 +2306,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testDiagnosticDoesNotSuggestReplacingPartOfSymbolName() throws {
+    func testDiagnosticDoesNotSuggestReplacingPartOfSymbolName() async throws {
         let exampleDocumentation = Folder(name: "CatalogName.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
                 makeSymbol(id: "some-class-id-1", kind: .class, pathComponents: ["SomeClass-(Something)"]),
@@ -2314,7 +2314,7 @@ class PathHierarchyTests: XCTestCase {
             ])),
         ])
         let catalogURL = try exampleDocumentation.write(inside: createTemporaryDirectory())
-        let (_, _, context) = try loadBundle(from: catalogURL)
+        let (_, _, context) = try await loadBundle(from: catalogURL)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems \(context.problems.map(\.diagnostic.summary))")
@@ -2337,8 +2337,8 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testSnippets() throws {
-        let (_, context) = try testBundleAndContext(named: "Snippets")
+    func testSnippets() async throws {
+        let (_, context) = try await testBundleAndContext(named: "Snippets")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/Snippets/Snippets/MySnippet", in: tree, asSymbolID: "$snippet__Test.Snippets.MySnippet")
@@ -2362,8 +2362,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "/Snippets/Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
     }
     
-    func testInheritedOperators() throws {
-        let (_, context) = try testBundleAndContext(named: "InheritedOperators")
+    func testInheritedOperators() async throws {
+        let (_, context) = try await testBundleAndContext(named: "InheritedOperators")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // public struct MyNumber: SignedNumeric, Comparable, Equatable, Hashable {
@@ -2464,8 +2464,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(repeatedHumanReadablePaths.keys.sorted(), [], "Every path should be unique")
     }
     
-    func testSameNameForSymbolAndContainer() throws {
-        let (_, context) = try testBundleAndContext(named: "BundleWithSameNameForSymbolAndContainer")
+    func testSameNameForSymbolAndContainer() async throws {
+        let (_, context) = try await testBundleAndContext(named: "BundleWithSameNameForSymbolAndContainer")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // public struct Something {
@@ -2498,8 +2498,8 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(try tree.findSymbol(path: "Something/SomethingElse", parent: moduleID).absolutePath, "Something/SomethingElse")
     }
     
-    func testPrefersNonSymbolsWhenOnlyFindSymbolIsFalse() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
+    func testPrefersNonSymbolsWhenOnlyFindSymbolIsFalse() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "SymbolsWithSameNameAsModule") { url in
             // This bundle has a top-level struct named "Wrapper". Adding an article named "Wrapper.md" introduces a possibility for a link collision
             try """
             # An article
@@ -2530,7 +2530,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertNotNil(symbolMatch.symbol, "Should have found the struct")
     }
     
-    func testOneSymbolPathsWithKnownDisambiguation() throws {
+    func testOneSymbolPathsWithKnownDisambiguation() async throws {
         let exampleDocumentation = Folder(name: "MyKit.docc", content: [
             CopyOfFile(original: Bundle.module.url(forResource: "mykit-one-symbol.symbols", withExtension: "json", subdirectory: "Test Resources")!),
             InfoPlist(displayName: "MyKit", identifier: "com.test.MyKit"),
@@ -2539,7 +2539,7 @@ class PathHierarchyTests: XCTestCase {
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
 
         do {
-            let (_, _, context) = try loadBundle(from: bundleURL)
+            let (_, _, context) = try await loadBundle(from: bundleURL)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertFindsPath("/MyKit/MyClass/myFunction()", in: tree, asSymbolID: "s:5MyKit0A5ClassC10myFunctionyyF")
@@ -2558,7 +2558,7 @@ class PathHierarchyTests: XCTestCase {
             configuration.convertServiceConfiguration.knownDisambiguatedSymbolPathComponents = [
                 "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class", "myFunction()"]
             ]
-            let (_, _, context) = try loadBundle(from: bundleURL, configuration: configuration)
+            let (_, _, context) = try await loadBundle(from: bundleURL, configuration: configuration)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertFindsPath("/MyKit/MyClass-swift.class/myFunction()", in: tree, asSymbolID: "s:5MyKit0A5ClassC10myFunctionyyF")
@@ -2577,7 +2577,7 @@ class PathHierarchyTests: XCTestCase {
             configuration.convertServiceConfiguration.knownDisambiguatedSymbolPathComponents = [
                 "s:5MyKit0A5ClassC10myFunctionyyF": ["MyClass-swift.class-hash", "myFunction()"]
             ]
-            let (_, _, context) = try loadBundle(from: bundleURL, configuration: configuration)
+            let (_, _, context) = try await loadBundle(from: bundleURL, configuration: configuration)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertFindsPath("/MyKit/MyClass-swift.class-hash/myFunction()", in: tree, asSymbolID: "s:5MyKit0A5ClassC10myFunctionyyF")
@@ -2593,7 +2593,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testArticleWithDisambiguationLookingName() throws {
+    func testArticleWithDisambiguationLookingName() async throws {
         let exampleDocumentation = Folder(name: "MyKit.docc", content: [
             CopyOfFile(original: Bundle.module.url(forResource: "BaseKit.symbols", withExtension: "json", subdirectory: "Test Resources")!),
             InfoPlist(displayName: "BaseKit", identifier: "com.test.BaseKit"),
@@ -2617,7 +2617,7 @@ class PathHierarchyTests: XCTestCase {
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
 
         do {
-            let (_, _, context) = try loadBundle(from: bundleURL)
+            let (_, _, context) = try await loadBundle(from: bundleURL)
             XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map { DiagnosticConsoleWriter.formattedDescription(for: $0) })")
             
             let tree = context.linkResolver.localResolver.pathHierarchy
@@ -2633,8 +2633,8 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testGeometricalShapes() throws {
-        let (_, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testGeometricalShapes() async throws {
+        let (_, context) = try await testBundleAndContext(named: "GeometricalShapes")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths().values.sorted()
@@ -2657,7 +2657,7 @@ class PathHierarchyTests: XCTestCase {
         ])
     }
     
-    func testPartialSymbolGraphPaths() throws {
+    func testPartialSymbolGraphPaths() async throws {
         let symbolPaths = [
             ["A", "B", "C"],
             ["A", "B", "C2"],
@@ -2675,7 +2675,7 @@ class PathHierarchyTests: XCTestCase {
         let tempURL = try createTemporaryDirectory()
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
         
-        let (_, _, context) = try loadBundle(from: bundleURL)
+        let (_, _, context) = try await loadBundle(from: bundleURL)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertPathNotFound("/Module/A", in: tree)
@@ -2697,7 +2697,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths["X.Y2.Z.W"], "/Module/X/Y2/Z/W")
     }
     
-    func testMixedLanguageSymbolWithSameKindAndAddedMemberFromExtendingModule() throws {
+    func testMixedLanguageSymbolWithSameKindAndAddedMemberFromExtendingModule() async throws {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"
         
@@ -2731,7 +2731,7 @@ class PathHierarchyTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -2739,7 +2739,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/MemberName")
     }
     
-    func testMixedLanguageSymbolWithDifferentKindsAndAddedMemberFromExtendingModule() throws {
+    func testMixedLanguageSymbolWithDifferentKindsAndAddedMemberFromExtendingModule() async throws {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"
         
@@ -2773,7 +2773,7 @@ class PathHierarchyTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -2781,7 +2781,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/MemberName")
     }
     
-    func testLanguageRepresentationsWithDifferentCapitalization() throws {
+    func testLanguageRepresentationsWithDifferentCapitalization() async throws {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"
         
@@ -2813,7 +2813,7 @@ class PathHierarchyTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -2821,7 +2821,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/memberName") // The Swift spelling is preferred
     }
 
-    func testLanguageRepresentationsWithDifferentParentKinds() throws {
+    func testLanguageRepresentationsWithDifferentParentKinds() async throws {
         enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
 
         let containerID = "some-container-symbol-id"
@@ -2861,7 +2861,7 @@ class PathHierarchyTests: XCTestCase {
             })
         ])
 
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
 
         let resolvedSwiftContainerID = try tree.find(path: "/ModuleName/ContainerName-struct", onlyFindSymbols: true)
@@ -2905,7 +2905,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName/MemberName")
     }
 
-    func testMixedLanguageSymbolAndItsExtendingModuleWithDifferentContainerNames() throws {
+    func testMixedLanguageSymbolAndItsExtendingModuleWithDifferentContainerNames() async throws {
         let containerID = "some-container-symbol-id"
         let memberID = "some-member-symbol-id"
         
@@ -2939,7 +2939,7 @@ class PathHierarchyTests: XCTestCase {
             ])
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -2947,7 +2947,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/SwiftContainerName/MemberName")
     }
     
-    func testOptionalMemberUnderCorrectContainer() throws {
+    func testOptionalMemberUnderCorrectContainer() async throws {
         let containerID = "some-container-symbol-id"
         let otherID = "some-other-symbol-id"
         let memberID = "some-member-symbol-id"
@@ -2966,7 +2966,7 @@ class PathHierarchyTests: XCTestCase {
             ))
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths(includeDisambiguationForUnambiguousChildren: true)
@@ -2975,7 +2975,7 @@ class PathHierarchyTests: XCTestCase {
         XCTAssertEqual(paths[memberID], "/ModuleName/ContainerName-qwwf/MemberName1")
     }
     
-    func testLinkToTopicSection() throws {
+    func testLinkToTopicSection() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 moduleName: "ModuleName",
@@ -3020,7 +3020,7 @@ class PathHierarchyTests: XCTestCase {
             """)
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let moduleID = try tree.find(path: "/ModuleName", onlyFindSymbols: true)
@@ -3071,7 +3071,7 @@ class PathHierarchyTests: XCTestCase {
         ], "The hierarchy only computes paths for symbols, not for headings or topic sections")
     }
     
-    func testModuleAndCollidingTechnologyRootHasPathsForItsSymbols() throws {
+    func testModuleAndCollidingTechnologyRootHasPathsForItsSymbols() async throws {
         let symbolID = "some-symbol-id"
         
         let catalog = Folder(name: "unit-test.docc", content: [
@@ -3094,14 +3094,14 @@ class PathHierarchyTests: XCTestCase {
             """)
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths(includeDisambiguationForUnambiguousChildren: true)
         XCTAssertEqual(paths[symbolID], "/ModuleName/SymbolName")
     }
     
-    func testSameDefaultImplementationOnMultiplePlatforms() throws {
+    func testSameDefaultImplementationOnMultiplePlatforms() async throws {
         let protocolID = "some-protocol-symbol-id"
         let protocolRequirementID = "some-protocol-requirement-symbol-id"
         let defaultImplementationID = "some-default-implementation-symbol-id"
@@ -3127,7 +3127,7 @@ class PathHierarchyTests: XCTestCase {
             makeSymbolGraphFile(platformName: "PlatformTwo"),
         ])
         
-        let (_, context) = try loadBundle(catalog: multiPlatformCatalog)
+        let (_, context) = try await loadBundle(catalog: multiPlatformCatalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -3138,21 +3138,21 @@ class PathHierarchyTests: XCTestCase {
         let singlePlatformCatalog = Folder(name: "unit-test.docc", content: [
             makeSymbolGraphFile(platformName: "PlatformOne"),
         ])
-        let (_, singlePlatformContext) = try loadBundle(catalog: singlePlatformCatalog)
+        let (_, singlePlatformContext) = try await loadBundle(catalog: singlePlatformCatalog)
         let singlePlatformPaths = singlePlatformContext.linkResolver.localResolver.pathHierarchy.caseInsensitiveDisambiguatedPaths()
         XCTAssertEqual(paths[protocolRequirementID], singlePlatformPaths[protocolRequirementID])
         XCTAssertEqual(paths[defaultImplementationID], singlePlatformPaths[defaultImplementationID])
     }
     
-    func testMultiPlatformModuleWithExtension() throws {
-        let (_, context) = try testBundleAndContext(named: "MultiPlatformModuleWithExtension")
+    func testMultiPlatformModuleWithExtension() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MultiPlatformModuleWithExtension")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/MainModule/TopLevelProtocol/extensionMember(_:)", in: tree, asSymbolID: "extensionMember1")
         try assertFindsPath("/MainModule/TopLevelProtocol/InnerStruct/extensionMember(_:)", in: tree, asSymbolID: "extensionMember2")
     }
     
-    func testMissingRequiredMemberOfSymbolGraphRelationshipInOneLanguageAcrossManyPlatforms() throws {
+    func testMissingRequiredMemberOfSymbolGraphRelationshipInOneLanguageAcrossManyPlatforms() async throws {
         // We make a best-effort attempt to create a valid path hierarchy, even if the symbol graph inputs are not valid.
         
         // If the symbol graph files define container and member symbols without the required memberOf relationships we still try to match them up.
@@ -3179,7 +3179,7 @@ class PathHierarchyTests: XCTestCase {
             })
         ])
 
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
 
         let container = try tree.findNode(path: "/ModuleName/ContainerName-struct", onlyFindSymbols: true)
@@ -3198,7 +3198,7 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("/ModuleName/ContainerName", in: tree, asSymbolID: containerID)
     }
     
-    func testInvalidSymbolGraphWithNoMemberOfRelationshipsDesptiteDeepHierarchyAcrossManyPlatforms() throws {
+    func testInvalidSymbolGraphWithNoMemberOfRelationshipsDesptiteDeepHierarchyAcrossManyPlatforms() async throws {
         // We make a best-effort attempt to create a valid path hierarchy, even if the symbol graph inputs are not valid.
         
         // If the symbol graph files define a deep hierarchy, with the same symbol names but different symbol kinds across different, we try to match them up by language.
@@ -3237,7 +3237,7 @@ class PathHierarchyTests: XCTestCase {
             })
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let swiftSpecificNode = try tree.findNode(path: "/ModuleName/OuterContainerName-struct/MiddleContainerName-struct/InnerContainerName-struct/swiftSpecificMember()", onlyFindSymbols: true, parent: nil)
@@ -3286,7 +3286,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testMissingReferencedContainerSymbolOnSomePlatforms() throws {
+    func testMissingReferencedContainerSymbolOnSomePlatforms() async throws {
         // We make a best-effort attempt to create a valid path hierarchy, even if the symbol graph inputs are not valid.
         
         // If some platforms are missing the local container symbol from a `memberOf` relationship, but other platforms with the same relationship define that symbol,
@@ -3321,14 +3321,14 @@ class PathHierarchyTests: XCTestCase {
             ))
         })
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         try assertFindsPath("/ModuleName/ContainerName/memberName", in: tree, asSymbolID: memberID)
         try assertFindsPath("/ModuleName/ContainerName", in: tree, asSymbolID: containerID)
     }
     
-    func testMinimalTypeDisambiguationForClosureParameterWithVoidReturnType() throws {
+    func testMinimalTypeDisambiguationForClosureParameterWithVoidReturnType() async throws {
         // Create a `doSomething(with:and:)` function with a `String` parameter (same in every overload) and a `(TYPE)->()` closure parameter.
         func makeSymbolOverload(closureParameterType: SymbolGraph.Symbol.DeclarationFragments.Fragment) -> SymbolGraph.Symbol {
             makeSymbol(
@@ -3371,7 +3371,7 @@ class PathHierarchyTests: XCTestCase {
             ))
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let link = "/ModuleName/doSomething(with:and:)"
@@ -3395,7 +3395,7 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testMissingMemberOfAnonymousStructInsideUnion() throws {
+    func testMissingMemberOfAnonymousStructInsideUnion() async throws {
         let outerContainerID = "some-outer-container-symbol-id"
         let innerContainerID = "some-inner-container-symbol-id"
         let memberID = "some-member-symbol-id"
@@ -3448,7 +3448,7 @@ class PathHierarchyTests: XCTestCase {
             })
         ])
 
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let paths = tree.caseInsensitiveDisambiguatedPaths()
@@ -3465,8 +3465,8 @@ class PathHierarchyTests: XCTestCase {
         try assertPathNotFound("/ModuleName/Outer-struct/inner/member", in: tree)
     }
     
-    func testLinksToCxxOperators() throws {
-        let (_, context) = try testBundleAndContext(named: "CxxOperators")
+    func testLinksToCxxOperators() async throws {
+        let (_, context) = try await testBundleAndContext(named: "CxxOperators")
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         // MyClass operator+() const;                     // unary plus
@@ -3698,7 +3698,7 @@ class PathHierarchyTests: XCTestCase {
         try assertFindsPath("/CxxOperators/MyClass/operator,", in: tree, asSymbolID: "c:@S@MyClass@F@operator,#&$@S@MyClass#")
     }
     
-    func testMinimalTypeDisambiguation() throws {
+    func testMinimalTypeDisambiguation() async throws {
         enum DeclToken: ExpressibleByStringLiteral {
             case text(String)
             case internalParameter(String)
@@ -3779,7 +3779,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:second:third:)", in: tree, collisions: [
@@ -3829,7 +3829,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:second:third:)", in: tree, collisions: [
@@ -3879,7 +3879,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:second:)", in: tree, collisions: [
@@ -3916,7 +3916,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(with:)", in: tree, collisions: [
@@ -3958,7 +3958,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:second:third:)", in: tree, collisions: [
@@ -4057,7 +4057,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:second:third:fourth:fifth:sixth:)", in: tree, collisions: [
@@ -4123,7 +4123,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:second:)", in: tree, collisions: [
@@ -4173,7 +4173,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(first:)", in: tree, collisions: [
@@ -4218,7 +4218,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(...)", in: tree, collisions: [
@@ -4245,7 +4245,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(...)", in: tree, collisions: [
@@ -4272,7 +4272,7 @@ class PathHierarchyTests: XCTestCase {
                 ))
             ])
             
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let tree = context.linkResolver.localResolver.pathHierarchy
             
             try assertPathCollision("ModuleName/doSomething(...)", in: tree, collisions: [
@@ -4431,7 +4431,7 @@ class PathHierarchyTests: XCTestCase {
         assertParsedPathComponents("operator[]-(std::string&)->std::string&", [("operator[]", .typeSignature(parameterTypes: ["std::string&"], returnTypes: ["std::string&"]))])
     }
     
-    func testResolveExternalLinkFromTechnologyRoot() throws {
+    func testResolveExternalLinkFromTechnologyRoot() async throws {
         enableFeatureFlag(\.isExperimentalLinkHierarchySerializationEnabled)
         
         let catalog = Folder(name: "unit-test.docc", content: [
@@ -4442,7 +4442,7 @@ class PathHierarchyTests: XCTestCase {
             """),
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         let tree = context.linkResolver.localResolver.pathHierarchy
         
         let rootIdentifier = try XCTUnwrap(tree.modules.first?.identifier)

--- a/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PresentationURLGeneratorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import Foundation
 @testable import SwiftDocC
 
 class PresentationURLGeneratorTests: XCTestCase {
-    func testInternalURLs() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testInternalURLs() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let generator = PresentationURLGenerator(context: context, baseURL: URL(string: "https://host:1024/webPrefix")!)
         
         // Test resolved tutorial reference

--- a/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ReferenceResolverTests.swift
@@ -14,7 +14,7 @@ import Markdown
 import SymbolKit
 
 class ReferenceResolverTests: XCTestCase {
-    func testResolvesMediaForIntro() throws {
+    func testResolvesMediaForIntro() async throws {
         let source = """
 @Intro(
        title: x) {
@@ -24,7 +24,7 @@ class ReferenceResolverTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)!
         
@@ -33,7 +33,7 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(resolver.problems.count, 1)
     }
     
-    func testResolvesMediaForContentAndMedia() throws {
+    func testResolvesMediaForContentAndMedia() async throws {
         let source = """
 @ContentAndMedia {
    Blah blah.
@@ -43,7 +43,7 @@ class ReferenceResolverTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)!
         
@@ -52,7 +52,7 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(resolver.problems.count, 1)
     }
 
-    func testResolvesExternalLinks() throws {
+    func testResolvesExternalLinks() async throws {
         let source = """
     @Intro(title: "Technology X") {
        Info at: <https://www.wikipedia.org>.
@@ -60,7 +60,7 @@ class ReferenceResolverTests: XCTestCase {
     """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)!
         
@@ -77,8 +77,8 @@ class ReferenceResolverTests: XCTestCase {
     }
     
     // Tests all reference syntax formats to a child symbol
-    func testReferencesToChildFromFramework() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testReferencesToChildFromFramework() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit``
@@ -110,8 +110,8 @@ class ReferenceResolverTests: XCTestCase {
     }
 
     // Test relative paths to non-child symbol
-    func testReferencesToGrandChildFromFramework() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testReferencesToGrandChildFromFramework() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit``
@@ -136,8 +136,8 @@ class ReferenceResolverTests: XCTestCase {
     }
     
     // Test references to a sibling symbol
-    func testReferencesToSiblingFromFramework() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testReferencesToSiblingFromFramework() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit/SideClass/myFunction()``
@@ -162,8 +162,8 @@ class ReferenceResolverTests: XCTestCase {
     }
 
     // Test references to symbols in root paths
-    func testReferencesToTutorial() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testReferencesToTutorial() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit/SideClass/myFunction()``
@@ -188,8 +188,8 @@ class ReferenceResolverTests: XCTestCase {
     }
 
     // Test references to technology pages
-    func testReferencesToTechnologyPages() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testReferencesToTechnologyPages() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit/SideClass/myFunction()``
@@ -213,8 +213,8 @@ class ReferenceResolverTests: XCTestCase {
     }
 
     // Test external references
-    func testExternalReferencesConsiderBundleIdentifier() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testExternalReferencesConsiderBundleIdentifier() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit/SideClass/myFunction()``
@@ -306,7 +306,7 @@ class ReferenceResolverTests: XCTestCase {
         }
     }
     
-    func testRegisteredButUncuratedArticles() throws {
+    func testRegisteredButUncuratedArticles() async throws {
         var referencingArticleURL: URL!
         var uncuratedArticleFile: URL!
         
@@ -321,7 +321,7 @@ class ReferenceResolverTests: XCTestCase {
         """
         
         // TestBundle has more than one module, so automatic registration and curation won't happen
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             referencingArticleURL = root.appendingPathComponent("article.md")
             try source.write(to: referencingArticleURL, atomically: true, encoding: .utf8)
             
@@ -345,8 +345,8 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(referencingFileDiagnostics.filter({ $0.identifier == "org.swift.docc.unresolvedTopicReference" }).count, 1)
     }
     
-    func testRelativeReferencesToExtensionSymbols() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
+    func testRelativeReferencesToExtensionSymbols() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
             // We don't want the external target to be part of the archive as that is not
             // officially supported yet.
             try FileManager.default.removeItem(at: root.appendingPathComponent("Dependency.symbols.json"))
@@ -406,8 +406,8 @@ class ReferenceResolverTests: XCTestCase {
         }
     }
 
-    func testCuratedExtensionRemovesEmptyPage() throws {
-        let (bundle, context) = try testBundleAndContext(named: "ModuleWithSingleExtension")
+    func testCuratedExtensionRemovesEmptyPage() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "ModuleWithSingleExtension")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -424,8 +424,8 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertNoThrow(try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithSingleExtension/Swift/Array/asdf", sourceLanguage: .swift)))
     }
 
-    func testCuratedExtensionWithDanglingReference() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "ModuleWithSingleExtension") { root in
+    func testCuratedExtensionWithDanglingReference() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "ModuleWithSingleExtension") { root in
             let topLevelArticle = root.appendingPathComponent("ModuleWithSingleExtension.md")
             try FileManager.default.removeItem(at: topLevelArticle)
 
@@ -464,8 +464,8 @@ class ReferenceResolverTests: XCTestCase {
         ])
     }
 
-    func testCuratedExtensionWithDanglingReferenceToFragment() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "ModuleWithSingleExtension") { root in
+    func testCuratedExtensionWithDanglingReferenceToFragment() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "ModuleWithSingleExtension") { root in
             let topLevelArticle = root.appendingPathComponent("ModuleWithSingleExtension.md")
             try FileManager.default.removeItem(at: topLevelArticle)
 
@@ -492,8 +492,8 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertFalse(context.knownPages.contains(where: { $0 == extendedStructure }))
     }
 
-    func testCuratedExtensionWithDocumentationExtension() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "ModuleWithSingleExtension") { root in
+    func testCuratedExtensionWithDocumentationExtension() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "ModuleWithSingleExtension") { root in
             let topLevelArticle = root.appendingPathComponent("ModuleWithSingleExtension.md")
             try FileManager.default.removeItem(at: topLevelArticle)
 
@@ -521,8 +521,8 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssert(context.knownPages.contains(where: { $0 == extendedStructure }))
     }
 
-    func testCuratedExtensionWithAdditionalConformance() throws {
-        let (bundle, context) = try testBundleAndContext(named: "ModuleWithConformanceAndExtension")
+    func testCuratedExtensionWithAdditionalConformance() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "ModuleWithConformanceAndExtension")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithConformanceAndExtension/MyProtocol", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -537,8 +537,8 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssert(renderReference is UnresolvedRenderReference)
     }
 
-    func testExtensionWithEmptyDeclarationFragments() throws {
-        let (bundle, context) = try testBundleAndContext(named: "ModuleWithEmptyDeclarationFragments")
+    func testExtensionWithEmptyDeclarationFragments() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "ModuleWithEmptyDeclarationFragments")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleWithEmptyDeclarationFragments", sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -549,7 +549,7 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(renderNode.topicSections.count, 0)
     }
     
-    func testUnresolvedTutorialReferenceIsWarning() throws {
+    func testUnresolvedTutorialReferenceIsWarning() async throws {
         let source = """
 @Chapter(name: "SwiftUI Essentials") {
 
@@ -560,7 +560,7 @@ class ReferenceResolverTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         var problems = [Problem]()
 
         let chapter = try XCTUnwrap(Chapter(from: directive, source: nil, for: bundle, problems: &problems))
@@ -571,7 +571,7 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertEqual(resolver.problems.filter({ $0.diagnostic.severity == .warning }).count, 1)
     }
     
-    func testResolvesArticleContent() throws {
+    func testResolvesArticleContent() async throws {
         let source = """
         # An Article
         
@@ -580,7 +580,7 @@ class ReferenceResolverTests: XCTestCase {
         Discussion link to ``SideKit``.
         """
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
         let article = try XCTUnwrap(Article(markup: document, metadata: nil, redirects: nil, options: [:]))
         
@@ -611,8 +611,8 @@ class ReferenceResolverTests: XCTestCase {
         XCTAssertTrue(foundSymbolDiscussionLink)
     }
     
-    func testForwardsSymbolPropertiesThatAreUnmodifiedDuringLinkResolution() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testForwardsSymbolPropertiesThatAreUnmodifiedDuringLinkResolution() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var resolver = ReferenceResolver(context: context, bundle: bundle)
         
@@ -736,7 +736,7 @@ class ReferenceResolverTests: XCTestCase {
         }
     }
     
-    func testEmitsDiagnosticsForEachDocumentationChunk() throws {
+    func testEmitsDiagnosticsForEachDocumentationChunk() async throws {
         let moduleReference = ResolvedTopicReference(bundleID: "com.example.test", path: "/documentation/ModuleName", sourceLanguage: .swift)
         let reference = ResolvedTopicReference(bundleID: "com.example.test", path: "/documentation/ModuleName/Something", sourceLanguage: .swift)
         
@@ -768,7 +768,7 @@ class ReferenceResolverTests: XCTestCase {
             mixins: [:]
         )
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         
         let documentationExtensionContent = """
         # ``Something``

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/AbsoluteSymbolLinkTests.swift
@@ -225,8 +225,8 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         }
     }
     
-    func testCompileSymbolGraphAndValidateLinks() throws {
-        let (_, _, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCompileSymbolGraphAndValidateLinks() async throws {
+        let (_, _, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let expectedDescriptions = [
             // doc://org.swift.docc.example/documentation/FillIntroduced:
             """
@@ -533,8 +533,8 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         }
     }
     
-    func testCompileOverloadedSymbolGraphAndValidateLinks() throws {
-        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
+    func testCompileOverloadedSymbolGraphAndValidateLinks() async throws {
+        let (_, _, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         
         let expectedDescriptions = [
             // doc://com.shapes.ShapeKit/documentation/ShapeKit:
@@ -853,8 +853,8 @@ class AbsoluteSymbolLinkTests: XCTestCase {
         }
     }
     
-    func testLinkComponentStringConversion() throws {
-        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
+    func testLinkComponentStringConversion() async throws {
+        let (_, _, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         
         let bundlePathComponents = context.documentationCache.allReferences
             .flatMap(\.pathComponents)

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentableTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/DocCSymbolRepresentableTests.swift
@@ -19,8 +19,8 @@ import SymbolKit
 // Deprecating the test silences the deprecation warning when running the tests. It doesn't skip the test.
 @available(*, deprecated, message: "This deprecated API will be removed after 6.2 is released")
 class DocCSymbolRepresentableTests: XCTestCase {
-    func testDisambiguatedByType() throws {
-        try performOverloadSymbolDisambiguationTest(
+    func testDisambiguatedByType() async throws {
+        try await performOverloadSymbolDisambiguationTest(
             correctLink: """
             doc://com.shapes.ShapeKit/documentation/ShapeKit/OverloadedStruct/secondTestMemberName-swift.property
             """,
@@ -34,8 +34,8 @@ class DocCSymbolRepresentableTests: XCTestCase {
         )
     }
     
-    func testOverloadedByCaseInsensitivity() throws {
-        try performOverloadSymbolDisambiguationTest(
+    func testOverloadedByCaseInsensitivity() async throws {
+        try await performOverloadSymbolDisambiguationTest(
             correctLink: """
             doc://com.shapes.ShapeKit/documentation/ShapeKit/OverloadedByCaseStruct/ThirdTestMemberName-5vyx9
             """,
@@ -48,8 +48,8 @@ class DocCSymbolRepresentableTests: XCTestCase {
         )
     }
     
-    func testProtocolMemberWithUSRHash() throws {
-        try performOverloadSymbolDisambiguationTest(
+    func testProtocolMemberWithUSRHash() async throws {
+        try await performOverloadSymbolDisambiguationTest(
             correctLink: """
             doc://com.shapes.ShapeKit/documentation/ShapeKit/OverloadedProtocol/fourthTestMemberName(test:)-961zx
             """,
@@ -62,8 +62,8 @@ class DocCSymbolRepresentableTests: XCTestCase {
         )
     }
     
-    func testFunctionWithKindIdentifierAndUSRHash() throws {
-        try performOverloadSymbolDisambiguationTest(
+    func testFunctionWithKindIdentifierAndUSRHash() async throws {
+        try await performOverloadSymbolDisambiguationTest(
             correctLink: """
             doc://com.shapes.ShapeKit/documentation/ShapeKit/OverloadedEnum/firstTestMemberName(_:)-14g8s
             """,
@@ -77,8 +77,8 @@ class DocCSymbolRepresentableTests: XCTestCase {
         )
     }
     
-    func testSymbolWithNoDisambiguation() throws {
-        try performOverloadSymbolDisambiguationTest(
+    func testSymbolWithNoDisambiguation() async throws {
+        try await performOverloadSymbolDisambiguationTest(
             correctLink: """
             doc://com.shapes.ShapeKit/documentation/ShapeKit/RegularParent/firstMember
             """,
@@ -93,8 +93,8 @@ class DocCSymbolRepresentableTests: XCTestCase {
         )
     }
     
-    func testAmbiguousProtocolMember() throws {
-        try performOverloadSymbolDisambiguationTest(
+    func testAmbiguousProtocolMember() async throws {
+        try await performOverloadSymbolDisambiguationTest(
             correctLink: """
             doc://com.shapes.ShapeKit/documentation/ShapeKit/RegularParent/firstMember
             """,
@@ -114,9 +114,9 @@ class DocCSymbolRepresentableTests: XCTestCase {
         incorrectLinks: [String],
         symbolTitle: String,
         expectedNumberOfAmbiguousSymbols: Int
-    ) throws {
+    ) async throws {
         // Build a bundle with an unusual number of overloaded symbols
-        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
+        let (_, _, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         
         // Collect the overloaded symbols nodes from the built bundle
         let ambiguousSymbols = context.documentationCache
@@ -169,8 +169,8 @@ class DocCSymbolRepresentableTests: XCTestCase {
         }
     }
     
-    func testLinkComponentInitialization() throws {
-        let (_, _, context) = try testBundleAndContext(named: "OverloadedSymbols")
+    func testLinkComponentInitialization() async throws {
+        let (_, _, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         
         var count = 0
         for (reference, documentationNode) in context.documentationCache {

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolBreadcrumbTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,8 +12,8 @@ import XCTest
 @testable import SwiftDocC
 
 class SymbolBreadcrumbTests: XCTestCase {
-    func testLanguageSpecificBreadcrumbs() throws {
-        let (bundle, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testLanguageSpecificBreadcrumbs() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "GeometricalShapes")
         let resolver = try XCTUnwrap(context.linkResolver.localResolver)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
@@ -96,8 +96,8 @@ class SymbolBreadcrumbTests: XCTestCase {
         }
     }
     
-    func testMixedLanguageSpecificBreadcrumbs() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+    func testMixedLanguageSpecificBreadcrumbs() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedLanguageFramework")
         let resolver = try XCTUnwrap(context.linkResolver.localResolver)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolDisambiguationTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolDisambiguationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import SymbolKit
 
 class SymbolDisambiguationTests: XCTestCase {
     
-    func testPathCollisionWithDifferentTypesInSameLanguage() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testPathCollisionWithDifferentTypesInSameLanguage() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "first"], kind: .property),
                 TestSymbolData(preciseID: "second", pathComponents: ["Something", "First"], kind: .struct),
@@ -36,8 +36,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testPathCollisionWithDifferentArgumentTypesInSameLanguage() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testPathCollisionWithDifferentArgumentTypesInSameLanguage() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 // The argument type isn't represented in the symbol name in the path components
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "first(_:)"], kind: .method),
@@ -59,8 +59,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testSameSymbolWithDifferentKindsInDifferentLanguages() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testSameSymbolWithDifferentKindsInDifferentLanguages() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "First"], kind: .enum),
             ],
@@ -77,8 +77,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testDifferentSymbolsWithDifferentKindsInDifferentLanguages() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testDifferentSymbolsWithDifferentKindsInDifferentLanguages() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "First"], kind: .struct),
             ],
@@ -98,8 +98,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testSameSymbolWithDifferentNamesInDifferentLanguages() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testSameSymbolWithDifferentNamesInDifferentLanguages() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "first(one:two:)"], kind: .method),
             ],
@@ -116,8 +116,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testOneVariantOfMultiLanguageSymbolCollidesWithDifferentTypeSymbol() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testOneVariantOfMultiLanguageSymbolCollidesWithDifferentTypeSymbol() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "instance-method", pathComponents: ["Something", "first(one:two:)"], kind: .method),
                 TestSymbolData(preciseID: "type-method", pathComponents: ["Something", "first(one:two:)"], kind: .typeMethod),
@@ -139,8 +139,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testStructAndEnumAndTypeAliasCollisionOfSameSymbol() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testStructAndEnumAndTypeAliasCollisionOfSameSymbol() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "First"], kind: .struct),
             ],
@@ -161,8 +161,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testTripleCollisionWithBothSameTypeAndDifferentType() throws {
-        let references = try disambiguatedReferencesForSymbols(
+    func testTripleCollisionWithBothSameTypeAndDifferentType() async throws {
+        let references = try await disambiguatedReferencesForSymbols(
             swift: [
                 TestSymbolData(preciseID: "first", pathComponents: ["Something", "first(_:_:)"], kind: .method),
                 TestSymbolData(preciseID: "second", pathComponents: ["Something", "first(_:_:)"], kind: .typeMethod),
@@ -188,8 +188,8 @@ class SymbolDisambiguationTests: XCTestCase {
         )
     }
     
-    func testMixedLanguageFramework() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+    func testMixedLanguageFramework() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedLanguageFramework")
         
         var loader = SymbolGraphLoader(bundle: bundle, dataLoader: { try context.contentsOfURL($0, in: $1) })
         try loader.loadAll()
@@ -265,7 +265,7 @@ class SymbolDisambiguationTests: XCTestCase {
         let kind: SymbolGraph.Symbol.KindIdentifier
     }
     
-    private func disambiguatedReferencesForSymbols(swift swiftSymbols: [TestSymbolData], objectiveC objectiveCSymbols: [TestSymbolData]) throws -> [SymbolGraph.Symbol.Identifier : ResolvedTopicReference] {
+    private func disambiguatedReferencesForSymbols(swift swiftSymbols: [TestSymbolData], objectiveC objectiveCSymbols: [TestSymbolData]) async throws -> [SymbolGraph.Symbol.Identifier : ResolvedTopicReference] {
         let graph = SymbolGraph(
             metadata: SymbolGraph.Metadata(
                 formatVersion: SymbolGraph.SemanticVersion(major: 1, minor: 1, patch: 1),
@@ -335,7 +335,7 @@ class SymbolDisambiguationTests: XCTestCase {
             objcSymbolGraphURL: try JSONEncoder().encode(graph2),
         ], fallback: nil)
         
-        let context = try DocumentationContext(bundle: bundle, dataProvider: provider)
+        let context = try await DocumentationContext(bundle: bundle, dataProvider: provider)
         
         return context.linkResolver.localResolver.referencesForSymbols(in: ["SymbolDisambiguationTests": unified], bundle: bundle, context: context)
     }

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,8 +50,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
     
     private let swiftSelector = UnifiedSymbolGraph.Selector(interfaceLanguage: "swift", platform: nil)
     
-    func testImplementsRelationship() throws {
-        let (bundle, context) = try testBundleAndContext()
+    func testImplementsRelationship() async throws {
+        let (bundle, context) = try await testBundleAndContext()
         var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
         let engine = DiagnosticEngine()
         
@@ -64,8 +64,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         XCTAssertFalse((documentationCache["B"]!.semantic as! Symbol).defaultImplementations.implementations.isEmpty)
     }
 
-    func testConformsRelationship() throws {
-        let (bundle, _) = try testBundleAndContext()
+    func testConformsRelationship() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
         let engine = DiagnosticEngine()
         
@@ -93,8 +93,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         XCTAssertEqual(conforming.destinations.first?.url?.absoluteString, "doc://com.example.test/documentation/SomeModuleName/A")
     }
 
-    func testInheritanceRelationship() throws {
-        let (bundle, _) = try testBundleAndContext()
+    func testInheritanceRelationship() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
         let engine = DiagnosticEngine()
         
@@ -122,8 +122,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         XCTAssertEqual(inherited.destinations.first?.url?.absoluteString, "doc://com.example.test/documentation/SomeModuleName/A")
     }
     
-    func testInheritanceRelationshipFromOtherFramework() throws {
-        let (bundle, _) = try testBundleAndContext()
+    func testInheritanceRelationshipFromOtherFramework() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
         let engine = DiagnosticEngine()
         
@@ -159,8 +159,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         }), "Could not fallback for parent in inherits from relationship")
     }
     
-    func testRequirementRelationship() throws {
-        let (bundle, _) = try testBundleAndContext()
+    func testRequirementRelationship() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
         let engine = DiagnosticEngine()
         
@@ -173,8 +173,8 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         XCTAssertTrue((documentationCache["A"]!.semantic as! Symbol).isRequired)
     }
     
-    func testOptionalRequirementRelationship() throws {
-        let (bundle, _) = try testBundleAndContext()
+    func testOptionalRequirementRelationship() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
         let engine = DiagnosticEngine()
         

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolReferenceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -105,7 +105,7 @@ class SymbolReferenceTests: XCTestCase {
         }
     }
 
-    func testCreatesUniquePathsForOverloadSymbols() throws {
+    func testCreatesUniquePathsForOverloadSymbols() async throws {
         let testCatalog = Folder(name: "TestCreatesUniquePathsForOverloadSymbols.docc", content: [
             InfoPlist(displayName: "TestCreatesUniquePathsForOverloadSymbols", identifier: "com.example.documentation"),
             Folder(name: "Resources", content: [
@@ -198,7 +198,7 @@ class SymbolReferenceTests: XCTestCase {
             ]),
         ])
         
-        let (_, context) = try loadBundle(catalog: testCatalog)
+        let (_, context) = try await loadBundle(catalog: testCatalog)
         
         // The overloads are sorted and all dupes get a hash suffix.
         XCTAssertEqual(

--- a/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/LinkTargets/LinkDestinationSummaryTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -93,8 +93,8 @@ class ExternalLinkableTests: XCTestCase {
         InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
     ])
     
-    func testSummaryOfTutorialPage() throws {
-        let (bundle, context) = try loadBundle(catalog: catalogHierarchy)
+    func testSummaryOfTutorialPage() async throws {
+        let (bundle, context) = try await loadBundle(catalog: catalogHierarchy)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
@@ -150,8 +150,8 @@ class ExternalLinkableTests: XCTestCase {
         XCTAssertEqual(summaries, decoded)
     }
 
-    func testSymbolSummaries() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testSymbolSummaries() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         do {
             let symbolReference = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass", sourceLanguage: .swift)
@@ -312,8 +312,8 @@ class ExternalLinkableTests: XCTestCase {
         }
     }
     
-    func testTopicImageReferences() throws {
-        let (url, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testTopicImageReferences() async throws {
+        let (url, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             let extensionFile = """
             # ``MyKit/MyClass/myFunction()``
 
@@ -430,8 +430,8 @@ class ExternalLinkableTests: XCTestCase {
         }
     }
     
-    func testVariantSummaries() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+    func testVariantSummaries() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedLanguageFramework")
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         // Check a symbol that's represented as a class in both Swift and Objective-C
@@ -647,7 +647,7 @@ class ExternalLinkableTests: XCTestCase {
     }
 
     /// Ensure that the task group link summary for overload group pages doesn't overwrite any manual curation.
-    func testOverloadSymbolsWithManualCuration() throws {
+    func testOverloadSymbolsWithManualCuration() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolGraph = SymbolGraph.init(
@@ -723,7 +723,7 @@ class ExternalLinkableTests: XCTestCase {
             JSONFile(name: "MyModule.symbols.json", content: symbolGraph),
             InfoPlist(displayName: "MyModule", identifier: "com.example.mymodule")
         ])
-        let (bundle, context) = try loadBundle(catalog: catalogHierarchy)
+        let (bundle, context) = try await loadBundle(catalog: catalogHierarchy)
         
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
 

--- a/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/ParametersAndReturnValidatorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,8 +17,8 @@ import SwiftDocCTestUtilities
 
 class ParametersAndReturnValidatorTests: XCTestCase {
     
-    func testFiltersParameters() throws {
-        let (bundle, context) = try testBundleAndContext(named: "ErrorParameters")
+    func testFiltersParameters() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "ErrorParameters")
         
         // /// - Parameters:
         // ///   - someValue: Some value.
@@ -111,7 +111,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         }
     }
     
-    func testExtendsReturnValueDocumentation() throws {
+    func testExtendsReturnValueDocumentation() async throws {
         for (returnValueDescription, expectsExtendedDocumentation) in [
             // Expects to extend the documentation
             ("Returns some value.", true),
@@ -153,7 +153,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
                 ])
             ])
             
-            let (bundle, context) = try loadBundle(catalog: catalog)
+            let (bundle, context) = try await loadBundle(catalog: catalog)
             
             XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
             
@@ -177,8 +177,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         }
     }
     
-    func testParametersWithAlternateSignatures() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "AlternateDeclarations") { url in
+    func testParametersWithAlternateSignatures() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "AlternateDeclarations") { url in
             try """
             # ``MyClass/present(completion:)``
             
@@ -207,8 +207,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(swiftReturnsContent, "Description of the return value that’s available for some other alternatives.")
     }
     
-    func testParameterDiagnosticsInDocumentationExtension() throws {
-        let (url, _, context) = try testBundleAndContext(copying: "ErrorParameters") { url in
+    func testParameterDiagnosticsInDocumentationExtension() async throws {
+        let (url, _, context) = try await testBundleAndContext(copying: "ErrorParameters") { url in
             try """
             # ``MyClassInObjectiveC/doSomethingWith:error:``
             
@@ -292,8 +292,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         }
     }
     
-    func testFunctionsThatCorrespondToPropertiesInAnotherLanguage() throws {
-        let (_, _, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testFunctionsThatCorrespondToPropertiesInAnotherLanguage() async throws {
+        let (_, _, context) = try await testBundleAndContext(named: "GeometricalShapes")
         XCTAssertEqual(context.problems.map(\.diagnostic.summary), [])
         
         let reference = try XCTUnwrap(context.knownPages.first(where: { $0.lastPathComponent == "isEmpty" }))
@@ -320,8 +320,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(objcReturnsContent, "`YES` if the specified circle is empty; otherwise, `NO`.")
     }
     
-    func testCanDocumentInitializerReturnValue() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "GeometricalShapes") { url in
+    func testCanDocumentInitializerReturnValue() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "GeometricalShapes") { url in
             try """
             # ``Circle/init(center:radius:)``
             
@@ -351,7 +351,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         ])
     }
     
-    func testNoParameterDiagnosticWithoutFunctionSignature() throws {
+    func testNoParameterDiagnosticWithoutFunctionSignature() async throws {
         var symbolGraph = makeSymbolGraph(docComment: """
             Some function description
             
@@ -365,12 +365,12 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 0)
     }
     
-    func testNoParameterDiagnosticWithoutDocumentationComment() throws {
+    func testNoParameterDiagnosticWithoutDocumentationComment() async throws {
         let symbolGraph = makeSymbolGraph(docComment: """
             Some function description
             
@@ -380,12 +380,12 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 0)
     }
     
-    func testMissingParametersInDocCommentDiagnostics() throws {
+    func testMissingParametersInDocCommentDiagnostics() async throws {
         let symbolGraph = makeSymbolGraph(docComment: """
             Some function description
             
@@ -396,7 +396,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 2)
         let endOfParameterSectionLocation = SourceLocation(line: start.line + 5, column: start.character + 40, source: symbolURL)
@@ -425,7 +425,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "\n///  - fourthParameter: <#parameter description#>")
     }
     
-    func testMissingSeparateParametersInDocCommentDiagnostics() throws {
+    func testMissingSeparateParametersInDocCommentDiagnostics() async throws {
         let symbolGraph = makeSymbolGraph(docComment: """
             Some function description
             
@@ -435,7 +435,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: symbolGraph)
         ])
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.count, 2)
         let endOfParameterSectionLocation = SourceLocation(line: start.line + 4, column: start.character + 48, source: symbolURL)
@@ -464,7 +464,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(otherMissingParameterProblem.possibleSolutions.first?.replacements.first?.replacement, "\n///- Parameter fourthParameter: <#parameter description#>")
     }
     
-    func testFunctionWithOnlyErrorParameter() throws {
+    func testFunctionWithOnlyErrorParameter() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 Folder(name: "swift", content: [
@@ -490,7 +490,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
                     ))
                 ])
             ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
@@ -508,7 +508,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(returnsSections[.objectiveC]?.content.map({ $0.format() }).joined(), "Some return value description.")
     }
     
-    func testFunctionWithDifferentSignaturesOnDifferentPlatforms() throws {
+    func testFunctionWithDifferentSignaturesOnDifferentPlatforms() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 // One parameter, void return
@@ -550,7 +550,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
                 """)
             ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
@@ -567,7 +567,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(returnSections[.objectiveC]?.content.map({ $0.format() }).joined(), "Some description of the return value that is only available on platform 3.")
     }
     
-    func testFunctionWithErrorParameterButVoidType() throws {
+    func testFunctionWithErrorParameterButVoidType() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 Folder(name: "swift", content: [
@@ -594,7 +594,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
                 ])
             ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
@@ -613,8 +613,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertNil(returnsSections[.objectiveC])
     }
     
-    func testWarningForDocumentingExternalParameterNames() throws {
-        let warningOutput = try warningOutputRaisedFrom(
+    func testWarningForDocumentingExternalParameterNames() async throws {
+        let warningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -633,8 +633,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         """)
     }
     
-    func testWarningForDocumentingVoidReturn() throws {
-        let warningOutput = try warningOutputRaisedFrom(
+    func testWarningForDocumentingVoidReturn() async throws {
+        let warningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -654,8 +654,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         """)
     }
     
-    func testWarningForParameterDocumentedTwice() throws {
-        let warningOutput = try warningOutputRaisedFrom(
+    func testWarningForParameterDocumentedTwice() async throws {
+        let warningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -676,8 +676,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         """)
     }
     
-    func testWarningForExtraDocumentedParameter() throws {
-        let warningOutput = try warningOutputRaisedFrom(
+    func testWarningForExtraDocumentedParameter() async throws {
+        let warningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -697,8 +697,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         """)
     }
     
-    func testWarningForUndocumentedParameter() throws {
-        let missingFirstWarningOutput = try warningOutputRaisedFrom(
+    func testWarningForUndocumentedParameter() async throws {
+        let missingFirstWarningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -717,7 +717,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         """)
         
         
-        let missingSecondWarningOutput = try warningOutputRaisedFrom(
+        let missingSecondWarningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -736,8 +736,8 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         """)
     }
     
-    func testDoesNotWarnAboutInheritedDocumentation() throws {
-        let warningOutput = try warningOutputRaisedFrom(
+    func testDoesNotWarnAboutInheritedDocumentation() async throws {
+        let warningOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -751,7 +751,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertEqual(warningOutput, "")
     }
     
-    func testDocumentingTwoUnnamedParameters() throws {
+    func testDocumentingTwoUnnamedParameters() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
                 docComment: """
@@ -768,7 +768,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
             ))
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
         
@@ -787,7 +787,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         XCTAssertNil(returnsSections[.objectiveC])
     }
     
-    func testDocumentingMixedNamedAndUnnamedParameters() throws {
+    func testDocumentingMixedNamedAndUnnamedParameters() async throws {
         // This test verifies the behavior of documenting two named parameters and one unnamed parameter.
         //
         // It checks different combinations of which parameter is unnamed:
@@ -828,7 +828,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
                         returnValue: .init(kind: .typeIdentifier, spelling: "Void", preciseIdentifier: "s:s4Voida")
                     ))
                 ])
-                let (bundle, context) = try loadBundle(catalog: catalog)
+                let (bundle, context) = try await loadBundle(catalog: catalog)
                 
                 XCTAssert(context.problems.isEmpty, "Unexpected problems: \(context.problems.map(\.diagnostic.summary))")
                 
@@ -852,10 +852,10 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         }
     }
     
-    func testWarningsForMissingOrExtraUnnamedParameters() throws {
+    func testWarningsForMissingOrExtraUnnamedParameters() async throws {
         let returnValue = SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment(kind: .typeIdentifier, spelling: "void", preciseIdentifier: "c:v")
         
-        let tooFewParametersOutput = try warningOutputRaisedFrom(
+        let tooFewParametersOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -882,7 +882,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
            |                                                    ╰─suggestion: Document unnamed parameter #3
         """)
         
-        let tooManyParametersOutput = try warningOutputRaisedFrom(
+        let tooManyParametersOutput = try await warningOutputRaisedFrom(
             docComment: """
             Some function description
             
@@ -913,7 +913,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         returnValue: SymbolGraph.Symbol.DeclarationFragments.Fragment,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws -> String {
+    ) async throws -> String {
         let fileSystem = try TestFileSystem(folders: [
             Folder(name: "path", content: [
                 Folder(name: "to", content: [
@@ -941,7 +941,7 @@ class ParametersAndReturnValidatorTests: XCTestCase {
         let (bundle, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
             .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/unit-test.docc"), options: .init())
 
-        _ = try DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine)
+        _ = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine)
         
         diagnosticEngine.flush()
         return logStorage.text.trimmingCharacters(in: .newlines)

--- a/Tests/SwiftDocCTests/Model/PropertyListPossibleValuesSectionTests.swift
+++ b/Tests/SwiftDocCTests/Model/PropertyListPossibleValuesSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,9 +17,9 @@ import SwiftDocCTestUtilities
 
 class PropertyListPossibleValuesSectionTests: XCTestCase {
     
-    func testPossibleValuesDiagnostics() throws {
+    func testPossibleValuesDiagnostics() async throws {
         // Check that a problem is emitted when extra possible values are documented.
-        var (url, _, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+        var (url, _, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             
@@ -44,7 +44,7 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         }
         
         // Check that no problems are emitted if no extra possible values are documented.
-        (url, _, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+        (url, _, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             
@@ -61,7 +61,7 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         }
         
         // Check that a problem is emitted with possible solutions.
-        (url, _, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+        (url, _, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             
@@ -81,8 +81,8 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         }
     }
     
-    func testAbsenceOfPossibleValues() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData")
+    func testAbsenceOfPossibleValues() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "DictionaryData")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Artist", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
@@ -90,8 +90,8 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         XCTAssertNil(converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
     }
     
-    func testUndocumentedPossibleValues() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData")
+    func testUndocumentedPossibleValues() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "DictionaryData")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DictionaryData/Month", sourceLanguage: .swift))
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         let possibleValuesSection = try XCTUnwrap(converter.convert(node).primaryContentSections.first(where: { $0.kind == .possibleValues}) as? PossibleValuesRenderSection)
@@ -101,8 +101,8 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         XCTAssertEqual(possibleValues.map { $0.name }, ["January", "February", "March"])
     }
     
-    func testDocumentedPossibleValuesMatchSymbolGraphPossibleValues() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+    func testDocumentedPossibleValuesMatchSymbolGraphPossibleValues() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             
@@ -125,8 +125,8 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         XCTAssertEqual(possibleValues.map { $0.value }, ["January", "February", "March"])
     }
     
-    func testDocumentedPossibleValues() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+    func testDocumentedPossibleValues() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             
@@ -149,8 +149,8 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         XCTAssertEqual(documentedPossibleValue.contents.count , 1)
     }
     
-    func testUnresolvedLinkWarnings() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+    func testUnresolvedLinkWarnings() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             
@@ -171,8 +171,8 @@ class PropertyListPossibleValuesSectionTests: XCTestCase {
         XCTAssertTrue(problemDiagnosticsSummary.contains("\'NotFoundSymbol\' doesn\'t exist at \'/DictionaryData/Month\'"))
     }
     
-    func testResolvedLins() throws {
-        let (_, _, context) = try testBundleAndContext(copying: "DictionaryData") { url in
+    func testResolvedLins() async throws {
+        let (_, _, context) = try await testBundleAndContext(copying: "DictionaryData") { url in
             try """
             #  ``Month``
             

--- a/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -66,8 +66,8 @@ class RenderContentMetadataTests: XCTestCase {
         XCTAssertEqual(metadata, roundtripListing.metadata)
     }
     
-    func testRenderingTables() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderingTables() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
@@ -107,8 +107,8 @@ class RenderContentMetadataTests: XCTestCase {
         }
     }
 
-    func testRenderingTableSpans() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderingTableSpans() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
@@ -160,8 +160,8 @@ class RenderContentMetadataTests: XCTestCase {
         try assertRoundTripCoding(renderedTable)
     }
 
-    func testRenderingTableColumnAlignments() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderingTableColumnAlignments() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
@@ -202,8 +202,8 @@ class RenderContentMetadataTests: XCTestCase {
     }
 
     /// Verifies that a table with `nil` alignments and a table with all-unset alignments still compare as equal.
-    func testRenderedTableEquality() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderedTableEquality() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
@@ -228,8 +228,8 @@ class RenderContentMetadataTests: XCTestCase {
     }
 
     /// Verifies that two tables with otherwise-identical contents but different column alignments compare as unequal.
-    func testRenderedTableInequality() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderedTableInequality() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let decodedTableWithUnsetColumns: RenderBlockContent.Table
@@ -275,8 +275,8 @@ class RenderContentMetadataTests: XCTestCase {
         XCTAssertNotEqual(decodedTableWithUnsetColumns, decodedTableWithLeftColumns)
     }
     
-    func testStrikethrough() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testStrikethrough() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
@@ -298,8 +298,8 @@ class RenderContentMetadataTests: XCTestCase {
         }
     }
     
-    func testHeadingAnchorShouldBeEncoded() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testHeadingAnchorShouldBeEncoded() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """

--- a/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderHierarchyTranslatorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,8 +12,8 @@
 import XCTest
 
 class RenderHierarchyTranslatorTests: XCTestCase {
-    func test() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func test() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let technologyReference = ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
         
         var translator = RenderHierarchyTranslator(context: context, bundle: bundle)
@@ -87,9 +87,9 @@ class RenderHierarchyTranslatorTests: XCTestCase {
         XCTAssertEqual(assessments.reference.identifier, "doc://org.swift.docc.example/tutorials/Test-Bundle/TestTutorial#Check-Your-Understanding")
     }
     
-    func testMultiplePaths() throws {
+    func testMultiplePaths() async throws {
         // Curate "TestTutorial" under MyKit as well as TechnologyX.
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             let myKitURL = root.appendingPathComponent("documentation/mykit.md")
             let text = try String(contentsOf: myKitURL).replacingOccurrences(of: "## Topics", with: """
             ## Topics
@@ -128,8 +128,8 @@ class RenderHierarchyTranslatorTests: XCTestCase {
         ])
     }
     
-    func testLanguageSpecificHierarchies() throws {
-        let (bundle, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testLanguageSpecificHierarchies() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "GeometricalShapes")
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         
         // An inner function to assert the rendered hierarchy values for a given reference

--- a/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeDiffingBundleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
     let testBundleName = "LegacyBundle_DoNotUseInNewTests"
     let testBundleID: DocumentationBundle.Identifier = "org.swift.docc.example"
     
-    func testDiffSymbolFromBundleWithDiscussionSectionRemoved() throws {
+    func testDiffSymbolFromBundleWithDiscussionSectionRemoved() async throws {
         let pathToSymbol = "/documentation/MyKit"
         
         let modification = { (url: URL) in
@@ -28,7 +28,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
@@ -41,7 +41,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: RenderInlineContent.self)
     }
     
-    func testDiffArticleFromBundleWithTopicSectionAdded() throws {
+    func testDiffArticleFromBundleWithTopicSectionAdded() async throws {
         let pathToArticle = "/documentation/Test-Bundle/article"
         
         let modification = { (url: URL) in
@@ -56,7 +56,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: articleURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToArticle,
                                                            modification: modification)
@@ -76,7 +76,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: TaskGroupRenderSection.self)
     }
     
-    func testDiffArticleFromBundleWithSeeAlsoSectionRemoved() throws {
+    func testDiffArticleFromBundleWithSeeAlsoSectionRemoved() async throws {
         let pathToArticle = "/documentation/Test-Bundle/article"
         
         let modification = { (url: URL) in
@@ -89,7 +89,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: articleURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToArticle,
                                                            modification: modification)
@@ -108,7 +108,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: RenderInlineContent.self)
     }
     
-    func testDiffSymbolFromBundleWithTopicSectionRemoved() throws {
+    func testDiffSymbolFromBundleWithTopicSectionRemoved() async throws {
         let pathToSymbol = "/documentation/MyKit"
         
         let modification = { (url: URL) in
@@ -121,7 +121,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
@@ -140,7 +140,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: RenderInlineContent.self)
     }
     
-    func testDiffSymbolFromBundleWithAbstractUpdated() throws {
+    func testDiffSymbolFromBundleWithAbstractUpdated() async throws {
         let pathToSymbol = "/documentation/MyKit/MyClass"
         let newAbstractValue = "MyClass new abstract."
         
@@ -150,7 +150,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
@@ -172,7 +172,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: AnyRenderReference.self)
     }
     
-    func testDiffSymbolFromBundleWithDeprecationAdded() throws {
+    func testDiffSymbolFromBundleWithDeprecationAdded() async throws {
         let pathToSymbol = "/documentation/MyKit/MyProtocol"
         let newDeprecationValue = "This protocol has been deprecated."
         
@@ -188,7 +188,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
@@ -211,7 +211,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: Bool.self)
     }
     
-    func testDiffSymbolFromBundleWithDisplayNameDirectiveAdded() throws {
+    func testDiffSymbolFromBundleWithDisplayNameDirectiveAdded() async throws {
         let pathToSymbol = "/documentation/MyKit"
         let newTitleValue = "My Kit"
         
@@ -227,7 +227,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: symbolURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToSymbol,
                                                            modification: modification)
@@ -247,7 +247,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: RenderMetadata.Module.self)
     }
     
-    func testDiffArticleFromBundleWithDownloadDirectiveAdded() throws {
+    func testDiffArticleFromBundleWithDownloadDirectiveAdded() async throws {
         let pathToArticle = "/documentation/Test-Bundle/article"
         
         let modification = { (url: URL) in
@@ -263,7 +263,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
             try text.write(to: articleURL, atomically: true, encoding: .utf8)
         }
         
-        let differences = try getDiffsFromModifiedDocument(bundleName: testBundleName,
+        let differences = try await getDiffsFromModifiedDocument(bundleName: testBundleName,
                                                            bundleID: testBundleID,
                                                            topicReferencePath: pathToArticle,
                                                            modification: modification)
@@ -283,8 +283,8 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                           valueType: String.self)
     }
     
-    func testNoDiffsWhenReconvertingSameBundle() throws {
-        let (bundle, context) = try testBundleAndContext(named: testBundleName)
+    func testNoDiffsWhenReconvertingSameBundle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: testBundleName)
         let renderContext = RenderContext(documentationContext: context, bundle: bundle)
         let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
         
@@ -302,8 +302,8 @@ class RenderNodeDiffingBundleTests: XCTestCase {
                                       bundleID: DocumentationBundle.Identifier,
                                       topicReferencePath: String,
                                       modification: @escaping (URL) throws -> ()
-    ) throws -> JSONPatchDifferences {
-        let (bundleOriginal, contextOriginal) = try testBundleAndContext(named: bundleName)
+    ) async throws -> JSONPatchDifferences {
+        let (bundleOriginal, contextOriginal) = try await testBundleAndContext(named: bundleName)
         let nodeOriginal = try contextOriginal.entity(with: ResolvedTopicReference(bundleID: bundleID,
                                                                                    path: topicReferencePath,
                                                                                    sourceLanguage: .swift))
@@ -313,7 +313,7 @@ class RenderNodeDiffingBundleTests: XCTestCase {
         let renderNodeOriginal = try XCTUnwrap(converter.renderNode(for: nodeOriginal))
         
         // Make copy of the bundle on disk, modify the document, and write it
-        let (_, bundleModified, contextModified) = try testBundleAndContext(copying: bundleName) { url in
+        let (_, bundleModified, contextModified) = try await testBundleAndContext(copying: bundleName) { url in
             try modification(url)
         }
         let nodeModified = try contextModified.entity(with: ResolvedTopicReference(bundleID: bundleID,

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -91,8 +91,8 @@ class RenderNodeSerializationTests: XCTestCase {
         checkRoundTrip(inputNode)
     }
     
-    func testBundleRoundTrip() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testBundleRoundTrip() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
@@ -114,8 +114,8 @@ class RenderNodeSerializationTests: XCTestCase {
         checkRoundTrip(renderNode)
     }
     
-    func testTutorialArticleRoundTrip() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testTutorialArticleRoundTrip() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
         
         guard let articleDirective = node.markup as? BlockDirective else {
@@ -137,10 +137,10 @@ class RenderNodeSerializationTests: XCTestCase {
         checkRoundTrip(renderNode)
     }
     
-    func testAssetReferenceDictionary() throws {
+    func testAssetReferenceDictionary() async throws {
         typealias JSONDictionary = [String: Any]
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
@@ -191,8 +191,8 @@ class RenderNodeSerializationTests: XCTestCase {
         }
     }
 
-    func testDiffAvailability() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDiffAvailability() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
         
         guard let articleDirective = node.markup as? BlockDirective else {

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeArticleOnlyCatalogTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeArticleOnlyCatalogTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -12,8 +12,8 @@ import XCTest
 @testable import SwiftDocC
 
 class SemaToRenderNodeArticleOnlyCatalogTests: XCTestCase {
-    func testDoesNotEmitVariantsForPagesInArticleOnlyCatalog() throws {
-        for renderNode in try renderNodeConsumer(for: "BundleWithTechnologyRoot").allRenderNodes() {
+    func testDoesNotEmitVariantsForPagesInArticleOnlyCatalog() async throws {
+        for renderNode in try await renderNodeConsumer(for: "BundleWithTechnologyRoot").allRenderNodes() {
             XCTAssertNil(renderNode.variants)
         }
     }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeDictionaryDataTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeDictionaryDataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import SymbolKit
 import XCTest
 
 class SemaToRenderNodeDictionaryDataTests: XCTestCase {
-    func testBaseRenderNodeFromDictionaryData() throws {
-        let (_, context) = try testBundleAndContext(named: "DictionaryData")
+    func testBaseRenderNodeFromDictionaryData() async throws {
+        let (_, context) = try await testBundleAndContext(named: "DictionaryData")
         
         let expectedPageUSRsAndLangs: [String : Set<SourceLanguage>] = [
             // Artist dictionary - ``Artist``:
@@ -75,8 +75,8 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
         }
     }
 
-    func testFrameworkRenderNodeHasExpectedContent() throws {
-        let outputConsumer = try renderNodeConsumer(for: "DictionaryData")
+    func testFrameworkRenderNodeHasExpectedContent() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "DictionaryData")
         let frameworkRenderNode = try outputConsumer.renderNode(
             withIdentifier: "DictionaryData"
         )
@@ -152,8 +152,8 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
         )
     }
     
-    func testDictionaryRenderNodeHasExpectedContent() throws {
-        let outputConsumer = try renderNodeConsumer(for: "DictionaryData")
+    func testDictionaryRenderNodeHasExpectedContent() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "DictionaryData")
         let artistRenderNode = try outputConsumer.renderNode(withIdentifier: "data:test:Artist")
         
         assertExpectedContent(
@@ -245,8 +245,8 @@ class SemaToRenderNodeDictionaryDataTests: XCTestCase {
         XCTAssert((nameProperty.attributes ?? []).isEmpty)
     }
     
-    func testTypeRenderNodeHasExpectedContent() throws {
-        let outputConsumer = try renderNodeConsumer(for: "DictionaryData")
+    func testTypeRenderNodeHasExpectedContent() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "DictionaryData")
         let genreRenderNode = try outputConsumer.renderNode(withIdentifier: "data:test:Genre")
         
         let type1 = DeclarationRenderSection.Token(fragment: SymbolGraph.Symbol.DeclarationFragments.Fragment(kind: .text, spelling: "string", preciseIdentifier: nil), identifier: nil)

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeHTTPRequestTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeHTTPRequestTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import SymbolKit
 import XCTest
 
 class SemaToRenderNodeHTTPRequestTests: XCTestCase {
-    func testBaseRenderNodeFromHTTPRequest() throws {
-        let (_, context) = try testBundleAndContext(named: "HTTPRequests")
+    func testBaseRenderNodeFromHTTPRequest() async throws {
+        let (_, context) = try await testBundleAndContext(named: "HTTPRequests")
         
         let expectedPageUSRsAndLanguages: [String : Set<SourceLanguage>] = [
             // Get Artist endpoint - ``Get_Artist``:
@@ -77,8 +77,8 @@ class SemaToRenderNodeHTTPRequestTests: XCTestCase {
         }
     }
 
-    func testFrameworkRenderNodeHasExpectedContent() throws {
-        let outputConsumer = try renderNodeConsumer(for: "HTTPRequests")
+    func testFrameworkRenderNodeHasExpectedContent() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "HTTPRequests")
         let frameworkRenderNode = try outputConsumer.renderNode(
             withIdentifier: "HTTPRequests"
         )
@@ -144,8 +144,8 @@ class SemaToRenderNodeHTTPRequestTests: XCTestCase {
         )
     }
     
-    func testRestGetRequestRenderNodeHasExpectedContent() throws {
-        let outputConsumer = try renderNodeConsumer(for: "HTTPRequests")
+    func testRestGetRequestRenderNodeHasExpectedContent() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "HTTPRequests")
         let getArtistRenderNode = try outputConsumer.renderNode(withIdentifier: "rest:test:get:v1/artists/{}")
         
         assertExpectedContent(
@@ -229,8 +229,8 @@ class SemaToRenderNodeHTTPRequestTests: XCTestCase {
         }
     }
     
-    func testRestPostRequestRenderNodeHasExpectedContent() throws {
-        let outputConsumer = try renderNodeConsumer(for: "HTTPRequests")
+    func testRestPostRequestRenderNodeHasExpectedContent() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "HTTPRequests")
         let getArtistRenderNode = try outputConsumer.renderNode(withIdentifier: "rest:test:post:v1/artists")
         
         assertExpectedContent(

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeMultiLanguageTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,8 +15,8 @@ import SwiftDocCTestUtilities
 import XCTest
 
 class SemaToRenderNodeMixedLanguageTests: XCTestCase {
-    func testBaseRenderNodeFromMixedLanguageFramework() throws {
-        let (_, context) = try testBundleAndContext(named: "MixedLanguageFramework")
+    func testBaseRenderNodeFromMixedLanguageFramework() async throws {
+        let (_, context) = try await testBundleAndContext(named: "MixedLanguageFramework")
         
         for (_, documentationNode) in context.documentationCache where documentationNode.kind.isSymbol {
             let symbolUSR = try XCTUnwrap((documentationNode.semantic as? Symbol)?.externalID)
@@ -78,8 +78,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         }
     }
 
-    func assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: String) throws {
-        let outputConsumer = try renderNodeConsumer(
+    func assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: String) async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFramework",
             configureBundle: { bundleURL in
                 // Update the clang symbol graph with the Objective-C identifier given in variantInterfaceLanguage.
@@ -198,20 +198,20 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
 
-    func testOutputsMultiLanguageRenderNodesWithOccIdentifier() throws {
-        try assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: "occ")
+    func testOutputsMultiLanguageRenderNodesWithOccIdentifier() async throws {
+        try await assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: "occ")
     }
 
-    func testOutputsMultiLanguageRenderNodesWithObjectiveCIdentifier() throws {
-        try assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: "objective-c")
+    func testOutputsMultiLanguageRenderNodesWithObjectiveCIdentifier() async throws {
+        try await assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: "objective-c")
     }
 
-    func testOutputsMultiLanguageRenderNodesWithCIdentifier() throws {
-        try assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: "c")
+    func testOutputsMultiLanguageRenderNodesWithCIdentifier() async throws {
+        try await assertOutputsMultiLanguageRenderNodes(variantInterfaceLanguage: "c")
     }
 
-    func testFrameworkRenderNodeHasExpectedContentAcrossLanguages() throws {
-        let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework")
+    func testFrameworkRenderNodeHasExpectedContentAcrossLanguages() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "MixedLanguageFramework")
         let mixedLanguageFrameworkRenderNode = try outputConsumer.renderNode(
             withIdentifier: "MixedLanguageFramework"
         )
@@ -347,8 +347,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testObjectiveCAuthoredRenderNodeHasExpectedContentAcrossLanguages() throws {
-        let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework")
+    func testObjectiveCAuthoredRenderNodeHasExpectedContentAcrossLanguages() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "MixedLanguageFramework")
         let fooRenderNode = try outputConsumer.renderNode(withIdentifier: "c:@E@Foo")
         
         assertExpectedContent(
@@ -448,8 +448,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testSymbolLinkWorkInMultipleLanguages() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFramework") { url in
+    func testSymbolLinkWorkInMultipleLanguages() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "MixedLanguageFramework") { url in
             try """
             # ``MixedLanguageFramework/Bar``
             
@@ -501,8 +501,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         ], "Both spellings of the symbol link should resolve to the canonical reference.")
     }
     
-    func testArticleInMixedLanguageFramework() throws {
-        let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework") { url in
+    func testArticleInMixedLanguageFramework() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "MixedLanguageFramework") { url in
             try """
             # MyArticle
             
@@ -564,8 +564,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testAPICollectionInMixedLanguageFramework() throws {
-        let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework")
+    func testAPICollectionInMixedLanguageFramework() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "MixedLanguageFramework")
         
         let articleRenderNode = try outputConsumer.renderNode(withTitle: "APICollection")
         
@@ -629,8 +629,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testGeneratedImplementationsCollectionIsCuratedInAllAvailableLanguages() throws {
-        let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework")
+    func testGeneratedImplementationsCollectionIsCuratedInAllAvailableLanguages() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "MixedLanguageFramework")
         
         let protocolRenderNode = try outputConsumer.renderNode(withTitle: "MixedLanguageClassConformingToProtocol")
         
@@ -653,8 +653,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testGeneratedImplementationsCollectionDoesNotCurateInAllUnavailableLanguages() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testGeneratedImplementationsCollectionDoesNotCurateInAllUnavailableLanguages() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFramework",
             configureBundle: { bundleURL in
                 // Update the clang symbol graph to remove the protocol method requirement, so that it's effectively
@@ -696,8 +696,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
 
-    func testAutomaticSeeAlsoOnlyShowsAPIsAvailableInParentsLanguageForSymbol() throws {
-        let outputConsumer = try renderNodeConsumer(for: "MixedLanguageFramework")
+    func testAutomaticSeeAlsoOnlyShowsAPIsAvailableInParentsLanguageForSymbol() async throws {
+        let outputConsumer = try await renderNodeConsumer(for: "MixedLanguageFramework")
         
         // Swift-only symbol.
         XCTAssertEqual(
@@ -766,8 +766,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testMultiLanguageChildOfSingleParentSymbolIsCuratedInMultiLanguage() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testMultiLanguageChildOfSingleParentSymbolIsCuratedInMultiLanguage() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFrameworkSingleLanguageParent"
         )
         
@@ -793,8 +793,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testMultiLanguageSymbolWithLanguageSpecificRelationships() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testMultiLanguageSymbolWithLanguageSpecificRelationships() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFrameworkWithLanguageSpecificRelationships"
         )
         
@@ -821,8 +821,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testMultiLanguageSymbolWithLanguageSpecificProtocolRequirements() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testMultiLanguageSymbolWithLanguageSpecificProtocolRequirements() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFrameworkWithLanguageSpecificRelationships"
         )
         
@@ -841,8 +841,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         XCTAssert(objectiveCSymbol.relationshipSections.isEmpty)
     }
     
-    func testArticlesWithSupportedLanguagesDirective() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testArticlesWithSupportedLanguagesDirective() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFrameworkWithArticlesUsingSupportedLanguages"
         )
         
@@ -879,8 +879,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         )
     }
     
-    func testArticlesAreIncludedInAllVariantsTopicsSection() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testArticlesAreIncludedInAllVariantsTopicsSection() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "MixedLanguageFramework",
             configureBundle: { bundleURL in
                 try """
@@ -961,8 +961,8 @@ class SemaToRenderNodeMixedLanguageTests: XCTestCase {
         XCTAssertFalse(objCTopicIDs.contains("doc://org.swift.MixedLanguageFramework/documentation/MixedLanguageFramework/SwiftOnlyStruct"))
     }
 
-    func testAutomaticSeeAlsoSectionElementLimit() throws {
-        let (bundle, context) = try loadBundle(catalog:
+    func testAutomaticSeeAlsoSectionElementLimit() async throws {
+        let (bundle, context) = try await loadBundle(catalog:
             Folder(name: "unit-test.docc", content: [
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: (1...50).map {
                     makeSymbol(id: "symbol-id-\($0)", kind: .class, pathComponents: ["SymbolName\($0)"])

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import SymbolKit
 import XCTest
 
 class SemaToRenderNodeSourceRepositoryTests: XCTestCase {
-    func testDoesNotEmitsSourceRepositoryInformationWhenNoSourceIsGiven() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testDoesNotEmitsSourceRepositoryInformationWhenNoSourceIsGiven() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "SourceLocations",
             sourceRepository: nil
         )
@@ -23,8 +23,8 @@ class SemaToRenderNodeSourceRepositoryTests: XCTestCase {
         XCTAssertNil(try outputConsumer.renderNode(withTitle: "MyStruct").metadata.remoteSource)
     }
     
-    func testEmitsSourceRepositoryInformationForSymbolsWhenPresent() throws {
-        let outputConsumer = try renderNodeConsumer(
+    func testEmitsSourceRepositoryInformationForSymbolsWhenPresent() async throws {
+        let outputConsumer = try await renderNodeConsumer(
             for: "SourceLocations",
             sourceRepository: SourceRepository.github(
                 checkoutPath: "/path/to/checkout",

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -15,8 +15,8 @@ import SymbolKit
 import SwiftDocCTestUtilities
 
 class SemaToRenderNodeTests: XCTestCase {
-    func testCompileTutorial() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCompileTutorial() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorial", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
@@ -400,8 +400,8 @@ class SemaToRenderNodeTests: XCTestCase {
         )
     }
     
-    func testTutorialBackgroundComesFromImageOrVideoPoster() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testTutorialBackgroundComesFromImageOrVideoPoster() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         func assertTutorialWithPath(_ tutorialPath: String, hasBackground backgroundIdentifier: String) throws {
             let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: tutorialPath, sourceLanguage: .swift))
@@ -430,8 +430,8 @@ class SemaToRenderNodeTests: XCTestCase {
         try assertTutorialWithPath("/tutorials/Test-Bundle/TestTutorial2", hasBackground: "introposter2.png")
     }
     
-    func testCompileTutorialArticle() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCompileTutorialArticle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TestTutorialArticle", sourceLanguage: .swift))
         
         let article = node.semantic as! TutorialArticle
@@ -491,13 +491,13 @@ class SemaToRenderNodeTests: XCTestCase {
         ])
     }
     
-    func testCompileOverviewWithNoVolumes() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCompileOverviewWithNoVolumes() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         try assertCompileOverviewWithNoVolumes(bundle: bundle, context: context)
     }
     
-    func testCompileOverviewWithEmptyChapter() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testCompileOverviewWithEmptyChapter() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             try """
             @Tutorials(name: "Technology X") {
                @Intro(title: "Technology X") {
@@ -717,8 +717,8 @@ class SemaToRenderNodeTests: XCTestCase {
         )
     }
     
-    func testCompileOverviewWithVolumes() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testCompileOverviewWithVolumes() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             let overviewURL = root.appendingPathComponent("TestOverview.tutorial")
             let text = """
             @Tutorials(name: "Technology X") {
@@ -926,8 +926,8 @@ class SemaToRenderNodeTests: XCTestCase {
         )
     }
     
-    func testCompileSymbol() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testCompileSymbol() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             // Remove the SideClass sub heading to match the expectations of this test
             let graphURL = url.appendingPathComponent("sidekit.symbols.json")
             var graph = try JSONDecoder().decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -1172,7 +1172,7 @@ class SemaToRenderNodeTests: XCTestCase {
         )
     }
 
-    func testCompileSymbolWithExternalReferences() throws {
+    func testCompileSymbolWithExternalReferences() async throws {
         class TestSymbolResolver: GlobalExternalSymbolResolver {
             func symbolReferenceAndEntity(withPreciseIdentifier preciseIdentifier: String) -> (ResolvedTopicReference, LinkResolver.ExternalEntity)? {
                 let reference = ResolvedTopicReference(bundleID: "com.test.external.symbols", path: "/\(preciseIdentifier)", sourceLanguage: .objectiveC)
@@ -1225,7 +1225,7 @@ class SemaToRenderNodeTests: XCTestCase {
         
         let testBundleURL = Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-        let (_, bundle, context) = try loadBundle(
+        let (_, bundle, context) = try await loadBundle(
             from: testBundleURL,
             externalResolvers: ["com.test.external": TestReferenceResolver()],
             externalSymbolResolver: TestSymbolResolver()
@@ -1321,11 +1321,11 @@ class SemaToRenderNodeTests: XCTestCase {
         )
     }
     
-    func testRenderConstraints() throws {
+    func testRenderConstraints() async throws {
         
         // Check for constraints in render node
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
@@ -1377,8 +1377,8 @@ class SemaToRenderNodeTests: XCTestCase {
         XCTAssertEqual(constraintsString, "Label is Text, Observer inherits NSObject, and S conforms to StringProtocol.")
     }
     
-    func testRenderConditionalConstraintsOnConformingType() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderConditionalConstraintsOnConformingType() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -1399,8 +1399,8 @@ class SemaToRenderNodeTests: XCTestCase {
         }.joined(), "Element conforms to Equatable.")
     }
     
-    func testRenderConditionalConstraintsOnProtocol() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderConditionalConstraintsOnProtocol() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -1421,8 +1421,8 @@ class SemaToRenderNodeTests: XCTestCase {
         }.joined(), "Element conforms to Equatable.")
     }
     
-    func testRenderReferenceResolving() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderReferenceResolving() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         // Compile docs and verify contents
@@ -1486,8 +1486,8 @@ class SemaToRenderNodeTests: XCTestCase {
         ])
     }
     
-    func testAvailabilityMetadata() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testAvailabilityMetadata() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         // Compile docs and verify contents
@@ -1528,14 +1528,14 @@ class SemaToRenderNodeTests: XCTestCase {
         XCTAssertEqual(platforms[5].introduced, "6.0")
     }
     
-    func testAvailabilityFromCurrentPlatformOverridesExistingValue() throws {
+    func testAvailabilityFromCurrentPlatformOverridesExistingValue() async throws {
         // The `MyClass` symbol has availability information for all platforms. Copy the symbol graph for each platform and override only the
         // availability for that platform to verify that the end result preferred the information for each platform.
         let allPlatformsNames: [(platformName: String, operatingSystemName: String)] = [("iOS", "ios"), ("macOS", "macosx"), ("watchOS", "watchos"), ("tvOS", "tvos")]
         
         // Override with both a low and a high value
         for version in [SymbolGraph.SemanticVersion(major: 1, minor: 1, patch: 1), SymbolGraph.SemanticVersion(major: 99, minor: 99, patch: 99)] {
-            let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { url in
+            let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { url in
                 // Duplicate the symbol graph
                 let myKitURL = url.appendingPathComponent("mykit-iOS.symbols.json")
                 let myClassUSR = "s:5MyKit0A5ClassC"
@@ -1586,8 +1586,8 @@ class SemaToRenderNodeTests: XCTestCase {
         }
     }
     
-    func testMediaReferencesWithSpaces() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testMediaReferencesWithSpaces() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/Test-Bundle/TutorialMediaWithSpaces", sourceLanguage: .swift))
         
         guard let tutorialDirective = node.markup as? BlockDirective else {
@@ -1611,7 +1611,7 @@ class SemaToRenderNodeTests: XCTestCase {
                        renderNode.references.keys.filter({ !$0.hasPrefix("doc://") }).sorted())
     }
     
-    func testUnexpectedDirectivesAreDropped() throws {
+    func testUnexpectedDirectivesAreDropped() async throws {
         let source = """
 This is some text.
 
@@ -1648,7 +1648,7 @@ Document @1:1-11:19
 """,
                        markup.debugDescription(options: .printSourceLocations))
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestTutorial", sourceLanguage: .swift))
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [
@@ -1667,7 +1667,7 @@ Document @1:1-11:19
         XCTAssertEqual(expectedContent, renderContent)
     }
 
-    func testTaskLists() throws {
+    func testTaskLists() async throws {
         let source = """
 This is some text.
 
@@ -1690,7 +1690,7 @@ Document
 """,
                        markup.debugDescription())
 
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestTutorial", sourceLanguage: .swift))
         let renderContent = try XCTUnwrap(markup.children.reduce(into: [], { result, item in result.append(contentsOf: contentTranslator.visit(item))}) as? [RenderBlockContent])
         let expectedContent: [RenderBlockContent] = [
@@ -1705,7 +1705,7 @@ Document
         XCTAssertEqual(expectedContent, renderContent)
     }
     
-    func testInlineHTMLDoesNotCrashTranslator() throws {
+    func testInlineHTMLDoesNotCrashTranslator() async throws {
         let markupSource = """
     # Test
 
@@ -1715,14 +1715,14 @@ Document
         
         let document = Document(parsing: markupSource, options: [])
         let node = DocumentationNode(reference: ResolvedTopicReference(bundleID: "org.swift.docc", path: "/blah", sourceLanguage: .swift), kind: .article, sourceLanguage: .swift, name: .conceptual(title: "Title"), markup: document, semantic: Semantic())
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         
         XCTAssertNotNil(translator.visit(MarkupContainer(document.children)))
         }
         
-    func testCompileSymbolMetadata() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testCompileSymbolMetadata() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift))
         
         // Compile docs and verify contents
@@ -1770,8 +1770,8 @@ Document
         ])
     }
     
-    func testArticleRoleHeadings() throws {
-        try assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: "Article", content: """
+    func testArticleRoleHeadings() async throws {
+        try await assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: "Article", content: """
             # Article 2
 
             This is article 2.
@@ -1779,8 +1779,8 @@ Document
         )
     }
     
-    func testArticleRoleHeadingsWithAutomaticTitleHeadingDisabled() throws {
-        try assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: nil, content: """
+    func testArticleRoleHeadingsWithAutomaticTitleHeadingDisabled() async throws {
+        try await assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: nil, content: """
             # Article 2
             
             @Options {
@@ -1792,8 +1792,8 @@ Document
         )
     }
     
-    func testArticleRoleHeadingsWithAutomaticTitleHeadingForPageKind() throws {
-        try assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: "Article", content: """
+    func testArticleRoleHeadingsWithAutomaticTitleHeadingForPageKind() async throws {
+        try await assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: "Article", content: """
             # Article 2
             
             @Options {
@@ -1805,8 +1805,8 @@ Document
         )
     }
 
-    func testAPICollectionRoleHeading() throws {
-        try assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: nil, content: """
+    func testAPICollectionRoleHeading() async throws {
+        try await assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: nil, content: """
             # Article 2
 
             This is article 2.
@@ -1819,7 +1819,7 @@ Document
         )
     }
     
-    private func renderNodeForArticleInTestBundle(content: String) throws -> RenderNode {
+    private func renderNodeForArticleInTestBundle(content: String) async throws -> RenderNode {
         // Overwrite the article so we can test the article eyebrow for articles without task groups
         let sourceURL = Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
@@ -1829,7 +1829,7 @@ Document
 
         try content.write(to: targetURL.appendingPathComponent("article2.md"), atomically: true, encoding: .utf8)
 
-        let (_, bundle, context) = try loadBundle(from: targetURL)
+        let (_, bundle, context) = try await loadBundle(from: targetURL)
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article2", sourceLanguage: .swift))
         let article = node.semantic as! Article
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -1840,16 +1840,16 @@ Document
         Asserts if `expectedRoleHeading` does not match the parsed render node's `roleHeading` after it's parsed.
         Uses 'TestBundle's documentation as a base for compiling, overwriting 'article2' with `content`.
     */
-    private func assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: String?, content: String, file: StaticString = #filePath, line: UInt = #line) throws {
-        let renderNode = try renderNodeForArticleInTestBundle(content: content)
+    private func assertRoleHeadingForArticleInTestBundle(expectedRoleHeading: String?, content: String, file: StaticString = #filePath, line: UInt = #line) async throws {
+        let renderNode = try await renderNodeForArticleInTestBundle(content: content)
         XCTAssertEqual(expectedRoleHeading, renderNode.metadata.roleHeading, file: (file), line: line)
     }
     
     
-    func testDisablingAutomaticArticleSubheadingGeneration() throws {
+    func testDisablingAutomaticArticleSubheadingGeneration() async throws {
         // Assert that by default, articles include an "Overview" heading even if it's not authored.
         do {
-            let articleRenderNode = try renderNodeForArticleInTestBundle(
+            let articleRenderNode = try await renderNodeForArticleInTestBundle(
                 content: """
                 # Article 2
                 
@@ -1873,7 +1873,7 @@ Document
         
         // Assert that disabling the automatic behavior with the option directive works as expected.
         do {
-            let articleRenderNode = try renderNodeForArticleInTestBundle(
+            let articleRenderNode = try await renderNodeForArticleInTestBundle(
                 content: """
                 # Article 2
                 
@@ -1900,7 +1900,7 @@ Document
     }
 
     /// Verifies we emit the correct warning for external links in topic task groups.
-    func testWarnForExternalLinksInTopicTaskGroups() throws {
+    func testWarnForExternalLinksInTopicTaskGroups() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
             ])),
@@ -1916,7 +1916,7 @@ Document
             """),
         ])
         
-        let (_, context) = try loadBundle(catalog: catalog)
+        let (_, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.InvalidDocumentationLink" }).count, 1)
         XCTAssertNotNil(context.problems.first(where: { problem -> Bool in
@@ -1925,8 +1925,8 @@ Document
         }))
     }
     
-    func testRendersBetaViolators() throws {
-        func makeTestBundle(currentPlatforms: [String : PlatformVersion]?, file: StaticString = #filePath, line: UInt = #line, referencePath: String) throws -> (DocumentationBundle, DocumentationContext, ResolvedTopicReference) {
+    func testRendersBetaViolators() async throws {
+        func makeTestBundle(currentPlatforms: [String : PlatformVersion]?, file: StaticString = #filePath, line: UInt = #line, referencePath: String) async throws -> (DocumentationBundle, DocumentationContext, ResolvedTopicReference) {
             var configuration = DocumentationContext.Configuration()
             // Add missing platforms if their fallback platform is present.
             var currentPlatforms = currentPlatforms ?? [:]
@@ -1935,7 +1935,7 @@ Document
             }
             configuration.externalMetadata.currentPlatforms = currentPlatforms
             
-            let (_, bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests", configuration: configuration)
+            let (_, bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests", configuration: configuration)
             
             let reference = ResolvedTopicReference(bundleID: bundle.id, path: referencePath, sourceLanguage: .swift)
             return (bundle, context, reference)
@@ -1943,7 +1943,7 @@ Document
         
         // Not a beta platform
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: nil, referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: nil, referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
             let node = try context.entity(with: reference)
             let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(node)
@@ -1956,7 +1956,7 @@ Document
         
         do {
             
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "Custom Name": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             let node = try context.entity(with: reference)
@@ -1969,7 +1969,7 @@ Document
         
         // Different platform is beta
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "tvOS": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
@@ -1983,7 +1983,7 @@ Document
         // Beta platform but *not* matching the introduced version
         
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "macOS": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
@@ -1997,7 +1997,7 @@ Document
         // Beta platform matching the introduced version
 
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "macOS": PlatformVersion(VersionTriplet(10, 15, 0), beta: true)
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
@@ -2011,7 +2011,7 @@ Document
         // Beta platform earlier than the introduced version
         
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "macOS": PlatformVersion(VersionTriplet(10, 14, 0), beta: true)
             ], referencePath: "/documentation/MyKit/globalFunction(_:considering:)")
             
@@ -2025,7 +2025,7 @@ Document
         // Set only some platforms to beta & the exact version globalFunction is being introduced at
         
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "macOS": PlatformVersion(VersionTriplet(10, 15, 0), beta: true),
                 "watchOS": PlatformVersion(VersionTriplet(9, 0, 0), beta: true),
                 "tvOS": PlatformVersion(VersionTriplet(1, 0, 0), beta: true),
@@ -2040,7 +2040,7 @@ Document
 
         // Set all platforms to beta & the exact version globalFunction is being introduced at to test beta SDK documentation
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "macOS": PlatformVersion(VersionTriplet(10, 15, 0), beta: true),
                 "watchOS": PlatformVersion(VersionTriplet(6, 0, 0), beta: true),
                 "tvOS": PlatformVersion(VersionTriplet(13, 0, 0), beta: true),
@@ -2056,7 +2056,7 @@ Document
 
         // Set all platforms to beta where the symbol is available,
         // some platforms not beta but the symbol is not available there.
-        let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+        let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
             "macOS": PlatformVersion(VersionTriplet(10, 15, 0), beta: true),
             "watchOS": PlatformVersion(VersionTriplet(6, 0, 0), beta: true),
             "tvOS": PlatformVersion(VersionTriplet(13, 0, 0), beta: true),
@@ -2088,7 +2088,7 @@ Document
         // Set all platforms to beta & the exact version MyClass is being introduced.
         // Expect the symbol to no be in beta sinceit does not have an introduced version for iOS
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "macOS": PlatformVersion(VersionTriplet(10, 15, 0), beta: true),
                 "watchOS": PlatformVersion(VersionTriplet(6, 0, 0), beta: true),
                 "tvOS": PlatformVersion(VersionTriplet(13, 0, 0), beta: true),
@@ -2104,7 +2104,7 @@ Document
         
         // Set all platforms as unconditionally unavailable and test that the symbol is not marked as beta.
         do {
-            let (bundle, context, reference) = try makeTestBundle(currentPlatforms: [
+            let (bundle, context, reference) = try await makeTestBundle(currentPlatforms: [
                 "iOS": PlatformVersion(VersionTriplet(100, 0, 0), beta: true)
             ], referencePath: "/documentation/MyKit/MyClass")
             let node = try context.entity(with: reference)
@@ -2116,8 +2116,8 @@ Document
         }
     }
     
-    func testRendersDeprecatedViolator() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRendersDeprecatedViolator() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Make the referenced symbol deprecated
         do {
@@ -2139,8 +2139,8 @@ Document
         XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, true)
     }
 
-    func testDoesNotRenderDeprecatedViolator() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDoesNotRenderDeprecatedViolator() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Make the referenced symbol deprecated
         do {
@@ -2163,8 +2163,8 @@ Document
         XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, false)
     }
     
-    func testRendersDeprecatedViolatorForUnconditionallyDeprecatedReference() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRendersDeprecatedViolatorForUnconditionallyDeprecatedReference() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Make the referenced symbol deprecated
         do {
@@ -2187,10 +2187,10 @@ Document
         XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/MyKit/MyClass/myFunction()"] as? TopicRenderReference)?.isDeprecated, true)
     }
     
-    func testRenderMetadataFragments() throws {
+    func testRenderMetadataFragments() async throws {
         
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
@@ -2209,8 +2209,8 @@ Document
         ])
     }
     
-    func testRenderMetadataExtendedModule() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testRenderMetadataExtendedModule() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         
         let symbol = try XCTUnwrap(node.semantic as? Symbol)
@@ -2220,8 +2220,8 @@ Document
         XCTAssertEqual(renderNode.metadata.extendedModule, "MyKit")
     }
     
-    func testDefaultImplementations() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDefaultImplementations() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         // Verify that the render reference to a required symbol includes the 'required' key and the number of default implementations provided.
         do {
@@ -2253,8 +2253,8 @@ Document
         }
     }
 
-    func testDefaultImplementationsNotListedInTopics() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDefaultImplementationsNotListedInTopics() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         // Verify that a required symbol does not include default implementations in Topics groups
         do {
@@ -2269,10 +2269,10 @@ Document
         }
     }
     
-    func testNoStringMetadata() throws {
+    func testNoStringMetadata() async throws {
         
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
@@ -2298,10 +2298,10 @@ Document
         XCTAssertEqual(extra, roundtripMetadata as? [String])
     }
     
-    func testRenderDeclarations() throws {
+    func testRenderDeclarations() async throws {
         
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
@@ -2318,9 +2318,9 @@ Document
         XCTAssertEqual(section.declarations.first?.languages, ["swift"])
     }
 
-    func testDocumentationRenderReferenceRoles() throws {
+    func testDocumentationRenderReferenceRoles() async throws {
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit", sourceLanguage: .swift))
         
         let symbol = node.semantic as! Symbol
@@ -2338,9 +2338,9 @@ Document
         XCTAssertEqual(roleFor("doc://org.swift.docc.example/documentation/Test-Bundle/Default-Code-Listing-Syntax"), "article")
     }
 
-    func testTutorialsRenderReferenceRoles() throws {
+    func testTutorialsRenderReferenceRoles() async throws {
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift))
         
         let symbol = node.semantic as! TutorialTableOfContents
@@ -2357,9 +2357,9 @@ Document
         XCTAssertEqual(roleFor("doc://org.swift.docc.example/tutorials/TestOverview"), "overview")
     }
     
-    func testRemovingTrailingNewLinesInDeclaration() throws {
+    func testRemovingTrailingNewLinesInDeclaration() async throws {
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
@@ -2380,9 +2380,9 @@ Document
         XCTAssertEqual(renderNode.metadata.navigatorTitle?.count, 10)
     }
     
-    func testRenderManualSeeAlsoInArticles() throws {
+    func testRenderManualSeeAlsoInArticles() async throws {
         // Check for fragments in metadata in render node
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Test-Bundle/article", sourceLanguage: .swift))
         
         let article = node.semantic as! Article
@@ -2403,9 +2403,9 @@ Document
         XCTAssertEqual(link.titleInlineContent, [.text("Website")])
     }
     
-    func testSafeSectionAnchorNames() throws {
+    func testSafeSectionAnchorNames() async throws {
         // Check that heading's anchor was safe-ified
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))
         let symbol = node.semantic as! Symbol
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
@@ -2424,8 +2424,8 @@ Document
         })
     }
     
-    func testDuplicateNavigatorTitleIsRemoved() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDuplicateNavigatorTitleIsRemoved() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
@@ -2440,8 +2440,8 @@ Document
         XCTAssertNil(renderReference.navigatorTitle)
     }
 
-    func testNonDuplicateNavigatorTitleIsRendered() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNonDuplicateNavigatorTitleIsRendered() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/MyProtocol", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
@@ -2483,8 +2483,8 @@ Document
         .aside(.init(style: .init(rawValue: "Throws"), content: [.paragraph(.init(inlineContent: [.text("A serious error.")]))])),
     ]
     
-    func testBareTechnology() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testBareTechnology() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             try """
             @Tutorials(name: "<#text#>") {
               @Intro(title: "<#text#>") {
@@ -2538,8 +2538,8 @@ Document
         }
     }
 
-    func testBareTutorial() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testBareTutorial() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             try """
             @Tutorial(time: <#number#>, projectFiles: <#.zip#>) {
               @Intro(title: "<#text#>") {
@@ -2614,10 +2614,10 @@ Document
     }
     
     /// Ensures we render our supported asides from symbol-graph content correctly, whether as a blockquote or as a list item.
-    func testRenderAsides() throws {
+    func testRenderAsides() async throws {
         let asidesSGFURL = Bundle.module.url(
             forResource: "Asides.symbols", withExtension: "json", subdirectory: "Test Resources")!
-        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { url in
+        let (bundleURL, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: asidesSGFURL, to: url.appendingPathComponent("Asides.symbols.json"))
         }
         defer {
@@ -2644,8 +2644,8 @@ Document
     }
 
     /// Tests parsing origin data from symbol graph.
-    func testOriginMetadata() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testOriginMetadata() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let myFuncReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/Element/inherited()", sourceLanguage: .swift)
         let node = try context.entity(with: myFuncReference)
@@ -2658,11 +2658,11 @@ Document
     }
     
     /// Tests that we inherit docs by default from within the same module.
-    func testDocInheritanceInsideModule() throws {
+    func testDocInheritanceInsideModule() async throws {
         let sgURL = Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests.docc/sidekit.symbols", withExtension: "json", subdirectory: "Test Bundles")!
 
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             // Replace the out-of-bundle origin with a symbol from the same bundle.
             try String(contentsOf: sgURL)
                 .replacingOccurrences(of: #"identifier" : "s:OriginalUSR"#, with: #"identifier" : "s:5MyKit0A5MyProtocol0Afunc()"#)
@@ -2684,11 +2684,11 @@ Document
     }
 
     /// Tests that we don't inherit docs by default from within the same bundle but not module.
-    func testDocInheritanceInsideBundleButNotModule() throws {
+    func testDocInheritanceInsideBundleButNotModule() async throws {
         let sgURL = Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests.docc/sidekit.symbols", withExtension: "json", subdirectory: "Test Bundles")!
 
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             // Replace the out-of-bundle origin with a symbol from the same bundle but
             // from the MyKit module.
             try String(contentsOf: sgURL)
@@ -2710,8 +2710,8 @@ Document
         }
     }
     /// Tests that we generated an automatic abstract and remove source docs.
-    func testDisabledDocInheritance() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDisabledDocInheritance() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         // Verify that the inherited docs which should be ignored are not reference resolved.
         // Verify inherited docs are reference resolved and their problems are recorded.
@@ -2741,8 +2741,8 @@ Document
     }
 
     /// Tests doc extensions are matched to inherited symbols
-    func testInheritedSymbolDocExtension() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+    func testInheritedSymbolDocExtension() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try? """
             # ``SideKit/SideClass/Element/inherited()``
             Doc extension abstract.
@@ -2783,7 +2783,7 @@ Document
     }
     
     /// Tests that authored documentation for inherited symbols isn't removed.
-    func testInheritedSymbolWithAuthoredDocComment() throws {
+    func testInheritedSymbolWithAuthoredDocComment() async throws {
         struct TestData {
             let docCommentJSON: String
             let expectedRenderedAbstract: [RenderInlineContent]
@@ -2885,7 +2885,7 @@ Document
         for testData in testData {
             let sgURL = Bundle.module.url(forResource: "LegacyBundle_DoNotUseInNewTests.docc/sidekit.symbols", withExtension: "json", subdirectory: "Test Bundles")!
          
-            let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+            let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
                 // Replace the out-of-bundle origin with a symbol from the same bundle but
                 // from the MyKit module.
                 var graph = try JSONDecoder().decode(SymbolGraph.self, from: Data(contentsOf: sgURL))
@@ -2912,14 +2912,14 @@ Document
     }
     
     /// Tests that we inherit docs when the feature is enabled.
-    func testEnabledDocInheritance() throws {
+    func testEnabledDocInheritance() async throws {
         let bundleURL = Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
         
         var configuration = DocumentationContext.Configuration()
         configuration.externalMetadata.inheritDocs = true
         
-        let (_, bundle, context) = try loadBundle(from: bundleURL, configuration: configuration)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL, configuration: configuration)
 
         // Verify that we don't reference resolve inherited docs.
         XCTAssertFalse(context.diagnosticEngine.problems.contains(where: { problem in
@@ -2958,8 +2958,8 @@ Document
     }
     
     // Verifies that undocumented symbol gets a nil abstract.
-    func testNonDocumentedSymbolNilAbstract() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testNonDocumentedSymbolNilAbstract() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/MyKit/globalFunction(_:considering:)", sourceLanguage: .swift)
         let node = try context.entity(with: reference)
@@ -3066,8 +3066,8 @@ Document
     }
 
     /// Tests links to symbols that have deprecation summary in markdown appear deprecated.
-    func testLinkToDeprecatedSymbolViaDirectiveIsDeprecated() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+    func testLinkToDeprecatedSymbolViaDirectiveIsDeprecated() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``MyKit/MyProtocol``
             @DeprecationSummary {
@@ -3086,8 +3086,8 @@ Document
         XCTAssertTrue(reference.isDeprecated)
     }
     
-    func testCustomSymbolDisplayNames() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+    func testCustomSymbolDisplayNames() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``MyKit``
             
@@ -3187,7 +3187,7 @@ Document
     }
     
     /// Tests that we correctly resolve links in automatic inherited API Collections.
-    func testInheritedAPIGroupsInCollidedParents() throws {
+    func testInheritedAPIGroupsInCollidedParents() async throws {
         
         // Loads a symbol graph which has a property `b` and a struct `B` that
         // collide path-wise and `B` has inherited children:
@@ -3196,7 +3196,7 @@ Document
         //   │ ╰ doc://com.test.TestBed/documentation/Minimal_docs/A/B-swift.struct/Equatable-Implementations
         //   │   ╰ doc://com.test.TestBed/documentation/Minimal_docs/A/B-swift.struct/!=(_:_:)
         //   ╰ doc://com.test.TestBed/documentation/Minimal_docs/A/b-swift.property
-        let (bundle, context) = try testBundleAndContext(named: "InheritedUnderCollision")
+        let (bundle, context) = try await testBundleAndContext(named: "InheritedUnderCollision")
 
         // Verify that the inherited symbol got a path that accounts for the collision between
         // the struct `B` and the property `b`.
@@ -3216,8 +3216,8 @@ Document
         XCTAssertEqual(inheritedSymbolReference.absoluteString, groupReference.absoluteString)
     }
     
-    func testVisitTutorialMediaWithoutExtension() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testVisitTutorialMediaWithoutExtension() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             try """
             @Tutorials(name: "Technology X") {
                @Intro(title: "Technology X") {
@@ -3262,8 +3262,8 @@ Document
         XCTAssertNil(renderNode.references["introposter"] as? ImageReference)
     }
     
-    func testTopicsSectionWithAnonymousTopicGroup() throws {
-        let (_, bundle, context) = try testBundleAndContext(
+    func testTopicsSectionWithAnonymousTopicGroup() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(
             copying: "LegacyBundle_DoNotUseInNewTests",
             configureBundle: { url in
                 try """
@@ -3308,7 +3308,7 @@ Document
         )
     }
     
-    func testTopicsSectionWithSingleAnonymousTopicGroup() throws {
+    func testTopicsSectionWithSingleAnonymousTopicGroup() async throws {
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "SomeModuleName.symbols.json", content: makeSymbolGraph(moduleName: "SomeModuleName", symbols: [
                 makeSymbol(id: "some-class-id",    kind: .class,    pathComponents: ["SomeClass"]),
@@ -3327,7 +3327,7 @@ Document
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
          
         let articleReference = ResolvedTopicReference(
@@ -3353,8 +3353,8 @@ Document
         )
     }
     
-    func testLanguageSpecificTopicSections() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
+    func testLanguageSpecificTopicSections() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "MixedLanguageFrameworkWithLanguageRefinements") { url in
             try """
             # ``MixedFramework/MyObjectiveCClassObjectiveCName``
             
@@ -3413,7 +3413,7 @@ Document
         ])
     }
     
-    func testLanguageSpecificTopicSectionDoesNotAppearInAutomaticSeeAlso() throws {
+    func testLanguageSpecificTopicSectionDoesNotAppearInAutomaticSeeAlso() async throws {
         let catalog = Folder(name: "Something.docc", content: [
             JSONFile(name: "Something-swift.symbols.json", content: makeSymbolGraph(moduleName: "Something", symbols: (1...4).map {
                 makeSymbol(id: "symbol-id-\($0)", language: .swift, kind: .class, pathComponents: ["SomeClass\($0)"])
@@ -3445,7 +3445,7 @@ Document
             - ``SomeClass4``
             """),
         ])
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         XCTAssert(context.problems.isEmpty, "\(context.problems.map(\.diagnostic.summary))")
         
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
@@ -3488,7 +3488,7 @@ Document
         try assertExpectedTopicSections(XCTUnwrap(contextConverter.renderNode(for: documentationNode)))
     }
     
-    func testTopicSectionWithUnsupportedDirectives() throws {
+    func testTopicSectionWithUnsupportedDirectives() async throws {
         let exampleDocumentation = Folder(name: "unit-test.docc", content: [
             TextFile(name: "root.md", utf8Content: """
                 # Main article
@@ -3519,7 +3519,7 @@ Document
         let tempURL = try createTemporaryDirectory()
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
         
-        let (_, bundle, context) = try loadBundle(from: bundleURL, diagnosticEngine: .init() /* no diagnostic consumers */)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL, diagnosticEngine: .init() /* no diagnostic consumers */)
         
         let reference = try XCTUnwrap(context.soleRootModuleReference)
         
@@ -3538,8 +3538,8 @@ Document
         ])
     }
     
-    func testAutomaticCurationForRefinedSymbols() throws {
-        let (_, bundle, context) = try testBundleAndContext(named: "GeometricalShapes")
+    func testAutomaticCurationForRefinedSymbols() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(named: "GeometricalShapes")
         
         do {
             let root = try XCTUnwrap(context.soleRootModuleReference)
@@ -3613,7 +3613,7 @@ Document
         }
     }
     
-    func testThematicBreak() throws {
+    func testThematicBreak() async throws {
         let source = """
 
         ---
@@ -3624,7 +3624,7 @@ Document
         
         XCTAssertEqual(markup.childCount, 1)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         
         var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
@@ -3636,7 +3636,7 @@ Document
         XCTAssertEqual(expectedContent, renderContent)
     }
     
-    func testSymbolWithEmptyName() throws {
+    func testSymbolWithEmptyName() async throws {
         // Symbols _should_ have names, but due to bugs there's cases when anonymous C structs don't.
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(
@@ -3657,7 +3657,7 @@ Document
             ))
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         XCTAssertEqual(context.knownPages.map(\.path).sorted(), [
             "/documentation/ModuleName",

--- a/Tests/SwiftDocCTests/Rendering/AutomaticSeeAlsoTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AutomaticSeeAlsoTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,8 +17,8 @@ class AutomaticSeeAlsoTests: XCTestCase {
     
     /// Test that a symbol with no authored See Also and with no curated siblings
     /// does not have a See Also section.
-    func testNoSeeAlso() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testNoSeeAlso() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Extension that curates `SideClass`
             try """
             # ``SideKit``
@@ -40,8 +40,8 @@ class AutomaticSeeAlsoTests: XCTestCase {
 
     /// Test that a symbol with authored See Also and with no curated siblings
     /// does include an authored See Also section
-    func testAuthoredSeeAlso() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testAuthoredSeeAlso() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Extension that curates `SideClass`
             try """
             # ``SideKit``
@@ -76,8 +76,8 @@ class AutomaticSeeAlsoTests: XCTestCase {
 
     /// Test that a symbol with authored See Also and with curated siblings
     /// does include both in See Also with authored section first
-    func testAuthoredAndAutomaticSeeAlso() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testAuthoredAndAutomaticSeeAlso() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Extension that curates `SideClass`
             try """
             # ``SideKit``
@@ -137,8 +137,8 @@ class AutomaticSeeAlsoTests: XCTestCase {
     
     // Duplicate of the `testAuthoredAndAutomaticSeeAlso()` test above
     // but with automatic see also creation disabled
-    func testAuthoredSeeAlsoWithDisabledAutomaticSeeAlso() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testAuthoredSeeAlsoWithDisabledAutomaticSeeAlso() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit``
@@ -200,8 +200,8 @@ class AutomaticSeeAlsoTests: XCTestCase {
     
     // Duplicate of the `testAuthoredAndAutomaticSeeAlso()` test above
     // but with automatic see also creation globally disabled
-    func testAuthoredSeeAlsoWithGloballyDisabledAutomaticSeeAlso() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
+    func testAuthoredSeeAlsoWithGloballyDisabledAutomaticSeeAlso() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { root in
             /// Article that curates `SideClass`
             try """
             # ``SideKit``
@@ -257,7 +257,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         }
     }
 
-    func testSeeAlsoWithSymbolAndTutorial() throws {
+    func testSeeAlsoWithSymbolAndTutorial() async throws {
         let exampleDocumentation = Folder(name: "MyKit.docc", content: [
            CopyOfFile(original: Bundle.module.url(forResource: "mykit-one-symbol.symbols", withExtension: "json", subdirectory: "Test Resources")!),
             
@@ -283,7 +283,7 @@ class AutomaticSeeAlsoTests: XCTestCase {
         let tempURL = try createTemporaryDirectory()
         let bundleURL = try exampleDocumentation.write(inside: tempURL)
 
-        let (_, bundle, context) = try loadBundle(from: bundleURL)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL)
         
         // Get a translated render node
         let node = try context.entity(with: ResolvedTopicReference(bundleID: "MyKit", path: "/documentation/MyKit/MyClass/myFunction()", sourceLanguage: .swift))

--- a/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/AvailabilityRenderOrderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,8 +16,8 @@ class AvailabilityRenderOrderTests: XCTestCase {
     let availabilitySGFURL = Bundle.module.url(
         forResource: "Availability.symbols", withExtension: "json", subdirectory: "Test Resources")!
     
-    func testSortingAtRenderTime() throws {
-        let (bundleURL, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { url in
+    func testSortingAtRenderTime() async throws {
+        let (bundleURL, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: self.availabilitySGFURL, to: url.appendingPathComponent("Availability.symbols.json"))
         }
         defer {

--- a/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ConstraintsRenderSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,8 +18,8 @@ fileprivate let jsonEncoder = JSONEncoder()
 
 class ConstraintsRenderSectionTests: XCTestCase {
     
-    func testSingleConstraint() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testSingleConstraint() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -48,8 +48,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Label is Text.")
     }
 
-    func testSingleRedundantConstraint() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testSingleRedundantConstraint() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -77,8 +77,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertNil(renderNode.metadata.conformance)
     }
 
-    func testSingleRedundantConstraintForLeaves() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testSingleRedundantConstraintForLeaves() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -106,8 +106,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertNil(renderNode.metadata.conformance)
     }
 
-    func testPreservesNonRedundantConstraints() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testPreservesNonRedundantConstraints() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -136,8 +136,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Element is MyClass.")
     }
 
-    func testGroups2Constraints() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testGroups2Constraints() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -166,8 +166,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Element conforms to MyProtocol and Equatable.")
     }
 
-    func testGroups3Constraints() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testGroups3Constraints() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -197,8 +197,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.conformance?.constraints.map(flattenInlineElements).joined(), "Element conforms to MyProtocol, Equatable, and Hashable.")
     }
 
-    func testRenderReferences() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testRenderReferences() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))
@@ -235,8 +235,8 @@ class ConstraintsRenderSectionTests: XCTestCase {
         XCTAssertEqual(renderReference.conformance?.constraints.map(flattenInlineElements).joined(), "Element conforms to MyProtocol and Equatable.")
     }
 
-    func testRenderReferencesWithNestedTypeInSelf() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
+    func testRenderReferencesWithNestedTypeInSelf() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { bundleURL in
             // Add constraints to `MyClass`
             let graphURL = bundleURL.appendingPathComponent("mykit-iOS.symbols.json")
             var graph = try jsonDecoder.decode(SymbolGraph.self, from: try Data(contentsOf: graphURL))

--- a/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeclarationsRenderSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -132,8 +132,8 @@ class DeclarationsRenderSectionTests: XCTestCase {
         try assertRoundTripCoding(value)
     }
 
-    func testAlternateDeclarations() throws {
-        let (bundle, context) = try testBundleAndContext(named: "AlternateDeclarations")
+    func testAlternateDeclarations() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "AlternateDeclarations")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/AlternateDeclarations/MyClass/present(completion:)",
@@ -159,7 +159,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
         XCTAssert(declarationsSection.declarations.allSatisfy({ $0.platforms == [.iOS, .macOS] }))
     }
 
-    func testHighlightDiff() throws {
+    func testHighlightDiff() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolGraphFile = Bundle.module.url(
@@ -173,7 +173,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             CopyOfFile(original: symbolGraphFile),
         ])
 
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
 
         // Make sure that type decorators like arrays, dictionaries, and optionals are correctly highlighted.
         do {
@@ -322,7 +322,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
         }
     }
 
-    func testDontHighlightWhenOverloadsAreDisabled() throws {
+    func testDontHighlightWhenOverloadsAreDisabled() async throws {
         let symbolGraphFile = Bundle.module.url(
             forResource: "FancyOverloads",
             withExtension: "symbols.json",
@@ -334,7 +334,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             CopyOfFile(original: symbolGraphFile),
         ])
 
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
 
         for hash in ["7eht8", "8p1lo", "858ja"] {
             let reference = ResolvedTopicReference(
@@ -353,7 +353,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
         }
     }
 
-    func testOverloadConformanceDataIsSavedWithDeclarations() throws {
+    func testOverloadConformanceDataIsSavedWithDeclarations() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
         let symbolGraphFile = Bundle.module.url(
@@ -367,7 +367,7 @@ class DeclarationsRenderSectionTests: XCTestCase {
             CopyOfFile(original: symbolGraphFile),
         ])
 
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
 
         // MyClass<T>
         // - myFunc() where T: Equatable

--- a/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,8 +17,8 @@ import SwiftDocCTestUtilities
 class DefaultAvailabilityTests: XCTestCase {
 
     // Test whether missing default availability key correctly produces nil availability
-    func testBundleWithoutDefaultAvailability() throws {
-        let bundle = try testBundle(named: "BundleWithoutAvailability")
+    func testBundleWithoutDefaultAvailability() async throws {
+        let bundle = try await testBundle(named: "BundleWithoutAvailability")
         XCTAssertNil(bundle.info.defaultAvailability)
     }
 
@@ -32,9 +32,9 @@ class DefaultAvailabilityTests: XCTestCase {
     ]
     
     // Test whether the default availability is loaded from Info.plist and applied during render time
-    func testBundleWithDefaultAvailability() throws {
+    func testBundleWithDefaultAvailability() async throws {
         // Copy an Info.plist with default availability
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { (url) in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
             
@@ -101,9 +101,9 @@ class DefaultAvailabilityTests: XCTestCase {
     }
     
     // Test whether the default availability is merged with beta status from the command line
-    func testBundleWithDefaultAvailabilityInBetaDocs() throws {
+    func testBundleWithDefaultAvailabilityInBetaDocs() async throws {
         // Beta status for the docs (which would normally be set via command line argument)
-        try assertRenderedPlatformsFor(currentPlatforms: [
+        try await assertRenderedPlatformsFor(currentPlatforms: [
             "macOS": PlatformVersion(VersionTriplet(10, 15, 1), beta: true),
             "Mac Catalyst": PlatformVersion(VersionTriplet(13, 5, 0), beta: true),
         ], equal: [
@@ -112,7 +112,7 @@ class DefaultAvailabilityTests: XCTestCase {
         ])
         
         // Repeat the assertions, but use an earlier platform version this time
-        try assertRenderedPlatformsFor(currentPlatforms: [
+        try await assertRenderedPlatformsFor(currentPlatforms: [
             "macOS": PlatformVersion(VersionTriplet(10, 14, 1), beta: true),
             "Mac Catalyst": PlatformVersion(VersionTriplet(13, 5, 0), beta: true),
         ], equal: [
@@ -121,7 +121,7 @@ class DefaultAvailabilityTests: XCTestCase {
         ])
     }
 
-    private func assertRenderedPlatformsFor(currentPlatforms: [String : PlatformVersion], equal expected: [String], file: StaticString = #filePath, line: UInt = #line) throws {
+    private func assertRenderedPlatformsFor(currentPlatforms: [String : PlatformVersion], equal expected: [String], file: StaticString = #filePath, line: UInt = #line) async throws {
         var configuration = DocumentationContext.Configuration()
         configuration.externalMetadata.currentPlatforms = currentPlatforms
         
@@ -131,7 +131,7 @@ class DefaultAvailabilityTests: XCTestCase {
             JSONFile(name: "MyKit.symbols.json", content: makeSymbolGraph(moduleName: "MyKit")),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog, configuration: configuration)
+        let (bundle, context) = try await loadBundle(catalog: catalog, configuration: configuration)
         let reference = try XCTUnwrap(context.soleRootModuleReference, file: file, line: line)
         
         // Test whether we:
@@ -146,9 +146,9 @@ class DefaultAvailabilityTests: XCTestCase {
     
     // Test whether when Mac Catalyst availability is missing we fall back on
     // Mac Catalyst info.plist availability and not on iOS availability.
-    func testBundleWithMissingCatalystAvailability() throws {
+    func testBundleWithMissingCatalystAvailability() async throws {
         // Beta status for both iOS and Mac Catalyst
-        try assertRenderedPlatformsFor(currentPlatforms: [
+        try await assertRenderedPlatformsFor(currentPlatforms: [
             "iOS": PlatformVersion(VersionTriplet(13, 5, 0), beta: true),
             "Mac Catalyst": PlatformVersion(VersionTriplet(13, 5, 0), beta: true),
         ], equal: [
@@ -157,7 +157,7 @@ class DefaultAvailabilityTests: XCTestCase {
         ])
         
         // Public status for Mac Catalyst
-        try assertRenderedPlatformsFor(currentPlatforms: [
+        try await assertRenderedPlatformsFor(currentPlatforms: [
             "Mac Catalyst": PlatformVersion(VersionTriplet(13, 5, 0), beta: false),
         ], equal: [
             "Mac Catalyst 13.5",
@@ -165,19 +165,19 @@ class DefaultAvailabilityTests: XCTestCase {
         ])
 
         // Verify that a bug rendering availability as beta when no platforms are provided is fixed.
-        try assertRenderedPlatformsFor(currentPlatforms: [:], equal: [
+        try await assertRenderedPlatformsFor(currentPlatforms: [:], equal: [
             "Mac Catalyst 13.5",
             "macOS 10.15.1",
         ])
     }
     
     // Test whether the default availability is not beta when not matching current target platform
-    func testBundleWithDefaultAvailabilityNotInBetaDocs() throws {
+    func testBundleWithDefaultAvailabilityNotInBetaDocs() async throws {
         var configuration = DocumentationContext.Configuration()
         // Set a beta status for the docs (which would normally be set via command line argument)
         configuration.externalMetadata.currentPlatforms = ["macOS": PlatformVersion(VersionTriplet(10, 16, 0), beta: true)]
         
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", configuration: configuration) { (url) in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", configuration: configuration) { (url) in
             // Copy an Info.plist with default availability of macOS 10.15.1
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
@@ -198,11 +198,11 @@ class DefaultAvailabilityTests: XCTestCase {
     }
 
     // Test that a symbol is unavailable and default availability does not precede the "unavailable" attribute.
-    func testUnavailableAvailability() throws {
+    func testUnavailableAvailability() async throws {
         var configuration = DocumentationContext.Configuration()
         // Set a beta status for the docs (which would normally be set via command line argument)
         configuration.externalMetadata.currentPlatforms = ["iOS": PlatformVersion(VersionTriplet(14, 0, 0), beta: true)]
-        let (_, bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests", configuration: configuration)
+        let (_, bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests", configuration: configuration)
         
         do {
             let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit/MyClass/myFunction()", fragment: nil, sourceLanguage: .swift)
@@ -328,8 +328,8 @@ class DefaultAvailabilityTests: XCTestCase {
     
     // Test that setting default availability doesn't prevent symbols with "universal" deprecation
     // (i.e. a platform of '*' and unconditional deprecation) from showing up as deprecated.
-    func testUniversalDeprecationWithDefaultAvailability() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithLonelyDeprecationDirective", excludingPaths: []) { (url) in
+    func testUniversalDeprecationWithDefaultAvailability() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "BundleWithLonelyDeprecationDirective", excludingPaths: []) { (url) in
             try? FileManager.default.removeItem(at: url.appendingPathComponent("Info.plist"))
             try? FileManager.default.copyItem(at: self.infoPlistAvailabilityURL, to: url.appendingPathComponent("Info.plist"))
         }
@@ -545,7 +545,7 @@ class DefaultAvailabilityTests: XCTestCase {
         )
     }
     
-    func testInheritDefaultAvailabilityOptions() throws {
+    func testInheritDefaultAvailabilityOptions() async throws {
         func makeInfoPlist(
             defaultAvailability: String
         ) -> String {
@@ -565,7 +565,7 @@ class DefaultAvailabilityTests: XCTestCase {
         }
         func setupContext(
             defaultAvailability: String
-        ) throws -> (DocumentationBundle, DocumentationContext) {
+        ) async throws -> (DocumentationBundle, DocumentationContext) {
             // Create an empty bundle
             let targetURL = try createTemporaryDirectory(named: "test.docc")
             // Create symbol graph
@@ -576,7 +576,7 @@ class DefaultAvailabilityTests: XCTestCase {
             let infoPlist = makeInfoPlist(defaultAvailability: defaultAvailability)
             try infoPlist.write(to: infoPlistURL, atomically: true, encoding: .utf8)
             // Load the bundle & reference resolve symbol graph docs
-            let (_, bundle, context) = try loadBundle(from: targetURL)
+            let (_, bundle, context) = try await loadBundle(from: targetURL)
             return (bundle, context)
         }
         
@@ -641,7 +641,7 @@ class DefaultAvailabilityTests: XCTestCase {
         
         // Don't use default availability version.
         
-        var (bundle, context) = try setupContext(
+        var (bundle, context) = try await setupContext(
             defaultAvailability: """
                <dict>
                    <key>name</key>
@@ -674,7 +674,7 @@ class DefaultAvailabilityTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.platforms?.first?.introduced, nil)
         
         // Add an extra default availability to test behaviour when mixin in source with default behaviour.
-        (bundle, context) = try setupContext(defaultAvailability: """
+        (bundle, context) = try await setupContext(defaultAvailability: """
                <dict>
                    <key>name</key>
                    <string>iOS</string>

--- a/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DefaultCodeListingSyntaxTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,7 +23,9 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
     var testBundleWithLanguageDefault: DocumentationBundle!
     var testBundleWithoutLanguageDefault: DocumentationBundle!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
+        try await super.setUp()
+        
         func renderSection(for bundle: DocumentationBundle, in context: DocumentationContext) throws -> ContentRenderSection {
             let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/Test-Bundle/Default-Code-Listing-Syntax", fragment: nil, sourceLanguage: .swift)
 
@@ -34,7 +36,7 @@ class DefaultCodeBlockSyntaxTests: XCTestCase {
             return renderNode.primaryContentSections.first! as! ContentRenderSection
         }
 
-        let (_, bundleWithLanguageDefault, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
+        let (_, bundleWithLanguageDefault, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
 
         testBundleWithLanguageDefault = bundleWithLanguageDefault
 

--- a/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DeprecationSummaryTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -30,8 +30,8 @@ class DeprecationSummaryTests: XCTestCase {
     
     /// This test verifies that a symbol's deprecation summary comes from its sidecar doc
     /// and it's preferred over the original deprecation note in the code docs.
-    func testAuthoredDeprecatedSummary() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testAuthoredDeprecatedSummary() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit/SideClass/init()", sourceLanguage: .swift))
         
         // Compile docs and verify contents
@@ -43,8 +43,8 @@ class DeprecationSummaryTests: XCTestCase {
     }
 
     /// Test for a warning when symbol is not deprecated
-    func testIncorrectlyAuthoredDeprecatedSummary() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { url in
+    func testIncorrectlyAuthoredDeprecatedSummary() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { url in
             // Add a sidecar file with wrong deprecated summary
             try """
             # ``SideKit/SideClass``
@@ -79,8 +79,8 @@ class DeprecationSummaryTests: XCTestCase {
     /// This test verifies that a symbol's deprecation summary comes from its documentation extension file
     /// and it's preferred over the original deprecation note in the code docs.
     /// (r69719494)
-    func testAuthoredDeprecatedSummaryAsSoleItemInFile() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testAuthoredDeprecatedSummaryAsSoleItemInFile() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
                 bundleID: bundle.id,
@@ -111,8 +111,8 @@ class DeprecationSummaryTests: XCTestCase {
         ])
     }
     
-    func testSymbolDeprecatedSummary() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testSymbolDeprecatedSummary() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
                 bundleID: bundle.id,
@@ -133,8 +133,8 @@ class DeprecationSummaryTests: XCTestCase {
         ])
     }
   
-  func testDeprecationOverride() throws {
-      let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testDeprecationOverride() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
       let node = try context.entity(
           with: ResolvedTopicReference(
             bundleID: bundle.id,
@@ -162,8 +162,8 @@ class DeprecationSummaryTests: XCTestCase {
     ])
   }
     
-    func testDeprecationSummaryInDiscussionSection() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testDeprecationSummaryInDiscussionSection() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
                 bundleID: bundle.id,
@@ -191,8 +191,8 @@ class DeprecationSummaryTests: XCTestCase {
         ])
     }
     
-    func testDeprecationSummaryWithMultiLineCommentSymbol() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
+    func testDeprecationSummaryWithMultiLineCommentSymbol() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BundleWithLonelyDeprecationDirective")
         let node = try context.entity(
             with: ResolvedTopicReference(
                 bundleID: bundle.id,

--- a/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/DocumentationContentRendererTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import Markdown
 @testable import SwiftDocC
 
 class DocumentationContentRendererTests: XCTestCase {
-    func testReplacesTypeIdentifierSubHeadingFragmentWithIdentifierForSwift() throws {
-        let subHeadingFragments = try makeDocumentationContentRenderer()
+    func testReplacesTypeIdentifierSubHeadingFragmentWithIdentifierForSwift() async throws {
+        let subHeadingFragments = try await makeDocumentationContentRenderer()
             .subHeadingFragments(for: nodeWithSubheadingAndNavigatorVariants)
         
         XCTAssertEqual(
@@ -45,8 +45,8 @@ class DocumentationContentRendererTests: XCTestCase {
         )
     }
     
-    func testDoesNotReplaceSubHeadingFragmentsForOtherLanguagesThanSwift() throws {
-        let subHeadingFragments = try makeDocumentationContentRenderer()
+    func testDoesNotReplaceSubHeadingFragmentsForOtherLanguagesThanSwift() async throws {
+        let subHeadingFragments = try await makeDocumentationContentRenderer()
             .subHeadingFragments(for: nodeWithSubheadingAndNavigatorVariants)
         
         guard case .replace(let fragments) = subHeadingFragments.variants.first?.patch.first else {
@@ -73,8 +73,8 @@ class DocumentationContentRendererTests: XCTestCase {
         )
     }
     
-    func testReplacesTypeIdentifierNavigatorFragmentWithIdentifierForSwift() throws {
-        let navigatorFragments = try makeDocumentationContentRenderer()
+    func testReplacesTypeIdentifierNavigatorFragmentWithIdentifierForSwift() async throws {
+        let navigatorFragments = try await makeDocumentationContentRenderer()
             .navigatorFragments(for: nodeWithSubheadingAndNavigatorVariants)
         
         XCTAssertEqual(
@@ -104,8 +104,8 @@ class DocumentationContentRendererTests: XCTestCase {
         )
     }
     
-    func testDoesNotReplacesNavigatorFragmentsForOtherLanguagesThanSwift() throws {
-        let navigatorFragments = try makeDocumentationContentRenderer()
+    func testDoesNotReplacesNavigatorFragmentsForOtherLanguagesThanSwift() async throws {
+        let navigatorFragments = try await makeDocumentationContentRenderer()
             .navigatorFragments(for: nodeWithSubheadingAndNavigatorVariants)
         
         guard case .replace(let fragments) = navigatorFragments.variants.first?.patch.first else {
@@ -138,8 +138,8 @@ private extension DocumentationDataVariantsTrait {
 }
 
 private extension DocumentationContentRendererTests {
-    func makeDocumentationContentRenderer() throws -> DocumentationContentRenderer {
-        let (bundle, context) = try testBundleAndContext()
+    func makeDocumentationContentRenderer() async throws -> DocumentationContentRenderer {
+        let (bundle, context) = try await testBundleAndContext()
         return DocumentationContentRenderer(documentationContext: context, bundle: bundle)
     }
     

--- a/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/ExternalLinkTitleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,7 +13,7 @@ import XCTest
 import Markdown
 
 class ExternalLinkTitleTests: XCTestCase {
-    private func getTranslatorAndBlockContentForMarkup(_ markupSource: String) throws -> (translator: RenderNodeTranslator, content: [RenderBlockContent]) {
+    private func getTranslatorAndBlockContentForMarkup(_ markupSource: String) async throws -> (translator: RenderNodeTranslator, content: [RenderBlockContent]) {
         let document = Document(parsing: markupSource, options: [.parseBlockDirectives, .parseSymbolLinks])
         let testReference = ResolvedTopicReference(bundleID: "org.swift.docc", path: "/test", sourceLanguage: .swift)
         let node = DocumentationNode(reference: testReference,
@@ -24,21 +24,21 @@ class ExternalLinkTitleTests: XCTestCase {
                                      semantic: Semantic())
         
         
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         let result = translator.visit(MarkupContainer(document.children)) as! [RenderBlockContent]
         
         return (translator, result)
     }
     
-    func testPlainTextExternalLinkTitle() throws {
+    func testPlainTextExternalLinkTitle() async throws {
         let markupSource = """
         # Test
 
         This is a plain text link: [Example](https://www.example.com).
         """
         
-        let (translator, content) = try getTranslatorAndBlockContentForMarkup(markupSource)
+        let (translator, content) = try await getTranslatorAndBlockContentForMarkup(markupSource)
         
         guard case let .paragraph(firstParagraph) = content[1] else {
             XCTFail("Unexpected render tree.")
@@ -58,14 +58,14 @@ class ExternalLinkTitleTests: XCTestCase {
         XCTAssertEqual(linkReference?.titleInlineContent, expectedLinkTitle, "Plain text title should have been rendered.")
     }
     
-    func testEmphasisExternalLinkTitle() throws {
+    func testEmphasisExternalLinkTitle() async throws {
         let markupSource = """
         # Test
 
         This is an emphasized text link: [*Apple*](https://www.example.com).
         """
         
-        let (translator, content) = try getTranslatorAndBlockContentForMarkup(markupSource)
+        let (translator, content) = try await getTranslatorAndBlockContentForMarkup(markupSource)
         
         guard case let .paragraph(firstParagraph) = content[1] else {
             XCTFail("Unexpected render tree.")
@@ -85,14 +85,14 @@ class ExternalLinkTitleTests: XCTestCase {
         XCTAssertEqual(linkReference?.titleInlineContent, expectedLinkTitle, "Emphasized text title should have been rendered.")
     }
     
-    func testStrongExternalLinkTitle() throws {
+    func testStrongExternalLinkTitle() async throws {
         let markupSource = """
         # Test
 
         This is a strong text link: [**Apple**](https://www.example.com).
         """
         
-        let (translator, content) = try getTranslatorAndBlockContentForMarkup(markupSource)
+        let (translator, content) = try await getTranslatorAndBlockContentForMarkup(markupSource)
         
         guard case let .paragraph(firstParagraph) = content[1] else {
             XCTFail("Unexpected render tree.")
@@ -112,14 +112,14 @@ class ExternalLinkTitleTests: XCTestCase {
         XCTAssertEqual(linkReference?.titleInlineContent, expectedLinkTitle, "Strong text title should have been rendered.")
     }
     
-    func testCodeVoiceExternalLinkTitle() throws {
+    func testCodeVoiceExternalLinkTitle() async throws {
         let markupSource = """
         # Test
 
         This is a code voice text link: [`Apple`](https://www.example.com).
         """
         
-        let (translator, content) = try getTranslatorAndBlockContentForMarkup(markupSource)
+        let (translator, content) = try await getTranslatorAndBlockContentForMarkup(markupSource)
         
         guard case let .paragraph(firstParagraph) = content[1] else {
             XCTFail("Unexpected render tree.")
@@ -139,14 +139,14 @@ class ExternalLinkTitleTests: XCTestCase {
         XCTAssertEqual(linkReference?.titleInlineContent, expectedLinkTitle, "Code voice text title should have been rendered.")
     }
     
-    func testMixedExternalLinkTitle() throws {
+    func testMixedExternalLinkTitle() async throws {
         let markupSource = """
         # Test
 
         This is a mixed text link: [**This** *is* a `fancy` _link_ title.](https://www.example.com).
         """
         
-        let (translator, content) = try getTranslatorAndBlockContentForMarkup(markupSource)
+        let (translator, content) = try await getTranslatorAndBlockContentForMarkup(markupSource)
         
         guard case let .paragraph(firstParagraph) = content[1] else {
             XCTFail("Unexpected render tree.")
@@ -174,7 +174,7 @@ class ExternalLinkTitleTests: XCTestCase {
     }
     
     
-    func testMultipleLinksWithEqualURL() throws {
+    func testMultipleLinksWithEqualURL() async throws {
         let markupSource = """
         # Test
 
@@ -182,7 +182,7 @@ class ExternalLinkTitleTests: XCTestCase {
         This is an emphasized text link: [*Apple*](https://www.example.com).
         """
         
-        let (translator, content) = try getTranslatorAndBlockContentForMarkup(markupSource)
+        let (translator, content) = try await getTranslatorAndBlockContentForMarkup(markupSource)
         
         guard case let .paragraph(firstParagraph) = content[1] else {
             XCTFail("Unexpected render tree.")

--- a/Tests/SwiftDocCTests/Rendering/HeadingAnchorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/HeadingAnchorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import XCTest
 import SwiftDocCTestUtilities
 
 class HeadingAnchorTests: XCTestCase {
-    func testEncodeHeadingAnchor() throws {
+    func testEncodeHeadingAnchor() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 TextFile(name: "Root.md", utf8Content: """
@@ -34,7 +34,7 @@ class HeadingAnchorTests: XCTestCase {
                 """),
             ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         
         let reference = try XCTUnwrap(context.soleRootModuleReference)
         let node = try context.entity(with: reference)

--- a/Tests/SwiftDocCTests/Rendering/LinkTitleResolverTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/LinkTitleResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import XCTest
 @testable import SwiftDocC
 
 class LinkTitleResolverTests: XCTestCase {
-    func testSymbolTitleResolving() throws {
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testSymbolTitleResolving() async throws {
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let resolver = LinkTitleResolver(context: context, source: nil)
         guard let reference = context.knownIdentifiers.filter({ ref -> Bool in
             return ref.path.hasSuffix("MyProtocol")

--- a/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/MentionsRenderSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,9 +15,9 @@ import XCTest
 class MentionsRenderSectionTests: XCTestCase {
     /// Verify that the Mentioned In section is present when a symbol is mentioned,
     /// pointing to the correct article.
-    func testMentionedInSectionFull() throws {
+    func testMentionedInSectionFull() async throws {
         enableFeatureFlag(\.isMentionedInEnabled)
-        let (bundle, context) = try createMentionedInTestBundle()
+        let (bundle, context) = try await createMentionedInTestBundle()
         let identifier = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/MentionedIn/MyClass",
@@ -38,9 +38,9 @@ class MentionsRenderSectionTests: XCTestCase {
     }
 
     /// If there are no qualifying mentions of a symbol, the Mentioned In section should not appear.
-    func testMentionedInSectionEmpty() throws {
+    func testMentionedInSectionEmpty() async throws {
         enableFeatureFlag(\.isMentionedInEnabled)
-        let (bundle, context) = try createMentionedInTestBundle()
+        let (bundle, context) = try await createMentionedInTestBundle()
         let identifier = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/MentionedIn/MyClass/myFunction()",

--- a/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PageKindTests.swift
@@ -15,8 +15,8 @@ import XCTest
 
 class PageKindTests: XCTestCase {
     
-    private func generateRenderNodeFromBundle(bundleName: String, resolvedTopicPath: String) throws -> RenderNode {
-        let (bundle, context) = try testBundleAndContext(named: bundleName)
+    private func generateRenderNodeFromBundle(bundleName: String, resolvedTopicPath: String) async throws -> RenderNode {
+        let (bundle, context) = try await testBundleAndContext(named: bundleName)
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: resolvedTopicPath,
@@ -27,8 +27,8 @@ class PageKindTests: XCTestCase {
         return try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
     }
     
-    func testPageKindSampleCode() throws {
-        let renderNode = try generateRenderNodeFromBundle(
+    func testPageKindSampleCode() async throws {
+        let renderNode = try await generateRenderNodeFromBundle(
             bundleName: "SampleBundle",
             resolvedTopicPath: "/documentation/SampleBundle/MyLocalSample"
         )
@@ -36,8 +36,8 @@ class PageKindTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.roleHeading, Metadata.PageKind.Kind.sampleCode.titleHeading)
     }
 
-    func testPageKindArticle() throws {
-        let renderNode = try generateRenderNodeFromBundle(
+    func testPageKindArticle() async throws {
+        let renderNode = try await generateRenderNodeFromBundle(
             bundleName: "SampleBundle",
             resolvedTopicPath: "/documentation/SampleBundle/MySample"
         )
@@ -46,8 +46,8 @@ class PageKindTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.roleHeading, Metadata.PageKind.Kind.article.titleHeading)
     }
 
-    func testPageKindDefault() throws {
-        let renderNode = try generateRenderNodeFromBundle(
+    func testPageKindDefault() async throws {
+        let renderNode = try await generateRenderNodeFromBundle(
             bundleName: "AvailabilityBundle",
             resolvedTopicPath: "/documentation/AvailabilityBundle/ComplexAvailable"
         )
@@ -55,8 +55,8 @@ class PageKindTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.roleHeading, "Article")
     }
 
-    func testPageKindReference() throws {
-        let renderNode = try generateRenderNodeFromBundle(
+    func testPageKindReference() async throws {
+        let renderNode = try await generateRenderNodeFromBundle(
             bundleName: "SampleBundle",
             resolvedTopicPath: "/documentation/SomeSample"
         )
@@ -64,7 +64,7 @@ class PageKindTests: XCTestCase {
         XCTAssertEqual(sampleReference.role, RenderMetadata.Role.sampleCode.rawValue)
     }
 
-    func testValidMetadataWithOnlyPageKind() throws {
+    func testValidMetadataWithOnlyPageKind() async throws {
         let source = """
         @Metadata {
             @PageKind(article)
@@ -75,7 +75,7 @@ class PageKindTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+        let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
         directive.map { directive in
             var problems = [Problem]()
@@ -90,8 +90,8 @@ class PageKindTests: XCTestCase {
     
     // Verify that we assign the `Collection` role to the root article of a
     // documentation catalog that contains only one article.
-    func testRoleForSingleArticleCatalog() throws {
-        let renderNode = try generateRenderNodeFromBundle(
+    func testRoleForSingleArticleCatalog() async throws {
+        let renderNode = try await generateRenderNodeFromBundle(
             bundleName: "BundleWithSingleArticle",
             resolvedTopicPath: "/documentation/Article"
         )
@@ -100,8 +100,8 @@ class PageKindTests: XCTestCase {
     
     // Verify we assign the `Collection` role to the root article of an article-only
     // documentation catalog that doesn't include manual curation
-    func testRoleForArticleOnlyCatalogWithNoCuration() throws {
-        let renderNode = try generateRenderNodeFromBundle(
+    func testRoleForArticleOnlyCatalogWithNoCuration() async throws {
+        let renderNode = try await generateRenderNodeFromBundle(
             bundleName: "BundleWithArticlesNoCurated",
             resolvedTopicPath: "/documentation/Article"
         )

--- a/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PlatformAvailabilityTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -33,8 +33,8 @@ class PlatformAvailabilityTests: XCTestCase {
     }
 
     /// Ensure that adding `@Available` directives in an article causes the final RenderNode to contain the appropriate availability data.
-    func testPlatformAvailabilityFromArticle() throws {
-        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+    func testPlatformAvailabilityFromArticle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/AvailableArticle",
@@ -52,8 +52,8 @@ class PlatformAvailabilityTests: XCTestCase {
     }
 
     /// Ensure that adding `@Available` directives in an extension file overrides the symbol's availability.
-    func testPlatformAvailabilityFromExtension() throws {
-        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+    func testPlatformAvailabilityFromExtension() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/MyKit/MyClass",
@@ -70,8 +70,8 @@ class PlatformAvailabilityTests: XCTestCase {
         XCTAssert(iosAvailability.isBeta != true)
     }
 
-    func testMultiplePlatformAvailabilityFromArticle() throws {
-        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+    func testMultiplePlatformAvailabilityFromArticle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/AvailabilityBundle/ComplexAvailable",
@@ -98,8 +98,8 @@ class PlatformAvailabilityTests: XCTestCase {
         })
     }
 
-    func testArbitraryPlatformAvailability() throws {
-        let (bundle, context) = try testBundleAndContext(named: "AvailabilityBundle")
+    func testArbitraryPlatformAvailability() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "AvailabilityBundle")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/AvailabilityBundle/ArbitraryPlatforms",
@@ -123,8 +123,8 @@ class PlatformAvailabilityTests: XCTestCase {
     }
     
     // Test that the Info.plist default availability does not affect the deprecated/unavailable availabilities provided by the symbol graph.
-    func testAvailabilityParserWithInfoPlistDefaultAvailability() throws {
-        let (bundle, context) = try testBundleAndContext(named: "AvailabilityOverrideBundle")
+    func testAvailabilityParserWithInfoPlistDefaultAvailability() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "AvailabilityOverrideBundle")
 
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
@@ -160,11 +160,11 @@ class PlatformAvailabilityTests: XCTestCase {
     }
     
     /// Ensure that adding `@Available` directives for platform versions marked as beta in an article causes the final RenderNode to contain the appropriate availability data.
-    func testBetaPlatformAvailabilityFromArticle() throws {
+    func testBetaPlatformAvailabilityFromArticle() async throws {
         let platformMetadata = [
             "iOS": PlatformVersion(VersionTriplet(16, 0, 0), beta: true),
         ]
-        let (bundle, context) = try testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
+        let (bundle, context) = try await testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/AvailableArticle",
@@ -181,13 +181,13 @@ class PlatformAvailabilityTests: XCTestCase {
         XCTAssert(iosAvailability.isBeta == true)
     }
 
-    func testMultipleBetaPlatformAvailabilityFromArticle() throws {
+    func testMultipleBetaPlatformAvailabilityFromArticle() async throws {
         let platformMetadata = [
             "iOS": PlatformVersion(VersionTriplet(15, 0, 0), beta: true),
             "macOS": PlatformVersion(VersionTriplet(12, 0, 0), beta: true),
             "watchOS": PlatformVersion(VersionTriplet(7, 0, 0), beta: true),
         ]
-        let (bundle, context) = try testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
+        let (bundle, context) = try await testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/AvailabilityBundle/ComplexAvailable",
@@ -215,11 +215,11 @@ class PlatformAvailabilityTests: XCTestCase {
     }
     
     /// Ensure that adding `@Available` directives in an extension file overrides the symbol's availability.
-    func testBetaPlatformAvailabilityFromExtension() throws {
+    func testBetaPlatformAvailabilityFromExtension() async throws {
         let platformMetadata = [
             "iOS": PlatformVersion(VersionTriplet(16, 0, 0), beta: true),
         ]
-        let (bundle, context) = try testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
+        let (bundle, context) = try await testBundleWithConfiguredPlatforms(named: "AvailabilityBundle", platformMetadata: platformMetadata)
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/MyKit/MyClass",
@@ -237,11 +237,11 @@ class PlatformAvailabilityTests: XCTestCase {
     }
 
     
-    func testBundleWithConfiguredPlatforms(named testBundleName: String, platformMetadata: [String : PlatformVersion]) throws -> (DocumentationBundle, DocumentationContext) {
+    func testBundleWithConfiguredPlatforms(named testBundleName: String, platformMetadata: [String : PlatformVersion]) async throws -> (DocumentationBundle, DocumentationContext) {
         let bundleURL = try XCTUnwrap(Bundle.module.url(forResource: testBundleName, withExtension: "docc", subdirectory: "Test Bundles"))
         var configuration = DocumentationContext.Configuration()
         configuration.externalMetadata.currentPlatforms = platformMetadata
-        let (_, bundle, context) = try loadBundle(from: bundleURL, configuration: configuration)
+        let (_, bundle, context) = try await loadBundle(from: bundleURL, configuration: configuration)
         return (bundle, context)
     }
 

--- a/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/PropertyListDetailsRenderSectionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,9 +16,9 @@ import SwiftDocCTestUtilities
 
 class PropertyListDetailsRenderSectionTests: XCTestCase {
 
-    func testDecoding() throws {
+    func testDecoding() async throws {
         
-        func getPlistDetailsSection(arrayMode: any CustomStringConvertible, baseType: any CustomStringConvertible, rawKey: any CustomStringConvertible) throws -> PropertyListDetailsRenderSection {
+        func getPlistDetailsSection(arrayMode: any CustomStringConvertible, baseType: any CustomStringConvertible, rawKey: any CustomStringConvertible) async throws -> PropertyListDetailsRenderSection {
             let symbolJSON = """
             {
               "accessLevel" : "public",
@@ -55,7 +55,7 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
             let catalog = Folder(name: "unit-test.docc", content: [
                 TextFile(name: "MyModule.symbols.json", utf8Content: symbolGraphString)
             ])
-            let (bundle, context) = try loadBundle(catalog: catalog)
+            let (bundle, context) = try await loadBundle(catalog: catalog)
             let node = try XCTUnwrap(context.documentationCache["plist:propertylistkey"])
             let converter = DocumentationNodeConverter(bundle: bundle, context: context)
             let renderNode = converter.convert(node)
@@ -63,8 +63,9 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
         }
         
         // Assert that the Details section is correctly generated when passing valid values into the plistDetails JSON object.
+        let withArrayMode = try await getPlistDetailsSection(arrayMode: true, baseType: "\"string\"", rawKey: "\"property-list-key\"")
         XCTAssertEqual(
-            try getPlistDetailsSection(arrayMode: true, baseType: "\"string\"", rawKey: "\"property-list-key\""),
+            withArrayMode,
             PropertyListDetailsRenderSection(
                details: PropertyListDetailsRenderSection.Details(
                    rawKey: "property-list-key",
@@ -76,8 +77,9 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
            )
        )
         
+        let withoutArrayMode = try await getPlistDetailsSection(arrayMode: false, baseType: "\"string\"", rawKey: "\"property-list-key\"")
         XCTAssertEqual(
-            try getPlistDetailsSection(arrayMode: false, baseType: "\"string\"", rawKey: "\"property-list-key\""),
+            withoutArrayMode,
             PropertyListDetailsRenderSection(
                details: PropertyListDetailsRenderSection.Details(
                    rawKey: "property-list-key",
@@ -91,12 +93,14 @@ class PropertyListDetailsRenderSectionTests: XCTestCase {
         
         // Assert that the Details section does not decode unsupported values.
         do {
-            _ = try getPlistDetailsSection(arrayMode: true, baseType: true, rawKey: "\"property-list-key\"")
+            _ = try await getPlistDetailsSection(arrayMode: true, baseType: true, rawKey: "\"property-list-key\"")
+            XCTFail("Didn't raise an error")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("isn’t in the correct format"))
         }
         do {
-            _ = try getPlistDetailsSection(arrayMode: true, baseType: "\"string\"", rawKey: 1)
+            _ = try await getPlistDetailsSection(arrayMode: true, baseType: "\"string\"", rawKey: 1)
+            XCTFail("Didn't raise an error")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("isn’t in the correct format"))
         }

--- a/Tests/SwiftDocCTests/Rendering/RenderBlockContent_ThematicBreakTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderBlockContent_ThematicBreakTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -25,7 +25,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
     }
     
     // MARK: - Thematic Break Markdown Variants
-    func testThematicBreakVariants() throws {
+    func testThematicBreakVariants() async throws {
         let source = """
 
         ---
@@ -38,7 +38,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         
         XCTAssertEqual(markup.childCount, 3)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         
         var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
@@ -52,7 +52,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         XCTAssertEqual(expectedContent, renderContent)
     }
     
-    func testThematicBreakVariantsWithSpaces() throws {
+    func testThematicBreakVariantsWithSpaces() async throws {
         let source = """
 
         - - -
@@ -65,7 +65,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         
         XCTAssertEqual(markup.childCount, 3)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         
         var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         
@@ -79,7 +79,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         XCTAssertEqual(expectedContent, renderContent)
     }
     
-    func testThematicBreakMoreThanThreeCharacters() throws {
+    func testThematicBreakMoreThanThreeCharacters() async throws {
         let source = """
 
         ----
@@ -95,7 +95,7 @@ class RenderBlockContent_ThematicBreakTests: XCTestCase {
         
         XCTAssertEqual(markup.childCount, 6)
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         
         var contentTranslator = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/TestThematicBreak", sourceLanguage: .swift))
         

--- a/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,8 +14,8 @@ import Markdown
 import XCTest
 
 class RenderContentCompilerTests: XCTestCase {
-    func testLinkOverrideTitle() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testLinkOverrideTitle() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = """
@@ -132,8 +132,8 @@ class RenderContentCompilerTests: XCTestCase {
         }
     }
     
-    func testLineBreak() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testLineBreak() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = #"""
@@ -197,8 +197,8 @@ class RenderContentCompilerTests: XCTestCase {
         }
     }
     
-    func testThematicBreak() throws {
-        let (bundle, context) = try testBundleAndContext()
+    func testThematicBreak() async throws {
+        let (bundle, context) = try await testBundleAndContext()
         var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
 

--- a/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderMetadataTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -69,11 +69,11 @@ class RenderMetadataTests: XCTestCase {
         XCTAssertEqual(metadata.symbolKind, "plum")
     }
 
-    func testAllPagesHaveTitleMetadata() throws {
+    func testAllPagesHaveTitleMetadata() async throws {
         var typesOfPages = [Tutorial.self, TutorialTableOfContents.self, Article.self, TutorialArticle.self, Symbol.self]
         
         for bundleName in ["LegacyBundle_DoNotUseInNewTests"] {
-            let (bundle, context) = try testBundleAndContext(named: bundleName)
+            let (bundle, context) = try await testBundleAndContext(named: bundleName)
             
             let renderContext = RenderContext(documentationContext: context, bundle: bundle)
             let converter = DocumentationContextConverter(bundle: bundle, context: context, renderContext: renderContext)
@@ -92,8 +92,8 @@ class RenderMetadataTests: XCTestCase {
     
     /// Test that a bystanders symbol graph is loaded, symbols are merged into the main module
     /// and the bystanders are included in the render node metadata.
-    func testRendersBystandersFromSymbolGraph() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [:]) { url in
+    func testRendersBystandersFromSymbolGraph() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [:]) { url in
             let bystanderSymbolGraphURL = Bundle.module.url(
                 forResource: "MyKit@Foundation@_MyKit_Foundation.symbols", withExtension: "json", subdirectory: "Test Resources")!
             try FileManager.default.copyItem(at: bystanderSymbolGraphURL, to: url.appendingPathComponent("MyKit@Foundation@_MyKit_Foundation.symbols.json"))
@@ -116,8 +116,8 @@ class RenderMetadataTests: XCTestCase {
 
     /// Test that when a bystanders symbol graph is loaded that extends a different module, that
     /// those symbols correctly report the modules when rendered.
-    func testRendersBystanderExtensionsFromSymbolGraph() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [:]) { url in
+    func testRendersBystanderExtensionsFromSymbolGraph() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", externalResolvers: [:]) { url in
             let baseSymbolGraphURL = Bundle.module.url(
                 forResource: "BaseKit.symbols", withExtension: "json", subdirectory: "Test Resources")!
             try FileManager.default.copyItem(at: baseSymbolGraphURL, to: url.appendingPathComponent("BaseKit.symbols.json"))
@@ -141,8 +141,8 @@ class RenderMetadataTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.modules?.first?.relatedModules, ["BaseKit"])
     }
 
-    func testRendersExtensionSymbolsWithBystanderModules() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
+    func testRendersExtensionSymbolsWithBystanderModules() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "BundleWithRelativePathAmbiguity") { root in
             // We don't want the external target to be part of the archive as that is not
             // officially supported yet.
             try FileManager.default.removeItem(at: root.appendingPathComponent("Dependency.symbols.json"))

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorSymbolVariantsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -17,8 +17,8 @@ import SwiftDocCTestUtilities
 
 class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     
-    func testIdentifierVariants() throws {
-        try assertMultiVariantSymbol(
+    func testIdentifierVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
                 var documentationNode = try XCTUnwrap(context.documentationCache[resolvedTopicReference])
                 documentationNode.availableSourceLanguages = [.swift, .objectiveC]
@@ -33,8 +33,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testMultipleModules() throws {
-        try assertMultiVariantSymbol(
+    func testMultipleModules() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
                 let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Custom Module Title")
@@ -49,8 +49,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testMultipleModulesWithBystanderModule() throws {
-        try assertMultiVariantSymbol(
+    func testMultipleModulesWithBystanderModule() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
                 let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Custom Module Title")
@@ -77,8 +77,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     }
 
     /// Make sure that when a symbol has `crossImportOverlayModule` information, that module name is used instead of its `moduleReference`.
-    func testMultipleModulesWithDifferentBystanderModule() throws {
-        try assertMultiVariantSymbol(
+    func testMultipleModulesWithDifferentBystanderModule() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
                 let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Extended Module Title")
@@ -104,8 +104,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testExtendedModuleVariants() throws {
-        try assertMultiVariantSymbol(
+    func testExtendedModuleVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 let newConstraint = SymbolGraph.Symbol.Swift.GenericConstraint(
                     kind: SymbolGraph.Symbol.Swift.GenericConstraint.Kind.sameType,
@@ -123,8 +123,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testPlatformsVariantsDefaultAvailability() throws {
-        try assertMultiVariantSymbol(
+    func testPlatformsVariantsDefaultAvailability() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
                 let moduleReference = ResolvedTopicReference(bundleID: resolvedTopicReference.bundleID, path: "/documentation/MyKit", sourceLanguage: .swift)
                 context.documentationCache[moduleReference]?.name = .conceptual(title: "Custom Module Title")
@@ -142,8 +142,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testPlatformsVariantsCustomAvailability() throws {
-        try assertMultiVariantSymbol(
+    func testPlatformsVariantsCustomAvailability() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.availabilityVariants[.swift] = SymbolGraph.Symbol.Availability(availability: [
                     SymbolGraph.Symbol.Availability.AvailabilityItem(
@@ -184,8 +184,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testRequiredVariants() throws {
-        try assertMultiVariantSymbol(
+    func testRequiredVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.isRequiredVariants[.swift] = false
                 symbol.isRequiredVariants[.objectiveC] = true
@@ -199,8 +199,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testRoleHeadingVariants() throws {
-        try assertMultiVariantSymbol(
+    func testRoleHeadingVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.roleHeadingVariants[.swift] = "Swift Title"
                 symbol.roleHeadingVariants[.objectiveC] = "Objective-C Title"
@@ -214,8 +214,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testTitleVariants() throws {
-        try assertMultiVariantSymbol(
+    func testTitleVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.titleVariants[.swift] = "Swift Title"
                 symbol.titleVariants[.objectiveC] = "Objective-C Title"
@@ -229,8 +229,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testExternalIDVariants() throws {
-        try assertMultiVariantSymbol(
+    func testExternalIDVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.roleHeadingVariants[.swift] = "Swift Title"
                 symbol.roleHeadingVariants[.objectiveC] = "Objective-C Title"
@@ -244,8 +244,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testSymbolKindVariants() throws {
-        try assertMultiVariantSymbol(
+    func testSymbolKindVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.kindVariants[.swift] = .init(rawIdentifier: "swift.method", displayName: "Swift Kind")
                 symbol.kindVariants[.objectiveC] = .init(rawIdentifier: "objc.func", displayName: "Objective-C Kind")
@@ -259,8 +259,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testFragmentsVariants() throws {
-        try assertMultiVariantSymbol(
+    func testFragmentsVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.subHeadingVariants[.swift] = [
                     .init(kind: .keyword, spelling: "swift", preciseIdentifier: nil)
@@ -291,8 +291,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testNavigatorTitleVariants() throws {
-        try assertMultiVariantSymbol(
+    func testNavigatorTitleVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.navigatorVariants[.swift] = [
                     .init(kind: .keyword, spelling: "swift", preciseIdentifier: nil)
@@ -320,7 +320,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testVariants() throws {
+    func testVariants() async throws {
         let expectedVariants = [
             RenderNode.Variant(
                 traits: [.interfaceLanguage("swift")],
@@ -332,7 +332,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             ),
         ]
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureContext: { context, resolvedTopicReference in
                 var documentationNode = try XCTUnwrap(context.documentationCache[resolvedTopicReference])
                 documentationNode.availableSourceLanguages = [.swift, .objectiveC]
@@ -347,8 +347,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testAbstractVariants() throws {
-        try assertMultiVariantSymbol(
+    func testAbstractVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.abstractSectionVariants[.swift] = AbstractSection(
                     paragraph: Paragraph(Text("Swift abstract"))
@@ -367,14 +367,14 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testDeclarationsSectionVariants() throws {
+    func testDeclarationsSectionVariants() async throws {
         func declarationSection(in renderNode: RenderNode) throws -> DeclarationRenderSection {
             try XCTUnwrap(
                 (renderNode.primaryContentSections.first as? DeclarationsRenderSection)?.declarations.first
             )
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.declarationVariants[.swift] = [
                     [.macOS]: SymbolGraph.Symbol.DeclarationFragments(
@@ -413,7 +413,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testReturnsSectionVariants() throws {
+    func testReturnsSectionVariants() async throws {
         func returnsSection(in renderNode: RenderNode) throws -> ContentRenderSection {
             let returnsSectionIndex = 1
             
@@ -425,7 +425,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             return try XCTUnwrap(renderNode.primaryContentSections[returnsSectionIndex] as? ContentRenderSection)
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.returnsSectionVariants[.swift] = ReturnsSection(
                     content: [Paragraph(Text("Swift Returns Section"))]
@@ -458,7 +458,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
    }
     
-    func testParametersSectionVariants() throws {
+    func testParametersSectionVariants() async throws {
         func parametersSection(in renderNode: RenderNode) throws -> ParametersRenderSection {
             let parametersSectionIndex = 1
             
@@ -470,7 +470,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             return try XCTUnwrap(renderNode.primaryContentSections[parametersSectionIndex] as? ParametersRenderSection)
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.parametersSectionVariants[.swift] = ParametersSection(
                     parameters: [Parameter(name: "Swift parameter", contents: [])]
@@ -501,7 +501,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testDictionaryKeysSection() throws {
+    func testDictionaryKeysSection() async throws {
         let keySymbol = makeSymbol(id: "some-key", language: .data, kind: .dictionaryKey, pathComponents: ["SomeDictionary", "SomeKey"])
         let catalog = Folder(name: "unit-test.docc", content: [
             JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName", symbols: [
@@ -510,7 +510,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             ]))
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let moduleReference = try XCTUnwrap(context.soleRootModuleReference)
         let dictionaryReference = moduleReference.appendingPath("SomeDictionary")
         
@@ -550,12 +550,12 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         }
     }
     
-    func testDiscussionSectionVariants() throws {
+    func testDiscussionSectionVariants() async throws {
         func discussionSection(in renderNode: RenderNode) throws -> ContentRenderSection {
             return try XCTUnwrap(renderNode.primaryContentSections.mapFirst { $0 as? ContentRenderSection })
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.discussionVariants[.swift] = DiscussionSection(
                     content: [Paragraph(Text("Swift Discussion"))]
@@ -590,7 +590,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testSourceFileURIVariants() throws {
+    func testSourceFileURIVariants() async throws {
         func makeLocation(uri: String) throws -> SymbolGraph.Symbol.Location {
             let location = """
             {
@@ -605,7 +605,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             return try JSONDecoder().decode(SymbolGraph.Symbol.Location.self, from: location)
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.locationVariants[.swift] = try makeLocation(uri: "Swift URI")
                 symbol.locationVariants[.objectiveC] = try makeLocation(uri: "Objective-C URI")
@@ -622,8 +622,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testSymbolAccessLevelVariants() throws {
-        try assertMultiVariantSymbol(
+    func testSymbolAccessLevelVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.accessLevelVariants[.swift] = "Swift access level"
                 symbol.accessLevelVariants[.objectiveC] = "Objective-C access level"
@@ -640,8 +640,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testRelationshipSectionsVariants() throws {
-        try assertMultiVariantSymbol(
+    func testRelationshipSectionsVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, _ in
             
                 // Set up an Objective-C title for MyProtocol.
@@ -691,8 +691,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testDoesNotEmitObjectiveCRelationshipsForTopicThatOnlyHasSwiftRelationships() throws {
-        try assertMultiVariantSymbol(
+    func testDoesNotEmitObjectiveCRelationshipsForTopicThatOnlyHasSwiftRelationships() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, _ in
             
                 // Set up an Objective-C title for MyProtocol.
@@ -732,8 +732,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testTopicsSectionVariants() throws {
-        try assertMultiVariantSymbol(
+    func testTopicsSectionVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureContext: { context, reference in
                 try makeSymbolAvailableInSwiftAndObjectiveC(
                     symbolPath: "/documentation/MyKit/MyProtocol",
@@ -777,8 +777,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testEncodesNilTopicsSectionsForArticleVariantIfDefaultIsNonEmpty() throws {
-        try assertMultiVariantArticle(
+    func testEncodesNilTopicsSectionsForArticleVariantIfDefaultIsNonEmpty() async throws {
+        try await assertMultiVariantArticle(
             configureArticle: { article in
                 article.automaticTaskGroups = []
                 article.topics = makeTopicsSection(
@@ -814,8 +814,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testEncodesNilTopicsSectionsForSymbolVariantIfDefaultIsNonEmpty() throws {
-        try assertMultiVariantSymbol(
+    func testEncodesNilTopicsSectionsForSymbolVariantIfDefaultIsNonEmpty() async throws {
+        try await assertMultiVariantSymbol(
             assertOriginalRenderNode: { renderNode in
                 XCTAssertEqual(renderNode.topicSections.count, 6)
             },
@@ -834,8 +834,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testTopicsSectionVariantsNoUserProvidedTopics() throws {
-        try assertMultiVariantSymbol(
+    func testTopicsSectionVariantsNoUserProvidedTopics() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.automaticTaskGroupsVariants[.fallback] = []
                 symbol.topicsVariants[.fallback] = nil
@@ -861,7 +861,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testDefaultImplementationsSectionsVariants() throws {
+    func testDefaultImplementationsSectionsVariants() async throws {
         func createDefaultImplementationsSection(path: String) -> DefaultImplementationsSection {
             DefaultImplementationsSection(
                 targetFallbacks: [:],
@@ -882,7 +882,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             )
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.defaultImplementationsVariants[.swift] = createDefaultImplementationsSection(
                     path: "/documentation/MyKit/MyProtocol"
@@ -923,7 +923,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testSeeAlsoSectionVariants() throws {
+    func testSeeAlsoSectionVariants() async throws {
         func makeSeeAlsoSection(destination: String) -> SeeAlsoSection {
             SeeAlsoSection(content: [
                 UnorderedList(
@@ -932,7 +932,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             ])
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureContext: { context, reference in
                 try makeSymbolAvailableInSwiftAndObjectiveC(
                     symbolPath: "/documentation/MyKit/MyProtocol",
@@ -972,7 +972,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testDoesNotEmitObjectiveCSeeAlsoIfEmpty() throws {
+    func testDoesNotEmitObjectiveCSeeAlsoIfEmpty() async throws {
         func makeSeeAlsoSection(destination: String) -> SeeAlsoSection {
             SeeAlsoSection(content: [
                 UnorderedList(
@@ -981,7 +981,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             ])
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.seeAlsoVariants[.swift] = makeSeeAlsoSection(
                     destination: "doc://org.swift.docc.example/documentation/MyKit/MyProtocol"
@@ -996,8 +996,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
     }
     
-    func testDeprecationSummaryVariants() throws {
-        try assertMultiVariantSymbol(
+    func testDeprecationSummaryVariants() async throws {
+        try await assertMultiVariantSymbol(
             configureSymbol: { symbol in
                 symbol.deprecatedSummaryVariants[.swift] = DeprecatedSection(
                     text: "Swift Deprecation Variant"
@@ -1047,8 +1047,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     /// The `DeprecatedInOneLanguageOnly` catalog defines a symbol `MyClass` which has availability
     /// annotations in Swift but not in Objective-C. This test verifies that the Swift render node for `MyClass` does
     /// indeed include availability information, but that the Objective-C one doesn't.
-    func testDoesNotInheritAvailabilityFromOtherLanguage() throws {
-        try assertMultiVariantSymbol(
+    func testDoesNotInheritAvailabilityFromOtherLanguage() async throws {
+        try await assertMultiVariantSymbol(
             bundleName: "DeprecatedInOneLanguageOnly",
             assertOriginalRenderNode: { renderNode in
                 XCTAssert(renderNode.metadata.platforms?.isEmpty == false)
@@ -1062,7 +1062,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
     }
     
     /// Tests that deprecation summaries only show up on variants of pages that are actually deprecated.
-    func testIncludesDeprecationSummaryOnlyInDeprecatedVariantOfSymbol() throws {
+    func testIncludesDeprecationSummaryOnlyInDeprecatedVariantOfSymbol() async throws {
         let deprecatedOnOnePlatform = SymbolGraph.Symbol.Availability.AvailabilityItem(
             domain: .init(rawValue: SymbolGraph.Symbol.Availability.Domain.macOS),
             introducedVersion: .init(major: 15, minor: 0, patch: 0),
@@ -1088,7 +1088,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         )
         
         for deprecatedAvailability in [deprecatedOnOnePlatform, unconditionallyDeprecated] {
-            try assertMultiVariantSymbol(
+            try await assertMultiVariantSymbol(
                 configureSymbol: { symbol in
                     symbol.deprecatedSummaryVariants[.swift] = DeprecatedSection(
                         text: "Deprecation summary"
@@ -1113,7 +1113,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         }
     }
 
-    func testTopicRenderReferenceVariants() throws {
+    func testTopicRenderReferenceVariants() async throws {
         func myFunctionReference(in renderNode: RenderNode) throws -> TopicRenderReference {
             return try XCTUnwrap(
                 renderNode.references[
@@ -1122,7 +1122,7 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
             )
         }
         
-        try assertMultiVariantSymbol(
+        try await assertMultiVariantSymbol(
             configureContext: { context, _ in
                 // Set up a symbol with variants.
                 
@@ -1166,8 +1166,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         assertOriginalRenderNode: (RenderNode) throws -> (),
         assertAfterApplyingVariant: (RenderNode) throws -> () = { _ in },
         assertDataAfterApplyingVariant: (Data) throws -> () = { _ in }
-    ) throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: bundleName)
+    ) async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: bundleName)
         
         let identifier = ResolvedTopicReference(
             bundleID: bundle.id,
@@ -1203,8 +1203,8 @@ class RenderNodeTranslatorSymbolVariantsTests: XCTestCase {
         assertOriginalRenderNode: (RenderNode) throws -> (),
         assertAfterApplyingVariant: (RenderNode) throws -> () = { _ in },
         assertDataAfterApplyingVariant: (Data) throws -> () = { _ in }
-    ) throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
+    ) async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
         
         let identifier = ResolvedTopicReference(
             bundleID: bundle.id,

--- a/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderNodeTranslatorTests.swift
@@ -16,8 +16,8 @@ import Markdown
 import SymbolKit
 
 class RenderNodeTranslatorTests: XCTestCase {
-    private func findDiscussion(forSymbolPath: String, configureBundle: ((URL) throws -> Void)? = nil) throws -> ContentRenderSection? {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", configureBundle: configureBundle)
+    private func findDiscussion(forSymbolPath: String, configureBundle: ((URL) throws -> Void)? = nil) async throws -> ContentRenderSection? {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", configureBundle: configureBundle)
         
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: forSymbolPath, sourceLanguage: .swift))
         
@@ -33,8 +33,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         return discussion
     }
     
-    private func findParagraph(withPrefix: String, forSymbolPath: String) throws -> [RenderInlineContent]? {
-        guard let discussion = try findDiscussion(forSymbolPath: forSymbolPath) else {
+    private func findParagraph(withPrefix: String, forSymbolPath: String) async throws -> [RenderInlineContent]? {
+        guard let discussion = try await findDiscussion(forSymbolPath: forSymbolPath) else {
             return nil
         }
         
@@ -59,8 +59,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         return paragraph
     }
     
-    func testResolvingSymbolLinks() throws {
-        guard let paragraph = try findParagraph(withPrefix: "Exercise links to symbols", forSymbolPath: "/documentation/MyKit/MyProtocol") else {
+    func testResolvingSymbolLinks() async throws {
+        guard let paragraph = try await findParagraph(withPrefix: "Exercise links to symbols", forSymbolPath: "/documentation/MyKit/MyProtocol") else {
             XCTFail("Failed to fetch test content")
             return
         }
@@ -78,8 +78,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(references.count, 2)
     }
     
-    func testExternalSymbolLink() throws {
-        guard let paragraph = try findParagraph(withPrefix: "Exercise unresolved symbols", forSymbolPath: "/documentation/MyKit/MyProtocol") else {
+    func testExternalSymbolLink() async throws {
+        guard let paragraph = try await findParagraph(withPrefix: "Exercise unresolved symbols", forSymbolPath: "/documentation/MyKit/MyProtocol") else {
             XCTFail("Failed to fetch test content")
             return
         }
@@ -97,8 +97,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(references.count, 1)
     }
     
-    func testOrderedAndUnorderedList() throws {
-        guard let discussion = try findDiscussion(forSymbolPath: "/documentation/MyKit/MyProtocol") else {
+    func testOrderedAndUnorderedList() async throws {
+        guard let discussion = try await findDiscussion(forSymbolPath: "/documentation/MyKit/MyProtocol") else {
             return
         }
         
@@ -144,8 +144,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         }))
     }
     
-    func testAutomaticOverviewAndDiscussionHeadings() throws {
-        guard let myFunctionDiscussion = try findDiscussion(forSymbolPath: "/documentation/MyKit/MyClass/myFunction()", configureBundle: { url in
+    func testAutomaticOverviewAndDiscussionHeadings() async throws {
+        guard let myFunctionDiscussion = try await findDiscussion(forSymbolPath: "/documentation/MyKit/MyClass/myFunction()", configureBundle: { url in
             let sidecarURL = url.appendingPathComponent("/documentation/myFunction.md")
             try """
             # ``MyKit/MyClass/myFunction()``
@@ -164,7 +164,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             ]
         )
         
-        guard let myClassDiscussion = try findDiscussion(forSymbolPath: "/documentation/MyKit/MyClass", configureBundle: { url in
+        guard let myClassDiscussion = try await findDiscussion(forSymbolPath: "/documentation/MyKit/MyClass", configureBundle: { url in
             let sidecarURL = url.appendingPathComponent("/documentation/myclass.md")
             XCTAssert(FileManager.default.fileExists(atPath: sidecarURL.path), "Make sure that this overrides the existing file.")
             try """
@@ -222,8 +222,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         }
     }
             
-    func testArticleRoles() throws {
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testArticleRoles() async throws {
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         
         // Verify article's role
@@ -279,9 +279,9 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
     
     // Verifies that links to sections include their container's abstract rdar://72110558
-    func testSectionAbstracts() throws {
+    func testSectionAbstracts() async throws {
         // Create an article including a link to a tutorial section
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], configureBundle: { url in
             try """
             # Article
             Article abstract
@@ -302,8 +302,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(renderReference.abstract.first?.plainText, "This is the tutorial abstract.")
     }
 
-    func testEmptyTaskGroupsNotRendered() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testEmptyTaskGroupsNotRendered() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         
         let source = """
@@ -364,8 +364,8 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
     
     /// Tests the ordering of automatic groups for symbols
-    func testAutomaticTaskGroupsOrderingInSymbols() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+    func testAutomaticTaskGroupsOrderingInSymbols() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``SideKit/SideClass``
             SideClass abstract
@@ -491,8 +491,8 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
     
     /// Tests the ordering of automatic groups for articles
-    func testAutomaticTaskGroupsOrderingInArticles() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+    func testAutomaticTaskGroupsOrderingInArticles() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # Article
             Article abstract
@@ -598,8 +598,8 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
 
     /// Tests the ordering of automatic groups in defining protocol
-    func testOrderingOfAutomaticGroupsInDefiningProtocol() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+    func testOrderingOfAutomaticGroupsInDefiningProtocol() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             //
         })
         
@@ -644,12 +644,12 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
 
     /// Verify that symbols with ellipsis operators don't get curated into an unnamed protocol implementation section.
-    func testAutomaticImplementationsWithExtraDots() throws {
+    func testAutomaticImplementationsWithExtraDots() async throws {
         let fancyProtocolSGFURL = Bundle.module.url(
             forResource: "FancyProtocol.symbols", withExtension: "json", subdirectory: "Test Resources")!
 
         // Create a test bundle copy with the symbol graph from above
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: []) { url in
             try? FileManager.default.copyItem(at: fancyProtocolSGFURL, to: url.appendingPathComponent("FancyProtocol.symbols.json"))
         }
 
@@ -674,7 +674,7 @@ class RenderNodeTranslatorTests: XCTestCase {
 
     }
     
-    func testAutomaticImplementationsWithExtraDotsFromExternalModule() throws {
+    func testAutomaticImplementationsWithExtraDotsFromExternalModule() async throws {
         let inheritedDefaultImplementationsFromExternalModuleSGF = Bundle.module.url(
             forResource: "InheritedDefaultImplementationsFromExternalModule.symbols",
             withExtension: "json",
@@ -689,21 +689,21 @@ class RenderNodeTranslatorTests: XCTestCase {
             ]
         ).write(inside: createTemporaryDirectory())
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/SecondTarget/FancyProtocolConformer", in: testBundle),
             [
                 "FancyProtocol Implementations",
             ]
         )
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/SecondTarget/OtherFancyProtocolConformer", in: testBundle),
             [
                 "OtherFancyProtocol Implementations",
             ]
         )
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/SecondTarget/FooConformer", in: testBundle),
             [
                 "Foo Implementations",
@@ -711,7 +711,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         )
     }
     
-    func testAutomaticImplementationsFromCurrentModuleWithMixOfDocCoverage() throws {
+    func testAutomaticImplementationsFromCurrentModuleWithMixOfDocCoverage() async throws {
         let inheritedDefaultImplementationsSGF = Bundle.module.url(
             forResource: "InheritedDefaultImplementations.symbols",
             withExtension: "json",
@@ -732,14 +732,14 @@ class RenderNodeTranslatorTests: XCTestCase {
             ]
         ).write(inside: createTemporaryDirectory())
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/FirstTarget/Bar", in: testBundle),
             [
                 "Foo Implementations",
             ]
         )
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/FirstTarget/OtherStruct", in: testBundle),
             [
                 "Comparable Implementations",
@@ -747,7 +747,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             ]
         )
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/FirstTarget/SomeStruct", in: testBundle),
             [
                 "Comparable Implementations",
@@ -758,7 +758,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         )
     }
     
-    func testAutomaticImplementationsFromMultiPlatformSymbolGraphs() throws {
+    func testAutomaticImplementationsFromMultiPlatformSymbolGraphs() async throws {
         let inheritedDefaultImplementationsSGF = Bundle.module.url(
             forResource: "InheritedDefaultImplementations.symbols",
             withExtension: "json",
@@ -807,14 +807,14 @@ class RenderNodeTranslatorTests: XCTestCase {
             ]
         ).write(inside: createTemporaryDirectory())
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/FirstTarget/Bar", in: testBundle),
             [
                 "Foo Implementations",
             ]
         )
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/FirstTarget/OtherStruct", in: testBundle),
             [
                 "Comparable Implementations",
@@ -822,7 +822,7 @@ class RenderNodeTranslatorTests: XCTestCase {
             ]
         )
         
-        try assertDefaultImplementationCollectionTitles(
+        try await assertDefaultImplementationCollectionTitles(
             in: try loadRenderNode(at: "/documentation/FirstTarget/SomeStruct", in: testBundle),
             [
                 "Comparable Implementations",
@@ -853,8 +853,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(references.map(\.title), expectedTitles, file: file, line: line)
     }
     
-    func loadRenderNode(at path: String, in bundleURL: URL) throws -> RenderNode {
-        let (_, bundle, context) = try loadBundle(from: bundleURL)
+    func loadRenderNode(at path: String, in bundleURL: URL) async throws -> RenderNode {
+        let (_, bundle, context) = try await loadBundle(from: bundleURL)
 
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: path, sourceLanguage: .swift)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -863,8 +863,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         return try XCTUnwrap(translator.visitSymbol(symbol) as? RenderNode)
     }
     
-    func testAutomaticTaskGroupTopicsAreSorted() throws {
-        let (bundle, context) = try testBundleAndContext(named: "DefaultImplementations")
+    func testAutomaticTaskGroupTopicsAreSorted() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "DefaultImplementations")
         let structReference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/DefaultImplementations/Foo", sourceLanguage: .swift)
         let structNode = try context.entity(with: structReference)
         let symbol = try XCTUnwrap(structNode.semantic as? Symbol)
@@ -883,9 +883,9 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
     
     // Verifies we don't render links to non linkable nodes.
-    func testNonLinkableNodes() throws {
+    func testNonLinkableNodes() async throws {
         // Create a bundle with variety absolute and relative links and symbol links to a non linkable node.
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
             try """
             # ``SideKit/SideClass``
             Abstract.
@@ -922,10 +922,10 @@ class RenderNodeTranslatorTests: XCTestCase {
     }
     
     // Verifies we support rendering links in abstracts.
-    func testLinkInAbstract() throws {
+    func testLinkInAbstract() async throws {
         do {
             // First verify that `SideKit` page does not contain render reference to `SideKit/SideClass/Element`.
-            let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+            let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             
             let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/SideKit", sourceLanguage: .swift)
             let node = try context.entity(with: reference)
@@ -940,7 +940,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         
         do {
             // Create a bundle with a link in abstract, then verify the render reference is present in `SideKit` render node references.
-            let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
+            let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests", excludingPaths: [], externalResolvers: [:], externalSymbolResolver: nil, configureBundle: { url in
                 try """
                 # ``SideKit/SideClass``
                 This is a link to <doc:/documentation/SideKit/SideClass/Element>.
@@ -959,8 +959,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         }
     }
 
-    func testSnippetToCodeListing() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+    func testSnippetToCodeListing() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -989,8 +989,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         }
     }
     
-    func testSnippetSliceToCodeListing() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+    func testSnippetSliceToCodeListing() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -1013,8 +1013,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(l.code, ["func foo() {}"])
     }
 
-    func testNestedSnippetSliceToCodeListing() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+    func testNestedSnippetSliceToCodeListing() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/Snippets", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -1044,8 +1044,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(l.code, ["middle()"])
     }
     
-    func testSnippetSliceTrimsIndentation() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+    func testSnippetSliceTrimsIndentation() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/Snippets/SliceIndentation", sourceLanguage: .swift)
         let article = try XCTUnwrap(context.entity(with: reference).semantic as? Article)
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: reference)
@@ -1069,8 +1069,8 @@ class RenderNodeTranslatorTests: XCTestCase {
 
     }
     
-    func testRowAndColumn() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
+    func testRowAndColumn() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BookLikeContent")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/BestBook/MyArticle",
@@ -1098,8 +1098,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(row.columns.last?.content.count, 3)
     }
     
-    func testSmall() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
+    func testSmall() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BookLikeContent")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/BestBook/MyArticle",
@@ -1126,8 +1126,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         )
     }
     
-    func testTabNavigator() throws {
-        let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
+    func testTabNavigator() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BookLikeContent")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/BestBook/TabNavigatorArticle",
@@ -1163,8 +1163,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(tabNavigator.tabs[2].content.count, 1)
     }
     
-    func testRenderNodeMetadata() throws {
-         let (bundle, context) = try testBundleAndContext(named: "BookLikeContent")
+    func testRenderNodeMetadata() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "BookLikeContent")
          let reference = ResolvedTopicReference(
             bundleID: bundle.id,
              path: "/documentation/BestBook/MyArticle",
@@ -1239,8 +1239,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(roundTrippedArticle.metadata.role, "article")
      }
     
-    func testPageColorMetadataInSymbolExtension() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+    func testPageColorMetadataInSymbolExtension() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedManualAutomaticCuration")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/TestBed",
@@ -1255,8 +1255,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(roundTrippedSymbol.metadata.color?.standardColorIdentifier, "purple")
     }
 
-    func testTitleHeadingMetadataInSymbolExtension() throws {
-        let (bundle, context) = try testBundleAndContext(named: "MixedManualAutomaticCuration")
+    func testTitleHeadingMetadataInSymbolExtension() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "MixedManualAutomaticCuration")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: "/documentation/TestBed",
@@ -1272,7 +1272,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(roundTrippedSymbol.metadata.role, "collection")
     }
     
-    func testExpectedRoleHeadingIsAssigned() throws {
+    func testExpectedRoleHeadingIsAssigned() async throws {
         let catalog = Folder(
             name: "unit-test.docc",
             content: [
@@ -1334,7 +1334,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                 ),
             ]
         )
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
 
         func renderNodeArticleFromReferencePath(
             referencePath: String
@@ -1362,7 +1362,7 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.roleHeading, "Sample Code")
     }
     
-    func testExpectedRoleHeadingWhenAutomaticRoleHeadingIsDisabled() throws {
+    func testExpectedRoleHeadingWhenAutomaticRoleHeadingIsDisabled() async throws {
         let catalog = Folder(
             name: "unit-test.docc",
             content: [
@@ -1426,7 +1426,7 @@ class RenderNodeTranslatorTests: XCTestCase {
                 ),
             ]
         )
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
 
         func renderNodeArticleFromReferencePath(
             referencePath: String
@@ -1458,10 +1458,10 @@ class RenderNodeTranslatorTests: XCTestCase {
         XCTAssertEqual(renderNode.metadata.roleHeading, "Sample Code")
     }
 
-    func testEncodesOverloadsInRenderNode() throws {
+    func testEncodesOverloadsInRenderNode() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
 
-        let (bundle, context) = try testBundleAndContext(named: "OverloadedSymbols")
+        let (bundle, context) = try await testBundleAndContext(named: "OverloadedSymbols")
         
         let overloadPreciseIdentifiers = ["s:8ShapeKit14OverloadedEnumO19firstTestMemberNameySdSiF",
                                    "s:8ShapeKit14OverloadedEnumO19firstTestMemberNameySdSfF",
@@ -1496,8 +1496,8 @@ class RenderNodeTranslatorTests: XCTestCase {
         }
     }
     
-    func testAlternateRepresentationsRenderedAsVariants() throws {
-        let (bundle, context) = try loadBundle(catalog: Folder(
+    func testAlternateRepresentationsRenderedAsVariants() async throws {
+        let (bundle, context) = try await loadBundle(catalog: Folder(
             name: "unit-test.docc",
             content: [
                 TextFile(name: "Symbol.md", utf8Content: """

--- a/Tests/SwiftDocCTests/Rendering/RoleTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RoleTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -24,8 +24,8 @@ class RoleTests: XCTestCase {
         "/documentation/SideKit/SideClass/init()": "symbol",
     ]
     
-    func testNodeRoles() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
+    func testNodeRoles() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
 
         // Compile docs and verify contents
         for (path, expectedRole) in expectedRoles {
@@ -42,8 +42,8 @@ class RoleTests: XCTestCase {
         }
     }
     
-    func testDocumentationRenderReferenceRoles() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
+    func testDocumentationRenderReferenceRoles() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
 
         let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/documentation/MyKit", fragment: nil, sourceLanguage: .swift)
         let node = try context.entity(with: identifier)
@@ -55,8 +55,8 @@ class RoleTests: XCTestCase {
         XCTAssertEqual((renderNode.references["doc://org.swift.docc.example/documentation/Test-Bundle/article2"] as? TopicRenderReference)?.role, "collectionGroup")
     }
 
-    func testTutorialsRenderReferenceRoles() throws {
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
+    func testTutorialsRenderReferenceRoles() async throws {
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests")
 
         let identifier = ResolvedTopicReference(bundleID: "org.swift.docc.example", path: "/tutorials/Test-Bundle/TestTutorial", fragment: nil, sourceLanguage: .swift)
         let node = try context.entity(with: identifier)

--- a/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SampleDownloadTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -74,8 +74,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(text, "You can experiment with the code. Just use WiFi Access on your Mac to download WiFi access sample code.")
     }
 
-    func testParseSampleDownload() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
+    func testParseSampleDownload() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
         
         let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
         guard case .reference(identifier: let ident, isActive: true, overridingTitle: "Download", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
@@ -85,8 +85,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(ident.identifier, "https://example.com/sample.zip")
     }
 
-    func testParseSampleLocalDownload() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MyLocalSample")
+    func testParseSampleLocalDownload() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MyLocalSample")
         
         let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
         guard case .reference(identifier: let ident, isActive: true, overridingTitle: "Download", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
@@ -96,8 +96,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(ident.identifier, "plus.svg")
     }
 
-    func testSampleDownloadRoundtrip() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
+    func testSampleDownloadRoundtrip() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
 
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
@@ -125,8 +125,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(origIdent, decodedIdent)
     }
     
-    private func renderNodeFromSampleBundle(at referencePath: String) throws -> RenderNode {
-        let (bundle, context) = try testBundleAndContext(named: "SampleBundle")
+    private func renderNodeFromSampleBundle(at referencePath: String) async throws -> RenderNode {
+        let (bundle, context) = try await testBundleAndContext(named: "SampleBundle")
         let reference = ResolvedTopicReference(
             bundleID: bundle.id,
             path: referencePath,
@@ -137,8 +137,8 @@ class SampleDownloadTests: XCTestCase {
         return try XCTUnwrap(translator.visitArticle(article) as? RenderNode)
     }
 
-    func testSampleDownloadRelativeURL() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/RelativeURLSample")
+    func testSampleDownloadRelativeURL() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/RelativeURLSample")
         let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
         guard case .reference(identifier: let ident, isActive: true, overridingTitle: "Download", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
             XCTFail("Unexpected action in callToAction")
@@ -152,8 +152,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(downloadReference.url.description, "files/ExternalSample.zip")
     }
 
-    func testExternalLocationRoundtrip() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/RelativeURLSample")
+    func testExternalLocationRoundtrip() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/RelativeURLSample")
         let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
         guard case .reference(identifier: let ident, isActive: true, overridingTitle: "Download", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
             XCTFail("Unexpected action in callToAction")
@@ -178,8 +178,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(firstJson, finalJson)
     }
     
-    func testExternalLinkOnSampleCodePage() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MyExternalSample")
+    func testExternalLinkOnSampleCodePage() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MyExternalSample")
         let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
         guard case .reference(identifier: let identifier, isActive: true, overridingTitle: "View Source", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
             XCTFail("Unexpected action in callToAction")
@@ -191,8 +191,8 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(reference.url.description, "https://www.example.com/source-repository.git")
     }
     
-    func testExternalLinkOnRegularArticlePage() throws {
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MyArticle")
+    func testExternalLinkOnRegularArticlePage() async throws {
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MyArticle")
         let sampleCodeDownload = try XCTUnwrap(renderNode.sampleDownload)
         guard case .reference(identifier: let identifier, isActive: true, overridingTitle: "Visit", overridingTitleInlineContent: nil) = sampleCodeDownload.action else {
             XCTFail("Unexpected action in callToAction")
@@ -265,10 +265,10 @@ class SampleDownloadTests: XCTestCase {
         XCTAssertEqual(decodedReference.url, newURL)
     }
 
-    func testProjectFilesForCallToActionDirectives() throws {
+    func testProjectFilesForCallToActionDirectives() async throws {
         // Make sure that the `projectFiles()` method correctly returns the DownloadReference
         // created by the `@CallToAction` directive.
-        let renderNode = try renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
+        let renderNode = try await renderNodeFromSampleBundle(at: "/documentation/SampleBundle/MySample")
         let downloadReference = try XCTUnwrap(renderNode.projectFiles())
         XCTAssertEqual(downloadReference.url.description, "https://example.com/sample.zip")
     }

--- a/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/SymbolAvailabilityTests.swift
@@ -21,7 +21,7 @@ class SymbolAvailabilityTests: XCTestCase {
             symbolGraphOperatingSystemPlatformName: String,
             symbols: [SymbolGraph.Symbol],
             symbolName: String
-    ) throws -> [SymbolGraph.Symbol.Availability.AvailabilityItem] {
+    ) async throws -> [SymbolGraph.Symbol.Availability.AvailabilityItem] {
             let catalog = Folder(
                 name: "unit-test.docc",
                 content: [
@@ -36,7 +36,7 @@ class SymbolAvailabilityTests: XCTestCase {
                     )),
                 ]
             )
-            let (_, context) = try loadBundle(catalog: catalog)
+            let (_, context) = try await loadBundle(catalog: catalog)
             let reference = try XCTUnwrap(context.soleRootModuleReference).appendingPath(symbolName)
             let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
             return try XCTUnwrap(symbol.availability?.availability)
@@ -48,7 +48,7 @@ class SymbolAvailabilityTests: XCTestCase {
         symbolGraphEnvironmentName: String? = nil,
         symbols: [SymbolGraph.Symbol],
         symbolName: String
-    ) throws -> [AvailabilityRenderItem] {
+    ) async throws -> [AvailabilityRenderItem] {
         let catalog = Folder(
             name: "unit-test.docc",
             content: [
@@ -63,16 +63,16 @@ class SymbolAvailabilityTests: XCTestCase {
                 )),
             ]
         )
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let reference = try XCTUnwrap(context.soleRootModuleReference).appendingPath(symbolName)
         let node = try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: reference.path, sourceLanguage: .swift))
         var translator = RenderNodeTranslator(context: context, bundle: bundle, identifier: node.reference)
         return try XCTUnwrap((translator.visit(node.semantic as! Symbol) as! RenderNode).metadata.platformsVariants.defaultValue)
     }
     
-    func testSymbolGraphSymbolWithoutDeprecatedVersionAndIntroducedVersion() throws {
+    func testSymbolGraphSymbolWithoutDeprecatedVersionAndIntroducedVersion() async throws {
 
-        var availability = try renderNodeAvailability(
+        var availability = try await renderNodeAvailability(
             defaultAvailability: [],
             symbolGraphOperatingSystemPlatformName: "ios",
             symbols: [
@@ -93,7 +93,7 @@ class SymbolAvailabilityTests: XCTestCase {
             "Mac Catalyst <nil> - 1.2.3",
         ])
         
-        availability = try renderNodeAvailability(
+        availability = try await renderNodeAvailability(
             defaultAvailability: [
                 DefaultAvailability.ModuleAvailability(platformName: PlatformName(operatingSystemName: "iOS"), platformVersion: "1.2.3")
             ],
@@ -122,9 +122,9 @@ class SymbolAvailabilityTests: XCTestCase {
         ])
     }
     
-    func testSymbolGraphSymbolWithObsoleteVersion() throws {
+    func testSymbolGraphSymbolWithObsoleteVersion() async throws {
 
-        let availability = try renderNodeAvailability(
+        let availability = try await renderNodeAvailability(
             defaultAvailability: [],
             symbolGraphOperatingSystemPlatformName: "ios",
             symbols: [

--- a/Tests/SwiftDocCTests/Rendering/TermListTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/TermListTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -47,7 +47,7 @@ class TermListTests: XCTestCase {
         XCTAssertEqual(l.items.count, 4)
     }
     
-    func testLinksAndCodeVoiceAsTerms() throws {
+    func testLinksAndCodeVoiceAsTerms() async throws {
         let catalog =
             Folder(name: "unit-test.docc", content: [
                 TextFile(name: "Article.md", utf8Content: """
@@ -86,7 +86,7 @@ class TermListTests: XCTestCase {
         
         var configuration = DocumentationContext.Configuration()
         configuration.externalDocumentationConfiguration.sources = ["com.external.testbundle": resolver]
-        let (bundle, context) = try loadBundle(catalog: catalog, configuration: configuration)
+        let (bundle, context) = try await loadBundle(catalog: catalog, configuration: configuration)
         
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/unit-test/Article", sourceLanguage: .swift)
         let entity = try context.entity(with: reference)
@@ -154,14 +154,14 @@ class TermListTests: XCTestCase {
         }
     }
     
-    func testRenderingListWithAllTermListItems() throws {
+    func testRenderingListWithAllTermListItems() async throws {
         let jsonFixtureItems = try discussionContents(fileName: "term-lists-2")
         guard jsonFixtureItems.count == 1 else {
             XCTFail("Discussion section didn't have expected number of contents")
             return
         }
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """
@@ -197,14 +197,14 @@ class TermListTests: XCTestCase {
         XCTAssertEqual(jsonFixtureItems, result)
     }
     
-    func testRenderingListWithInterleavedListItems() throws {
+    func testRenderingListWithInterleavedListItems() async throws {
         let jsonFixtureItems = try discussionContents(fileName: "term-lists-3")
         guard jsonFixtureItems.count == 4 else {
             XCTFail("Discussion section didn't have expected number of contents")
             return
         }
         
-        let (bundle, context) = try testBundleAndContext()
+        let (bundle, context) = try await testBundleAndContext()
         var renderContentCompiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
         
         let source = """

--- a/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleSymbolMentionsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -86,8 +86,8 @@ class ArticleSymbolMentionsTests: XCTestCase {
         }
     }
 
-    func testSymbolLinkCollectorEnabled() throws {
-        let (bundle, context) = try createMentionedInTestBundle()
+    func testSymbolLinkCollectorEnabled() async throws {
+        let (bundle, context) = try await createMentionedInTestBundle()
 
         // The test bundle currently only has one article with symbol mentions
         // in the abstract/discussion.
@@ -108,7 +108,7 @@ class ArticleSymbolMentionsTests: XCTestCase {
         XCTAssertEqual(mentioningArticle, gottenArticle)
     }
 
-    func testSymbolLinkCollectorDisabled() throws {
+    func testSymbolLinkCollectorDisabled() async throws {
         let currentFeatureFlags = FeatureFlags.current
         addTeardownBlock {
             FeatureFlags.current = currentFeatureFlags
@@ -116,7 +116,7 @@ class ArticleSymbolMentionsTests: XCTestCase {
         FeatureFlags.current.isMentionedInEnabled = false
         
         
-        let (bundle, context) = try createMentionedInTestBundle()
+        let (bundle, context) = try await createMentionedInTestBundle()
         XCTAssertTrue(context.articleSymbolMentions.mentions.isEmpty)
 
         let mentionedSymbol = ResolvedTopicReference(

--- a/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ArticleTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import Markdown
 
 class ArticleTests: XCTestCase {
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
         # This is my article
 
@@ -22,7 +22,7 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
@@ -33,7 +33,7 @@ class ArticleTests: XCTestCase {
         XCTAssertEqual((article?.discussion?.content ?? []).map { $0.detachedFromParent.format() }.joined(separator: "\n"), "Here’s an overview.")
     }
     
-    func testWithExplicitOverviewHeading() throws {
+    func testWithExplicitOverviewHeading() async throws {
         let source = """
         # This is my article
 
@@ -44,7 +44,7 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
@@ -62,7 +62,7 @@ class ArticleTests: XCTestCase {
         }
     }
     
-    func testWithExplicitCustomHeading() throws {
+    func testWithExplicitCustomHeading() async throws {
         let source = """
         # This is my article
 
@@ -73,7 +73,7 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
@@ -92,12 +92,12 @@ class ArticleTests: XCTestCase {
         }
     }
     
-    func testOnlyTitleArticle() throws {
+    func testOnlyTitleArticle() async throws {
         let source = """
         # This is my article
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
@@ -108,14 +108,14 @@ class ArticleTests: XCTestCase {
         XCTAssertNil(article?.discussion)
     }
     
-    func testNoAbstract() throws {
+    func testNoAbstract() async throws {
         let source = """
         # This is my article
 
         - This is not an abstract.
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
@@ -126,14 +126,14 @@ class ArticleTests: XCTestCase {
         XCTAssertEqual((article?.discussion?.content ?? []).map { $0.detachedFromParent.format() }.joined(separator: "\n"), "- This is not an abstract.")
     }
     
-    func testSolutionForTitleMissingIndentation() throws {
+    func testSolutionForTitleMissingIndentation() async throws {
         let source = """
          My article
 
          This is my article
          """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
 
@@ -148,12 +148,12 @@ class ArticleTests: XCTestCase {
         XCTAssertEqual(replacement.replacement, "# My article")
     }
 
-    func testSolutionForEmptyArticle() throws {
+    func testSolutionForEmptyArticle() async throws {
         let source = """
          
         """
         let document = Document(parsing: source, options: [])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
 
@@ -168,7 +168,7 @@ class ArticleTests: XCTestCase {
         XCTAssertEqual(replacement.replacement, "# <#Title#>")
     }
     
-    func testArticleWithDuplicateOptions() throws {
+    func testArticleWithDuplicateOptions() async throws {
         let source = """
         # Article
         
@@ -185,7 +185,7 @@ class ArticleTests: XCTestCase {
         Here's an overview.
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article)
@@ -209,7 +209,7 @@ class ArticleTests: XCTestCase {
         XCTAssertEqual(article?.options[.local]?.automaticSeeAlsoEnabled, false)
     }
     
-    func testDisplayNameDirectiveIsRemoved() throws {
+    func testDisplayNameDirectiveIsRemoved() async throws {
         let source = """
         # Root
         
@@ -222,7 +222,7 @@ class ArticleTests: XCTestCase {
         Adding @DisplayName to an article will result in a warning.
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         

--- a/Tests/SwiftDocCTests/Semantics/AssessmentsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/AssessmentsTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class AssessmentsTests: XCTestCase {
-    func testEmptyAndLonely() throws {
+    func testEmptyAndLonely() async throws {
         let source = "@Assessments"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()

--- a/Tests/SwiftDocCTests/Semantics/CallToActionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/CallToActionTests.swift
@@ -15,13 +15,13 @@ import Markdown
 @testable import SwiftDocC
 
 class CallToActionTests: XCTestCase {
-    func testInvalidWithNoArguments() throws {
+    func testInvalidWithNoArguments() async throws {
         let source = "@CallToAction"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+        let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
         directive.map { directive in
             var problems = [Problem]()
@@ -35,13 +35,13 @@ class CallToActionTests: XCTestCase {
         }
     }
 
-    func testInvalidWithoutLink() throws {
-        func assertMissingLink(source: String) throws {
+    func testInvalidWithoutLink() async throws {
+        func assertMissingLink(source: String) async throws {
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
 
-            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
             directive.map { directive in
                 var problems = [Problem]()
@@ -53,17 +53,17 @@ class CallToActionTests: XCTestCase {
                 XCTAssertTrue(diagnosticIdentifiers.contains("org.swift.docc.\(CallToAction.self).missingLink"))
             }
         }
-        try assertMissingLink(source: "@CallToAction(label: \"Button\")")
-        try assertMissingLink(source: "@CallToAction(purpose: download)")
+        try await assertMissingLink(source: "@CallToAction(label: \"Button\")")
+        try await assertMissingLink(source: "@CallToAction(purpose: download)")
     }
 
-    func testInvalidWithoutLabel() throws {
-        func assertMissingLabel(source: String) throws {
+    func testInvalidWithoutLabel() async throws {
+        func assertMissingLabel(source: String) async throws {
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
 
-            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
             directive.map { directive in
                 var problems = [Problem]()
@@ -75,17 +75,17 @@ class CallToActionTests: XCTestCase {
                 XCTAssertTrue(diagnosticIdentifiers.contains("org.swift.docc.\(CallToAction.self).missingLabel"))
             }
         }
-        try assertMissingLabel(source: "@CallToAction(url: \"https://example.com/sample.zip\"")
-        try assertMissingLabel(source: "@CallToAction(file: \"Downloads/plus.svg\"")
+        try await assertMissingLabel(source: "@CallToAction(url: \"https://example.com/sample.zip\"")
+        try await assertMissingLabel(source: "@CallToAction(file: \"Downloads/plus.svg\"")
     }
 
-    func testInvalidTooManyLinks() throws {
+    func testInvalidTooManyLinks() async throws {
         let source = "@CallToAction(url: \"https://example.com/sample.zip\", file: \"Downloads/plus.svg\", purpose: download)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+        let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
         directive.map { directive in
             var problems = [Problem]()
@@ -98,13 +98,13 @@ class CallToActionTests: XCTestCase {
         }
     }
 
-    func testValidDirective() throws {
-        func assertValidDirective(source: String) throws {
+    func testValidDirective() async throws {
+        func assertValidDirective(source: String) async throws {
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
 
-            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
             directive.map { directive in
                 var problems = [Problem]()
@@ -131,17 +131,17 @@ class CallToActionTests: XCTestCase {
 
         for link in validLinks {
             for label in validLabels {
-                try assertValidDirective(source: "@CallToAction(\(link), \(label))")
+                try await assertValidDirective(source: "@CallToAction(\(link), \(label))")
             }
         }
     }
 
-    func testDefaultLabel() throws {
-        func assertExpectedLabel(source: String, expectedDefaultLabel: String, expectedSampleCodeLabel: String) throws {
+    func testDefaultLabel() async throws {
+        func assertExpectedLabel(source: String, expectedDefaultLabel: String, expectedSampleCodeLabel: String) async throws {
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = try XCTUnwrap(document.child(at: 0) as? BlockDirective)
 
-            let (bundle, _) = try testBundleAndContext(named: "SampleBundle")
+            let (bundle, _) = try await testBundleAndContext(named: "SampleBundle")
 
             var problems = [Problem]()
             XCTAssertEqual(CallToAction.directiveName, directive.name)
@@ -173,7 +173,7 @@ class CallToActionTests: XCTestCase {
 
         for (arg, defaultLabel, sampleCodeLabel) in validLabels {
             let directive = "@CallToAction(file: \"Downloads/plus.svg\", \(arg))"
-            try assertExpectedLabel(
+            try await assertExpectedLabel(
                 source: directive,
                 expectedDefaultLabel: defaultLabel,
                 expectedSampleCodeLabel: sampleCodeLabel

--- a/Tests/SwiftDocCTests/Semantics/ChapterTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ChapterTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class ChapterTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @Chapter
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let chapter = Chapter(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(chapter)
@@ -31,7 +31,7 @@ class ChapterTests: XCTestCase {
         XCTAssert(problems.map { $0.diagnostic.severity }.allSatisfy { $0 == .warning })
     }
     
-    func testMultipleMedia() throws {
+    func testMultipleMedia() async throws {
         let chapterName = "Chapter 1"
         let source = """
 @Chapter(name: "\(chapterName)") {
@@ -42,7 +42,7 @@ class ChapterTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let chapter = Chapter(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertEqual(1, problems.count)
@@ -61,7 +61,7 @@ class ChapterTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let chapterName = "Chapter 1"
         let source = """
 @Chapter(name: "\(chapterName)") {
@@ -71,7 +71,7 @@ class ChapterTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let chapter = Chapter(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertTrue(problems.isEmpty)
@@ -82,8 +82,8 @@ class ChapterTests: XCTestCase {
         }
     }
     
-    func testDuplicateTutorialReferences() throws {
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testDuplicateTutorialReferences() async throws {
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         /*
          The test bundle contains the duplicate tutorial references in TestOverview:

--- a/Tests/SwiftDocCTests/Semantics/ChoiceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ChoiceTests.swift
@@ -14,13 +14,13 @@ import Markdown
 import SwiftDocCTestUtilities
 
 class ChoiceTests: XCTestCase {
-    func testInvalidEmpty() throws {
+    func testInvalidEmpty() async throws {
         let source = "@Choice"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -35,7 +35,7 @@ class ChoiceTests: XCTestCase {
         }
     }
     
-    func testInvalidMissingContent() throws {
+    func testInvalidMissingContent() async throws {
         let source = """
 @Choice(isCorrect: true) {
    @Justification {
@@ -47,7 +47,7 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -60,7 +60,7 @@ class ChoiceTests: XCTestCase {
         }
     }
     
-    func testInvalidMissingJustification() throws {
+    func testInvalidMissingJustification() async throws {
         let source = """
 @Choice(isCorrect: true) {
    This is some content.
@@ -70,7 +70,7 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -84,7 +84,7 @@ class ChoiceTests: XCTestCase {
         }
     }
     
-    func testInvalidMissingIsCorrect() throws {
+    func testInvalidMissingIsCorrect() async throws {
         let source = """
 @Choice {
    This is some content.
@@ -96,7 +96,7 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -110,7 +110,7 @@ class ChoiceTests: XCTestCase {
         }
     }
     
-    func testInvalidIsCorrect() throws {
+    func testInvalidIsCorrect() async throws {
         let source = """
 @Choice(isCorrect: blah) {
    This is some content.
@@ -122,7 +122,7 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -139,7 +139,7 @@ class ChoiceTests: XCTestCase {
         }
     }
     
-    func testValidParagraph() throws {
+    func testValidParagraph() async throws {
         let source = """
 @Choice(isCorrect: true) {
    This is some content.
@@ -152,7 +152,7 @@ class ChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -172,7 +172,7 @@ Choice @1:1-6:2 isCorrect: true
         }
     }
     
-    func testValidCode() throws {
+    func testValidCode() async throws {
         let source = """
 @Choice(isCorrect: true) {
    ```swift
@@ -188,7 +188,7 @@ Choice @1:1-6:2 isCorrect: true
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -208,7 +208,7 @@ Choice @1:1-9:2 isCorrect: true
         }
     }
     
-    func testValidImage() throws {
+    func testValidImage() async throws {
         let source = """
 @Choice(isCorrect: true) {
    @Image(source: blah.png, alt: blah)
@@ -222,7 +222,7 @@ Choice @1:1-9:2 isCorrect: true
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try loadBundle(catalog: Folder(name: "unit-test.docc", content: [
+        let (bundle, _) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: [
             InfoPlist(identifier: "org.swift.docc.example"),
             DataFile(name: "blah.png", data: Data()),
         ]))

--- a/Tests/SwiftDocCTests/Semantics/CodeTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/CodeTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class CodeTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Code"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let code = Code(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(code)

--- a/Tests/SwiftDocCTests/Semantics/ContentAndMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ContentAndMediaTests.swift
@@ -13,20 +13,20 @@ import XCTest
 import Markdown
 
 class ContentAndMediaTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @ContentAndMedia {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
         XCTAssertEqual(0, problems.count)
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
 @ContentAndMedia {
    
@@ -37,7 +37,7 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
@@ -47,7 +47,7 @@ class ContentAndMediaTests: XCTestCase {
         }
     }
     
-    func testTrailingMiddleMediaPosition() throws {
+    func testTrailingMiddleMediaPosition() async throws {
         let source = """
 @ContentAndMedia {
    
@@ -58,7 +58,7 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
@@ -68,7 +68,7 @@ class ContentAndMediaTests: XCTestCase {
         }
     }
     
-    func testTrailingMediaPosition() throws {
+    func testTrailingMediaPosition() async throws {
         let source = """
 @ContentAndMedia {
    
@@ -81,7 +81,7 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)
@@ -91,7 +91,7 @@ class ContentAndMediaTests: XCTestCase {
         }
     }
 
-    func testDeprecatedArguments() throws {
+    func testDeprecatedArguments() async throws {
         let source = """
 @ContentAndMedia(layout: horizontal, eyebrow: eyebrow, title: title) {
 
@@ -102,7 +102,7 @@ class ContentAndMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let contentAndMedia = ContentAndMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(contentAndMedia)

--- a/Tests/SwiftDocCTests/Semantics/DisplayNameTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DisplayNameTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class DisplayNameTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@DisplayName"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(displayName)
@@ -28,11 +28,11 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.unlabeled", problems.first?.diagnostic.identifier)
     }
     
-    func testUnlabeledArgumentValue() throws {
+    func testUnlabeledArgumentValue() async throws {
         let source = "@DisplayName(\"Custom Symbol Name\")"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
@@ -40,11 +40,11 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual(displayName?.style, .conceptual)
     }
     
-    func testConceptualStyleArgumentValue() throws {
+    func testConceptualStyleArgumentValue() async throws {
         let source = "@DisplayName(\"Custom Symbol Name\", style: conceptual)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
@@ -52,11 +52,11 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual(displayName?.style, .conceptual)
     }
     
-    func testSymbolStyleArgumentValue() throws {
+    func testSymbolStyleArgumentValue() async throws {
         let source = "@DisplayName(\"Custom Symbol Name\", style: symbol)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
@@ -64,11 +64,11 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual(displayName?.style, .symbol)
     }
     
-    func testUnknownStyleArgumentValue() throws {
+    func testUnknownStyleArgumentValue() async throws {
         let source = "@DisplayName(\"Custom Symbol Name\", style: somethingUnknown)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName)
@@ -77,11 +77,11 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.style.ConversionFailed", problems.first?.diagnostic.identifier)
     }
     
-    func testExtraArguments() throws {
+    func testExtraArguments() async throws {
         let source = "@DisplayName(\"Custom Symbol Name\", argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName, "Even if there are warnings we can create a displayName value")
@@ -90,7 +90,7 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.UnknownArgument", problems.first?.diagnostic.identifier)
     }
     
-    func testExtraDirective() throws {
+    func testExtraDirective() async throws {
         let source = """
         @DisplayName(\"Custom Symbol Name\") {
            @Image
@@ -98,7 +98,7 @@ class DisplayNameTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName, "Even if there are warnings we can create a DisplayName value")
@@ -108,7 +108,7 @@ class DisplayNameTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.DisplayName.NoInnerContentAllowed", problems.last?.diagnostic.identifier)
     }
     
-    func testExtraContent() throws {
+    func testExtraContent() async throws {
         let source = """
         @DisplayName(\"Custom Symbol Name\") {
            Some text
@@ -116,7 +116,7 @@ class DisplayNameTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let displayName = DisplayName(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(displayName, "Even if there are warnings we can create a DisplayName value")

--- a/Tests/SwiftDocCTests/Semantics/DocumentationExtensionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DocumentationExtensionTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class DocumentationExtensionTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@DocumentationExtension"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(options)
@@ -28,11 +28,11 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.mergeBehavior", problems.first?.diagnostic.identifier)
     }
     
-    func testAppendArgumentValue() throws {
+    func testAppendArgumentValue() async throws {
         let source = "@DocumentationExtension(mergeBehavior: append)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options)
@@ -41,11 +41,11 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual(options?.behavior, .append)
     }
     
-    func testOverrideArgumentValue() throws {
+    func testOverrideArgumentValue() async throws {
         let source = "@DocumentationExtension(mergeBehavior: override)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options)
@@ -53,11 +53,11 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual(options?.behavior, .override)
     }
     
-    func testUnknownArgumentValue() throws {
+    func testUnknownArgumentValue() async throws {
         let source = "@DocumentationExtension(mergeBehavior: somethingUnknown )"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(options)
@@ -66,11 +66,11 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.mergeBehavior.ConversionFailed", problems.first?.diagnostic.identifier)
     }
     
-    func testExtraArguments() throws {
+    func testExtraArguments() async throws {
         let source = "@DocumentationExtension(mergeBehavior: override, argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options, "Even if there are warnings we can create an options value")
@@ -79,7 +79,7 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.UnknownArgument", problems.first?.diagnostic.identifier)
     }
     
-    func testExtraDirective() throws {
+    func testExtraDirective() async throws {
         let source = """
         @DocumentationExtension(mergeBehavior: override) {
            @Image
@@ -87,7 +87,7 @@ class DocumentationExtensionTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options, "Even if there are warnings we can create a DocumentationExtension value")
@@ -97,7 +97,7 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.DocumentationExtension.NoInnerContentAllowed", problems.last?.diagnostic.identifier)
     }
     
-    func testExtraContent() throws {
+    func testExtraContent() async throws {
         let source = """
         @DocumentationExtension(mergeBehavior: override) {
            Some text
@@ -105,7 +105,7 @@ class DocumentationExtensionTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(options, "Even if there are warnings we can create a DocumentationExtension value")
@@ -114,14 +114,14 @@ class DocumentationExtensionTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.DocumentationExtension.NoInnerContentAllowed", problems.first?.diagnostic.identifier)
     }
     
-    func testIncorrectArgumentLabel() throws {
+    func testIncorrectArgumentLabel() async throws {
         let source = """
         @DocumentationExtension(merge: override)
         """
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let options = DocumentationExtension(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(options)

--- a/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@ import SwiftDocCTestUtilities
 @testable import SymbolKit
 
 class DoxygenTests: XCTestCase {
-    func testDoxygenDiscussionAndNote() throws {
+    func testDoxygenDiscussionAndNote() async throws {
         let documentationLines: [SymbolGraph.LineList.Line] = """
             This is an abstract.
             @abstract This is description with abstract.
@@ -88,7 +88,7 @@ class DoxygenTests: XCTestCase {
                 )),
             ])
 
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let reference = ResolvedTopicReference(bundleID: bundle.id, path: "/documentation/ModuleName/SomeClass", sourceLanguage: .swift)
 
         // Verify the expected content in the in-memory model

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtLeastOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtLeastOneTests.swift
@@ -49,13 +49,13 @@ final class TestChild: Semantic, DirectiveConvertible {
 }
 
 class HasAtLeastOneTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Parent"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         do {
             var problems = [Problem]()
@@ -83,7 +83,7 @@ class HasAtLeastOneTests: XCTestCase {
         }
     }
     
-    func testOne() throws {
+    func testOne() async throws {
         let source = """
 @Parent {
    @Child
@@ -94,7 +94,7 @@ class HasAtLeastOneTests: XCTestCase {
         var problems = [Problem]()
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
@@ -104,7 +104,7 @@ class HasAtLeastOneTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testMany() throws {
+    func testMany() async throws {
         let source = """
 @Parent {
    @Child
@@ -117,7 +117,7 @@ class HasAtLeastOneTests: XCTestCase {
         var problems = [Problem]()
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)
@@ -127,7 +127,7 @@ class HasAtLeastOneTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testAlternateDirectiveTitle() throws {
+    func testAlternateDirectiveTitle() async throws {
         let source = """
 @AlternateParent {
    @AlternateChild
@@ -138,7 +138,7 @@ class HasAtLeastOneTests: XCTestCase {
         var problems = [Problem]()
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             let (matches, remainder) = Semantic.Analyses.HasAtLeastOne<TestParent, TestChild>(severityIfNotFound: .error).analyze(directive, children: directive.children, source: nil, for: bundle, problems: &problems)

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtMostOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasAtMostOneTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class HasAtMostOneTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Parent"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -30,7 +30,7 @@ class HasAtMostOneTests: XCTestCase {
         }
     }
     
-    func testHasOne() throws {
+    func testHasOne() async throws {
         let source = """
 @Parent {
    @Child
@@ -40,7 +40,7 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -51,7 +51,7 @@ class HasAtMostOneTests: XCTestCase {
         }
     }
     
-    func testHasMany() throws {
+    func testHasMany() async throws {
         let source = """
 @Parent {
    @Child
@@ -63,7 +63,7 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -80,7 +80,7 @@ class HasAtMostOneTests: XCTestCase {
         }
     }
     
-    func testAlternateDirectiveTitle() throws {
+    func testAlternateDirectiveTitle() async throws {
         let source = """
 @AlternateParent {
    @AlternateChild
@@ -90,7 +90,7 @@ class HasAtMostOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasExactlyOneTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasExactlyOneTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class HasExactlyOneTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Parent"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -40,7 +40,7 @@ class HasExactlyOneTests: XCTestCase {
         }
     }
     
-    func testHasOne() throws {
+    func testHasOne() async throws {
         let source = """
 @Parent {
    @Child
@@ -50,7 +50,7 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -61,7 +61,7 @@ class HasExactlyOneTests: XCTestCase {
         }
     }
     
-    func testHasMany() throws {
+    func testHasMany() async throws {
         let source = """
 @Parent {
    @Child
@@ -73,7 +73,7 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -92,7 +92,7 @@ class HasExactlyOneTests: XCTestCase {
         }
     }
     
-    func testAlternateDirectiveTitle() throws {
+    func testAlternateDirectiveTitle() async throws {
         let source = """
 @AlternateParent {
    @AlternateChild
@@ -102,7 +102,7 @@ class HasExactlyOneTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()

--- a/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlySequentialHeadingsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/General Purpose Analyses/HasOnlySequentialHeadingsTests.swift
@@ -15,7 +15,7 @@ import Markdown
 class HasOnlySequentialHeadingsTests: XCTestCase {
     private let containerDirective = BlockDirective(name: "TestContainer")
     
-    func testNoHeadings() throws {
+    func testNoHeadings() async throws {
         let source = """
 asdf
 
@@ -27,7 +27,7 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         var problems: [Problem] = []
         Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
@@ -35,7 +35,7 @@ some more *stuff*
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testValidHeadings() throws {
+    func testValidHeadings() async throws {
         let source = """
 ## H2
 ### H3
@@ -50,7 +50,7 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         var problems: [Problem] = []
         Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
@@ -58,14 +58,14 @@ some more *stuff*
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testHeadingLevelTooLow() throws {
+    func testHeadingLevelTooLow() async throws {
         let source = """
 # H1
 # H1
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         var problems: [Problem] = []
         Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)
@@ -77,7 +77,7 @@ some more *stuff*
                        ])
     }
     
-    func testHeadingSkipsLevel() throws {
+    func testHeadingSkipsLevel() async throws {
             let source = """
 ## H2
 #### H4
@@ -86,7 +86,7 @@ some more *stuff*
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
 
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         var problems: [Problem] = []
         Semantic.Analyses.HasOnlySequentialHeadings<TutorialArticle>(severityIfFound: .warning, startingFromLevel: 2).analyze(containerDirective, children: document.children, source: nil, for: bundle, problems: &problems)

--- a/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ImageMediaTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class ImageMediaTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @Image
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(image)
@@ -30,7 +30,7 @@ class ImageMediaTests: XCTestCase {
         ], problems.map { $0.diagnostic.identifier })
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let imageSource = "/path/to/image"
         let alt = "This is an image"
         let source = """
@@ -38,7 +38,7 @@ class ImageMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(image)
@@ -49,7 +49,7 @@ class ImageMediaTests: XCTestCase {
         }
     }
 
-    func testSpacesInSource() throws {
+    func testSpacesInSource() async throws {
         for imageSource in ["my image.png", "my%20image.png"] {
             let alt = "This is an image"
             let source = """
@@ -57,7 +57,7 @@ class ImageMediaTests: XCTestCase {
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, _) = try testBundleAndContext()
+            let (bundle, _) = try await testBundleAndContext()
             var problems = [Problem]()
             let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(image)
@@ -69,13 +69,13 @@ class ImageMediaTests: XCTestCase {
         }
     }
     
-    func testIncorrectArgumentLabels() throws {
+    func testIncorrectArgumentLabels() async throws {
         let source = """
         @Image(imgSource: "/img/path", altText: "Text")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let image = ImageMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(image)
@@ -94,9 +94,9 @@ class ImageMediaTests: XCTestCase {
         }
     }
     
-    func testRenderImageDirectiveInReferenceMarkup() throws {
+    func testRenderImageDirectiveInReferenceMarkup() async throws {
         do {
-            let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+            let (renderedContent, problems, image) = try await parseDirective(ImageMedia.self, in: "BookLikeContent") {
                 """
                 @Image(source: "figure1")
                 """
@@ -120,7 +120,7 @@ class ImageMediaTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+            let (renderedContent, problems, image) = try await parseDirective(ImageMedia.self, in: "BookLikeContent") {
                 """
                 @Image(source: "unknown-image")
                 """
@@ -133,8 +133,8 @@ class ImageMediaTests: XCTestCase {
         }
     }
     
-    func testRenderImageDirectiveWithCaption() throws {
-        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+    func testRenderImageDirectiveWithCaption() async throws {
+        let (renderedContent, problems, image) = try await parseDirective(ImageMedia.self, in: "BookLikeContent") {
             """
             @Image(source: "figure1") {
                 This is my caption.
@@ -159,8 +159,8 @@ class ImageMediaTests: XCTestCase {
         )
     }
     
-    func testImageDirectiveDiagnosesDeviceFrameByDefault() throws {
-        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+    func testImageDirectiveDiagnosesDeviceFrameByDefault() async throws {
+        let (renderedContent, problems, image) = try await parseDirective(ImageMedia.self, in: "BookLikeContent") {
             """
             @Image(source: "figure1", deviceFrame: phone)
             """
@@ -183,10 +183,10 @@ class ImageMediaTests: XCTestCase {
         )
     }
     
-    func testRenderImageDirectiveWithDeviceFrame() throws {
+    func testRenderImageDirectiveWithDeviceFrame() async throws {
         enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
         
-        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+        let (renderedContent, problems, image) = try await parseDirective(ImageMedia.self, in: "BookLikeContent") {
             """
             @Image(source: "figure1", deviceFrame: phone)
             """
@@ -209,10 +209,10 @@ class ImageMediaTests: XCTestCase {
         )
     }
     
-    func testRenderImageDirectiveWithDeviceFrameAndCaption() throws {
+    func testRenderImageDirectiveWithDeviceFrameAndCaption() async throws {
         enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
         
-        let (renderedContent, problems, image) = try parseDirective(ImageMedia.self, in: "BookLikeContent") {
+        let (renderedContent, problems, image) = try await parseDirective(ImageMedia.self, in: "BookLikeContent") {
             """
             @Image(source: "figure1", deviceFrame: laptop) {
                 This is my caption.
@@ -237,9 +237,9 @@ class ImageMediaTests: XCTestCase {
         )
     }
     
-    func testImageDirectiveDoesNotResolveVideoReference() throws {
+    func testImageDirectiveDoesNotResolveVideoReference() async throws {
         // First check that the Video exists
-        let (_, videoProblems, _) = try parseDirective(VideoMedia.self, in: "LegacyBundle_DoNotUseInNewTests") {
+        let (_, videoProblems, _) = try await parseDirective(VideoMedia.self, in: "LegacyBundle_DoNotUseInNewTests") {
             """
             @Video(source: "introvideo")
             """
@@ -248,7 +248,7 @@ class ImageMediaTests: XCTestCase {
         XCTAssertEqual(videoProblems, [])
         
         // Then check that it doesn't resolve as an image
-        let (renderedContent, imageProblems, image) = try parseDirective(ImageMedia.self, in: "LegacyBundle_DoNotUseInNewTests") {
+        let (renderedContent, imageProblems, image) = try await parseDirective(ImageMedia.self, in: "LegacyBundle_DoNotUseInNewTests") {
             """
             @Image(source: "introvideo")
             """

--- a/Tests/SwiftDocCTests/Semantics/IntroTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/IntroTests.swift
@@ -13,11 +13,11 @@ import XCTest
 import Markdown
 
 class IntroTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Intro"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(intro)
@@ -26,7 +26,7 @@ class IntroTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.title", problems[0].diagnostic.identifier)
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let videoPath = "/path/to/video"
         let imagePath = "/path/to/image"
         let posterPath = "/path/to/poster"
@@ -42,7 +42,7 @@ class IntroTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(intro)
@@ -56,7 +56,7 @@ class IntroTests: XCTestCase {
         }
     }
     
-    func testIncorrectArgumentLabel() throws {
+    func testIncorrectArgumentLabel() async throws {
         let source = """
         @Intro(titleText: "Title") {
           Here is a paragraph.
@@ -68,7 +68,7 @@ class IntroTests: XCTestCase {
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let intro = Intro(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(intro)

--- a/Tests/SwiftDocCTests/Semantics/JustificationTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/JustificationTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class JustificationTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Justification"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -34,7 +34,7 @@ class JustificationTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
 @Justification(reaction: "Correct!") {
    Here is some content.
@@ -44,7 +44,7 @@ class JustificationTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()

--- a/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MarkupReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -13,8 +13,8 @@ import XCTest
 import Markdown
 
 class MarkupReferenceResolverTests: XCTestCase {
-    func testArbitraryReferenceInComment() throws {
-        let (bundle, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+    func testArbitraryReferenceInComment() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         let source = """
         @Comment {
             ``hello`` and ``world`` are 2 arbitrary symbol links.
@@ -28,8 +28,8 @@ class MarkupReferenceResolverTests: XCTestCase {
         XCTAssertEqual(0, resolver.problems.count)
     }
 
-    func testDuplicatedDiagnosticForExtensionFile() throws {
-        let (_, context) = try testBundleAndContext(named: "ExtensionArticleBundle")
+    func testDuplicatedDiagnosticForExtensionFile() async throws {
+        let (_, context) = try await testBundleAndContext(named: "ExtensionArticleBundle")
         // Before #733, symbols with documentation extension files emitted duplicated problems:
         // - one with a source location in the in-source documentation comment
         // - one with a source location in the documentation extension file.

--- a/Tests/SwiftDocCTests/Semantics/MetadataAlternateRepresentationTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAlternateRepresentationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,9 +15,9 @@ import Markdown
 @testable import SwiftDocC
 
 class MetadataAlternateRepresentationTests: XCTestCase {
-    func testValidLocalLink() throws {
+    func testValidLocalLink() async throws {
         for link in ["``MyClass/property``", "MyClass/property"] {
-            let (problems, metadata) = try parseDirective(Metadata.self) {
+            let (problems, metadata) = try await parseDirective(Metadata.self) {
                 """
                 @Metadata {
                     @AlternateRepresentation(\(link))
@@ -33,8 +33,8 @@ class MetadataAlternateRepresentationTests: XCTestCase {
         }
     }
         
-    func testValidExternalLinkReference() throws {
-        let (problems, metadata) = try parseDirective(Metadata.self) {
+    func testValidExternalLinkReference() async throws {
+        let (problems, metadata) = try await parseDirective(Metadata.self) {
             """
             @Metadata {
                 @AlternateRepresentation("doc://com.example/documentation/MyClass/property")
@@ -49,8 +49,8 @@ class MetadataAlternateRepresentationTests: XCTestCase {
         XCTAssertEqual(alternateRepresentation.reference.url, URL(string: "doc://com.example/documentation/MyClass/property"))
     }
 
-    func testInvalidTopicReference() throws {
-        let (problems, _) = try parseDirective(Metadata.self) {
+    func testInvalidTopicReference() async throws {
+        let (problems, _) = try await parseDirective(Metadata.self) {
             """
             @Metadata {
                 @AlternateRepresentation("doc://")

--- a/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataAvailabilityTests.swift
@@ -15,10 +15,10 @@ import Markdown
 @testable import SwiftDocC
 
 class MetadataAvailabilityTests: XCTestCase {
-    func testInvalidWithNoArguments() throws {
+    func testInvalidWithNoArguments() async throws {
         let source = "@Available"
         
-        try assertDirective(Metadata.Availability.self, source: source) { directive, problems in
+        try await assertDirective(Metadata.Availability.self, source: source) { directive, problems in
             XCTAssertNil(directive)
             
             XCTAssertEqual(2, problems.count)
@@ -32,7 +32,7 @@ class MetadataAvailabilityTests: XCTestCase {
         }
     }
 
-    func testInvalidDuplicateIntroduced() throws {
+    func testInvalidDuplicateIntroduced() async throws {
         for platform in Metadata.Availability.Platform.defaultCases {
             let source = """
             @Metadata {
@@ -40,7 +40,7 @@ class MetadataAvailabilityTests: XCTestCase {
                 @Available(\(platform.rawValue), introduced: \"2.0\")
             }
             """
-            try assertDirective(Metadata.self, source: source) { directive, problems in
+            try await assertDirective(Metadata.self, source: source) { directive, problems in
                 XCTAssertEqual(2, problems.count)
                 let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
                 XCTAssertEqual(diagnosticIdentifiers, ["org.swift.docc.\(Metadata.Availability.self).DuplicateIntroduced"])
@@ -48,7 +48,7 @@ class MetadataAvailabilityTests: XCTestCase {
         }
     }
     
-    func testInvalidIntroducedFormat() throws {
+    func testInvalidIntroducedFormat() async throws {
         let source = """
         @Metadata {
             @TechnologyRoot
@@ -63,7 +63,7 @@ class MetadataAvailabilityTests: XCTestCase {
         }
         """
 
-        try assertDirective(Metadata.self, source: source) { directive, problems in
+        try await assertDirective(Metadata.self, source: source) { directive, problems in
             XCTAssertEqual(8, problems.count)
             let diagnosticIdentifiers = Set(problems.map { $0.diagnostic.identifier })
             let diagnosticExplanations = Set(problems.map { $0.diagnostic.explanation })
@@ -74,7 +74,7 @@ class MetadataAvailabilityTests: XCTestCase {
         }
     }
     
-    func testValidSemanticVersionFormat() throws {
+    func testValidSemanticVersionFormat() async throws {
         let source = """
         @Metadata {
             @Available(iOS, introduced: \"3.5.2\", deprecated: \"5.6.7\")
@@ -83,7 +83,7 @@ class MetadataAvailabilityTests: XCTestCase {
         }
         """
 
-        try assertDirective(Metadata.self, source: source) { directive, problems in
+        try await assertDirective(Metadata.self, source: source) { directive, problems in
             XCTAssertEqual(0, problems.count)
 
             let directive = try XCTUnwrap(directive)
@@ -113,7 +113,7 @@ class MetadataAvailabilityTests: XCTestCase {
         }
     }
 
-    func testValidIntroducedDirective() throws {
+    func testValidIntroducedDirective() async throws {
         // Assemble all the combinations of arguments you could give
         let validArguments: [String] = [
           "deprecated: \"1.0\"",
@@ -135,13 +135,13 @@ class MetadataAvailabilityTests: XCTestCase {
         
         for platform in checkPlatforms {
             for args in validArgumentsWithVersion {
-                try assertValidAvailability(source: "@Available(\(platform), \(args))")
+                try await assertValidAvailability(source: "@Available(\(platform), \(args))")
             }
         }
     }
         
     /// Basic validity test for giving several directives.
-    func testMultipleAvailabilityDirectives() throws {
+    func testMultipleAvailabilityDirectives() async throws {
         let source = """
         @Metadata {
             @Available(macOS, introduced: "11.0")
@@ -150,15 +150,15 @@ class MetadataAvailabilityTests: XCTestCase {
             @Available("My Package", introduced: "0.1", deprecated: "1.0")
         }
         """
-        try assertValidMetadata(source: source)
+        try await assertValidMetadata(source: source)
     }
     
-    func assertDirective<Directive: AutomaticDirectiveConvertible>(_ type: Directive.Type, source: String, assertion assert: (Directive?, [Problem]) throws -> Void) throws {
+    func assertDirective<Directive: AutomaticDirectiveConvertible>(_ type: Directive.Type, source: String, assertion assert: (Directive?, [Problem]) throws -> Void) async throws {
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
 
-        let (bundle, _) = try testBundleAndContext(named: "AvailabilityBundle")
+        let (bundle, _) = try await testBundleAndContext(named: "AvailabilityBundle")
 
         try directive.map { directive in
             var problems = [Problem]()
@@ -168,18 +168,18 @@ class MetadataAvailabilityTests: XCTestCase {
         }
     }
 
-    func assertValidDirective<Directive: AutomaticDirectiveConvertible>(_ type: Directive.Type, source: String) throws {
-        try assertDirective(type, source: source) { directive, problems in
+    func assertValidDirective<Directive: AutomaticDirectiveConvertible>(_ type: Directive.Type, source: String) async throws {
+        try await assertDirective(type, source: source) { directive, problems in
             XCTAssertNotNil(directive)
             XCTAssert(problems.isEmpty)
         }
     }
 
-    func assertValidAvailability(source: String) throws {
-        try assertValidDirective(Metadata.Availability.self, source: source)
+    func assertValidAvailability(source: String) async throws {
+        try await assertValidDirective(Metadata.Availability.self, source: source)
     }
 
-    func assertValidMetadata(source: String) throws {
-        try assertValidDirective(Metadata.self, source: source)
+    func assertValidMetadata(source: String) async throws {
+        try await assertValidDirective(Metadata.self, source: source)
     }
 }

--- a/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MetadataTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class MetadataTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Metadata"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if a Metadata directive is empty we can create it")
@@ -29,11 +29,11 @@ class MetadataTests: XCTestCase {
         XCTAssertNotNil(problems.first?.possibleSolutions.first)
     }
     
-    func testUnexpectedArgument() throws {
+    func testUnexpectedArgument() async throws {
         let source = "@Metadata(argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if there are warnings we can create a metadata value")
@@ -42,7 +42,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.Metadata.NoConfiguration", problems.last?.diagnostic.identifier)
     }
     
-    func testUnexpectedDirective() throws {
+    func testUnexpectedDirective() async throws {
         let source = """
         @Metadata {
            @Image
@@ -50,7 +50,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if there are warnings we can create a Metadata value")
@@ -61,7 +61,7 @@ class MetadataTests: XCTestCase {
 
     }
     
-    func testExtraContent() throws {
+    func testExtraContent() async throws {
         let source = """
         @Metadata {
            Some text
@@ -69,7 +69,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata, "Even if there are warnings we can create a Metadata value")
@@ -80,7 +80,7 @@ class MetadataTests: XCTestCase {
     
     // MARK: - Supported metadata directives
     
-    func testDocumentationExtensionSupport() throws {
+    func testDocumentationExtensionSupport() async throws {
         let source = """
         @Metadata {
            @DocumentationExtension(mergeBehavior: override)
@@ -88,7 +88,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
@@ -96,7 +96,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(metadata?.documentationOptions?.behavior, .override)
     }
     
-    func testRepeatDocumentationExtension() throws {
+    func testRepeatDocumentationExtension() async throws {
         let source = """
         @Metadata {
            @DocumentationExtension(mergeBehavior: append)
@@ -105,7 +105,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
@@ -117,7 +117,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(metadata?.documentationOptions?.behavior, .append)
     }
     
-    func testDisplayNameSupport() throws {
+    func testDisplayNameSupport() async throws {
         let source = """
         @Metadata {
            @DisplayName("Custom Name")
@@ -125,7 +125,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
@@ -134,7 +134,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(metadata?.displayName?.name, "Custom Name")
     }
 
-    func testTitleHeadingSupport() throws {
+    func testTitleHeadingSupport() async throws {
         let source = """
         @Metadata {
            @TitleHeading("Custom Heading")
@@ -142,7 +142,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
@@ -151,7 +151,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(metadata?.titleHeading?.heading, "Custom Heading")
     }
     
-    func testCustomMetadataSupport() throws {
+    func testCustomMetadataSupport() async throws {
         let source = """
         @Metadata {
            @CustomMetadata(key: "country", value: "Belgium")
@@ -160,7 +160,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
@@ -168,7 +168,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(problems.count, 0)
     }
 
-    func testRedirectSupport() throws {
+    func testRedirectSupport() async throws {
         let source = """
         @Metadata {
            @Redirected(from: "some/other/path")
@@ -176,7 +176,7 @@ class MetadataTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let metadata = Metadata(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(metadata)
@@ -186,7 +186,7 @@ class MetadataTests: XCTestCase {
 
     // MARK: - Metadata Support
     
-    func testArticleSupportsMetadata() throws {
+    func testArticleSupportsMetadata() async throws {
         let source = """
         # Plain article
         
@@ -197,7 +197,7 @@ class MetadataTests: XCTestCase {
         The abstract of this article
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child.")
@@ -208,7 +208,7 @@ class MetadataTests: XCTestCase {
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
     
-    func testSymbolArticleSupportsMetadataDisplayName() throws {
+    func testSymbolArticleSupportsMetadataDisplayName() async throws {
         let source = """
         # ``SomeSymbol``
         
@@ -219,7 +219,7 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a DisplayName child.")
@@ -232,7 +232,7 @@ class MetadataTests: XCTestCase {
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
     
-    func testArticleDoesNotSupportsMetadataDisplayName() throws {
+    func testArticleDoesNotSupportsMetadataDisplayName() async throws {
         let source = """
         # Article title
         
@@ -243,7 +243,7 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a DisplayName child.")
@@ -268,7 +268,7 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(solution.replacements.last?.replacement, "# Custom Name")
     }
 
-    func testArticleSupportsMetadataTitleHeading() throws {
+    func testArticleSupportsMetadataTitleHeading() async throws {
         let source = """
         # Article title
         
@@ -279,7 +279,7 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options:  [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a TitleHeading child.")
@@ -293,7 +293,7 @@ class MetadataTests: XCTestCase {
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got:\n \(DiagnosticConsoleWriter.formattedDescription(for: analyzer.problems))")
     }
     
-    func testDuplicateMetadata() throws {
+    func testDuplicateMetadata() async throws {
         let source = """
         # Article title
         
@@ -307,7 +307,7 @@ class MetadataTests: XCTestCase {
         The abstract of this documentation extension
         """
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Metadata child with a DisplayName child.")
@@ -323,8 +323,8 @@ class MetadataTests: XCTestCase {
         )
     }
     
-    func testPageImageSupport() throws {
-        let (problems, metadata) = try parseMetadataFromSource(
+    func testPageImageSupport() async throws {
+        let (problems, metadata) = try await parseMetadataFromSource(
             """
             # Article title
             
@@ -353,8 +353,8 @@ class MetadataTests: XCTestCase {
         XCTAssertEqual(slothImage?.alt, "A sloth on a branch.")
     }
     
-    func testDuplicatePageImage() throws {
-        let (problems, _) = try parseMetadataFromSource(
+    func testDuplicatePageImage() async throws {
+        let (problems, _) = try await parseMetadataFromSource(
             """
             # Article title
             
@@ -376,9 +376,9 @@ class MetadataTests: XCTestCase {
         )
     }
     
-    func testPageColorSupport() throws {
+    func testPageColorSupport() async throws {
         do {
-            let (problems, metadata) = try parseMetadataFromSource(
+            let (problems, metadata) = try await parseMetadataFromSource(
             """
             # Article title
             
@@ -395,7 +395,7 @@ class MetadataTests: XCTestCase {
         }
         
         do {
-            let (problems, metadata) = try parseMetadataFromSource(
+            let (problems, metadata) = try await parseMetadataFromSource(
             """
             # Article title
             
@@ -416,9 +416,9 @@ class MetadataTests: XCTestCase {
         _ source: String,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws -> (problems: [String], metadata: Metadata) {
+    ) async throws -> (problems: [String], metadata: Metadata) {
         let document = Document(parsing: source, options: [.parseBlockDirectives, .parseSymbolLinks])
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)

--- a/Tests/SwiftDocCTests/Semantics/MultipleChoiceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/MultipleChoiceTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class MultipleChoiceTests: XCTestCase {
-    func testInvalidEmpty() throws {
+    func testInvalidEmpty() async throws {
         let source = "@MultipleChoice"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -34,7 +34,7 @@ class MultipleChoiceTests: XCTestCase {
         }
     }
     
-    func testInvalidTooFewChoices() throws {
+    func testInvalidTooFewChoices() async throws {
         let source = """
 @MultipleChoice {
   What is your favorite color?
@@ -53,7 +53,7 @@ class MultipleChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         try directive.map { directive in
             var problems = [Problem]()
@@ -70,7 +70,7 @@ class MultipleChoiceTests: XCTestCase {
         }
     }
     
-    func testInvalidCodeAndImage() throws {
+    func testInvalidCodeAndImage() async throws {
         let source = """
 @MultipleChoice {
   Question 1
@@ -101,7 +101,7 @@ class MultipleChoiceTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -133,7 +133,7 @@ MultipleChoice @1:1-24:2 title: 'SwiftDocC.MarkupContainer'
 
     }
     
-    func testValidNoCodeOrMedia() throws {
+    func testValidNoCodeOrMedia() async throws {
         let source = """
 @MultipleChoice {
   Question 1
@@ -158,7 +158,7 @@ MultipleChoice @1:1-24:2 title: 'SwiftDocC.MarkupContainer'
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -185,7 +185,7 @@ MultipleChoice @1:1-18:2 title: 'SwiftDocC.MarkupContainer'
         }
     }
     
-    func testValidCode() throws {
+    func testValidCode() async throws {
         let source = """
 @MultipleChoice {
   Question 1
@@ -214,7 +214,7 @@ MultipleChoice @1:1-18:2 title: 'SwiftDocC.MarkupContainer'
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -246,7 +246,7 @@ MultipleChoice @1:1-22:2 title: 'SwiftDocC.MarkupContainer'
 
     }
     
-    func testMultipleCorrectAnswers() throws {
+    func testMultipleCorrectAnswers() async throws {
         let source = """
 @MultipleChoice {
   Question 1
@@ -274,7 +274,7 @@ MultipleChoice @1:1-22:2 title: 'SwiftDocC.MarkupContainer'
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = try XCTUnwrap(document.child(at: 0) as? BlockDirective)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         var problems = [Problem]()
         XCTAssertEqual(MultipleChoice.directiveName, directive.name)

--- a/Tests/SwiftDocCTests/Semantics/Options/OptionsTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Options/OptionsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class OptionsTests: XCTestCase {
-    func testDefaultOptions() throws {
-        let (problems, options) = try parseDirective(Options.self) {
+    func testDefaultOptions() async throws {
+        let (problems, options) = try await parseDirective(Options.self) {
             """
             @Options {
             
@@ -33,9 +33,9 @@ class OptionsTests: XCTestCase {
         XCTAssertEqual(unwrappedOptions.scope, .local)
     }
     
-    func testOptionsParameters() throws {
+    func testOptionsParameters() async throws {
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options(scope: global) {
                 
@@ -48,7 +48,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options(scope: local) {
                 
@@ -61,7 +61,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options(scope: global, random: foo) {
                 
@@ -79,9 +79,9 @@ class OptionsTests: XCTestCase {
         }
     }
     
-    func testAutomaticSeeAlso() throws {
+    func testAutomaticSeeAlso() async throws {
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticSeeAlso(disabled)
@@ -94,7 +94,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticSeeAlso(enabled)
@@ -107,7 +107,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticSeeAlso(foo)
@@ -128,9 +128,9 @@ class OptionsTests: XCTestCase {
         }
     }
     
-    func testTopicsVisualStyle() throws {
+    func testTopicsVisualStyle() async throws {
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @TopicsVisualStyle(detailedGrid)
@@ -143,7 +143,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @TopicsVisualStyle(compactGrid)
@@ -156,7 +156,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @TopicsVisualStyle(list)
@@ -169,7 +169,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @TopicsVisualStyle(hidden)
@@ -182,7 +182,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticSeeAlso(foo)
@@ -203,9 +203,9 @@ class OptionsTests: XCTestCase {
         }
     }
     
-    func testAutomaticTitleHeading() throws {
+    func testAutomaticTitleHeading() async throws {
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticTitleHeading(disabled)
@@ -218,7 +218,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticTitleHeading(enabled)
@@ -231,7 +231,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticTitleHeading(foo)
@@ -252,8 +252,8 @@ class OptionsTests: XCTestCase {
         }
     }
     
-    func testMixOfOptions() throws {
-        let (problems, options) = try parseDirective(Options.self) {
+    func testMixOfOptions() async throws {
+        let (problems, options) = try await parseDirective(Options.self) {
             """
             @Options {
                 @AutomaticTitleHeading(enabled)
@@ -271,8 +271,8 @@ class OptionsTests: XCTestCase {
         XCTAssertEqual(options?.automaticArticleSubheadingEnabled, true)
     }
     
-    func testUnsupportedChild() throws {
-        let (problems, options) = try parseDirective(Options.self) {
+    func testUnsupportedChild() async throws {
+        let (problems, options) = try await parseDirective(Options.self) {
             """
             @Options {
                 @AutomaticTitleHeading(enabled)
@@ -295,9 +295,9 @@ class OptionsTests: XCTestCase {
         )
     }
     
-    func testAutomaticArticleSubheading() throws {
+    func testAutomaticArticleSubheading() async throws {
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                 }
@@ -310,7 +310,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticArticleSubheading(randomArgument)
@@ -324,7 +324,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticArticleSubheading(disabled)
@@ -338,7 +338,7 @@ class OptionsTests: XCTestCase {
         }
         
         do {
-            let (problems, options) = try parseDirective(Options.self) {
+            let (problems, options) = try await parseDirective(Options.self) {
                 """
                 @Options {
                     @AutomaticArticleSubheading(enabled)

--- a/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/RedirectedTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class RedirectedTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Redirected"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(redirected)
@@ -28,12 +28,12 @@ class RedirectedTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.from", problems.first?.diagnostic.identifier)
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let oldPath = "/old/path/to/this/page"
         let source = "@Redirected(from: \(oldPath))"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected)
@@ -41,12 +41,12 @@ class RedirectedTests: XCTestCase {
         XCTAssertEqual(redirected?.oldPath.path, oldPath)
     }
     
-    func testExtraArguments() throws {
+    func testExtraArguments() async throws {
         let oldPath = "/old/path/to/this/page"
         let source = "@Redirected(from: \(oldPath), argument: value)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected, "Even if there are warnings we can create a Redirected value")
@@ -55,7 +55,7 @@ class RedirectedTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.UnknownArgument", problems.first?.diagnostic.identifier)
     }
     
-    func testExtraDirective() throws {
+    func testExtraDirective() async throws {
         let oldPath = "/old/path/to/this/page"
         let source = """
         @Redirected(from: \(oldPath)) {
@@ -64,7 +64,7 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected, "Even if there are warnings we can create a Redirected value")
@@ -74,7 +74,7 @@ class RedirectedTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.Redirected.NoInnerContentAllowed", problems.last?.diagnostic.identifier)
     }
     
-    func testExtraContent() throws {
+    func testExtraContent() async throws {
         let oldPath = "/old/path/to/this/page"
         let source = """
         @Redirected(from: \(oldPath)) {
@@ -83,7 +83,7 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(redirected, "Even if there are warnings we can create a Redirected value")
@@ -94,7 +94,7 @@ class RedirectedTests: XCTestCase {
     
     // MARK: - Redirect support
     
-    func testTechnologySupportsRedirect() throws {
+    func testTechnologySupportsRedirect() async throws {
         let source = """
         @Tutorials(name: "Technology X") {
            @Intro(title: "Technology X") {
@@ -107,7 +107,7 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let tutorialTableOfContents = TutorialTableOfContents(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(tutorialTableOfContents, "A tutorial table-of-contents value can be created with a Redirected child.")
@@ -118,7 +118,7 @@ class RedirectedTests: XCTestCase {
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
     }
     
-    func testVolumeAndChapterSupportsRedirect() throws {
+    func testVolumeAndChapterSupportsRedirect() async throws {
         let source = """
         @Volume(name: "Name of this volume") {
            @Image(source: image.png, alt: image)
@@ -139,14 +139,14 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let volume = Volume(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(volume, "A Volume value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
     }
     
-    func testTutorialAndSectionsSupportsRedirect() throws {
+    func testTutorialAndSectionsSupportsRedirect() async throws {
         let source = """
         @Tutorial(time: 20, projectFiles: project.zip) {
            @Intro(title: "Basic Augmented Reality App") {
@@ -204,7 +204,7 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let tutorial = Tutorial(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(tutorial, "A Tutorial value can be created with a Redirected child.")
@@ -215,7 +215,7 @@ class RedirectedTests: XCTestCase {
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
     }
     
-    func testTutorialArticleSupportsRedirect() throws {
+    func testTutorialArticleSupportsRedirect() async throws {
         let source = """
         @Article(time: 20) {
            @Intro(title: "Making an Augmented Reality App") {
@@ -232,7 +232,7 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let article = TutorialArticle(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "A TutorialArticle value can be created with a Redirected child.")
@@ -243,7 +243,7 @@ class RedirectedTests: XCTestCase {
         XCTAssert(analyzer.problems.isEmpty, "Expected no problems. Got \(DiagnosticConsoleWriter.formattedDescription(for:  analyzer.problems))")
     }
     
-    func testResourcesSupportsRedirect() throws {
+    func testResourcesSupportsRedirect() async throws {
         let source = """
         @Resources(technology: doc:/TestOverview) {
            Find the tools and a comprehensive set of resources for creating AR experiences on iOS.
@@ -281,14 +281,14 @@ class RedirectedTests: XCTestCase {
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let article = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "A Resources value can be created with a Redirected child.")
         XCTAssert(problems.isEmpty, "There shouldn't be any problems. Got:\n\(problems.map { $0.diagnostic.summary })")
     }
     
-    func testArticleSupportsRedirect() throws {
+    func testArticleSupportsRedirect() async throws {
         let source = """
         # Plain article
         
@@ -302,7 +302,7 @@ class RedirectedTests: XCTestCase {
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
@@ -321,7 +321,7 @@ class RedirectedTests: XCTestCase {
         ], oldPaths)
     }
 
-    func testArticleSupportsRedirectInMetadata() throws {
+    func testArticleSupportsRedirectInMetadata() async throws {
         let source = """
         # Plain article
 
@@ -337,7 +337,7 @@ class RedirectedTests: XCTestCase {
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
@@ -356,7 +356,7 @@ class RedirectedTests: XCTestCase {
         ], oldPaths)
     }
 
-    func testArticleSupportsBothRedirects() throws {
+    func testArticleSupportsBothRedirects() async throws {
         let source = """
         # Plain article
 
@@ -374,7 +374,7 @@ class RedirectedTests: XCTestCase {
         ![full width image](referenced-article-image.png)
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let article = Article(from: document, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(article, "An Article value can be created with a Redirected child.")
@@ -394,11 +394,11 @@ class RedirectedTests: XCTestCase {
         ], oldPaths)
     }
     
-    func testIncorrectArgumentLabel() throws {
+    func testIncorrectArgumentLabel() async throws {
         let source = "@Redirected(fromURL: /old/path)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let redirected = Redirect(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(redirected)

--- a/Tests/SwiftDocCTests/Semantics/Reference/LinksTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/LinksTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,9 +15,9 @@ import XCTest
 import Markdown
 
 class LinksTests: XCTestCase {
-    func testMissingBasicRequirements() throws {
+    func testMissingBasicRequirements() async throws {
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "BookLikeContent") {
                 """
                 @Links(visualStyle: compactGrid)
                 """
@@ -34,7 +34,7 @@ class LinksTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "BookLikeContent") {
                 """
                 @Links {
                     - <doc:MyArticle>
@@ -55,9 +55,9 @@ class LinksTests: XCTestCase {
         }
     }
     
-    func testInvalidBodyContent() throws {
+    func testInvalidBodyContent() async throws {
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "BookLikeContent") {
                 """
                 @Links(visualStyle: compactGrid) {
                     This is a paragraph of text in 'Links' directive.
@@ -82,7 +82,7 @@ class LinksTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "BookLikeContent") {
                 """
                 @Links(visualStyle: compactGrid) {
                     This is a paragraph of text in 'Links' directive.
@@ -116,7 +116,7 @@ class LinksTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "BookLikeContent") {
                 """
                 @Links(visualStyle: compactGrid) {
                     - <doc:MyArticle> Link with some trailing content.
@@ -147,9 +147,9 @@ class LinksTests: XCTestCase {
         }
     }
     
-    func testLinkResolution() throws {
+    func testLinkResolution() async throws {
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "BookLikeContent") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "BookLikeContent") {
                 """
                 @Links(visualStyle: compactGrid) {
                     - <doc:MyArticle>
@@ -185,7 +185,7 @@ class LinksTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, links) = try parseDirective(Links.self, in: "LegacyBundle_DoNotUseInNewTests") {
+            let (renderedContent, problems, links) = try await parseDirective(Links.self, in: "LegacyBundle_DoNotUseInNewTests") {
                 """
                 @Links(visualStyle: compactGrid) {
                     - ``MyKit/MyClass``

--- a/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/RowTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class RowTests: XCTestCase {
-    func testNoColumns() throws {
-        let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+    func testNoColumns() async throws {
+        let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
             """
             @Row
             """
@@ -36,9 +36,9 @@ class RowTests: XCTestCase {
         )
     }
     
-    func testInvalidParameters() throws {
+    func testInvalidParameters() async throws {
         do {
-            let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+            let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
                 """
                 @Row(columns: 3) {
                     @Column(what: true) {
@@ -81,7 +81,7 @@ class RowTests: XCTestCase {
         }
         
         do {
-            let (_, problems, row) = try parseDirective(Row.self) {
+            let (_, problems, row) = try await parseDirective(Row.self) {
                 """
                 @Row(numberOfColumns: 3) {
                     @Column(size: 3) {
@@ -107,9 +107,9 @@ class RowTests: XCTestCase {
         }
     }
     
-    func testInvalidChildren() throws {
+    func testInvalidChildren() async throws {
         do {
-            let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+            let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
                 """
                 @Row {
                     @Row {
@@ -142,7 +142,7 @@ class RowTests: XCTestCase {
         }
         
         do {
-            let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+            let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
                 """
                 @Row {
                     @Column {
@@ -175,7 +175,7 @@ class RowTests: XCTestCase {
         }
         
         do {
-            let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+            let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
                 """
                 @Row {
 
@@ -199,8 +199,8 @@ class RowTests: XCTestCase {
         }
     }
     
-    func testEmptyColumn() throws {
-        let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+    func testEmptyColumn() async throws {
+        let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
             """
             @Row {
                 @Column
@@ -236,8 +236,8 @@ class RowTests: XCTestCase {
         )
     }
     
-    func testNestedRowAndColumns() throws {
-        let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+    func testNestedRowAndColumns() async throws {
+        let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
             """
             @Row {
                 @Column {

--- a/Tests/SwiftDocCTests/Semantics/Reference/SmallTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/SmallTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class SmallTests: XCTestCase {
-    func testNoContent() throws {
-        let (renderBlockContent, problems, small) = try parseDirective(Small.self) {
+    func testNoContent() async throws {
+        let (renderBlockContent, problems, small) = try await parseDirective(Small.self) {
             """
             @Small
             """
@@ -32,9 +32,9 @@ class SmallTests: XCTestCase {
         XCTAssertEqual(renderBlockContent, [])
     }
     
-    func testHasContent() throws {
+    func testHasContent() async throws {
         do {
-            let (renderBlockContent, problems, small) = try parseDirective(Small.self) {
+            let (renderBlockContent, problems, small) = try await parseDirective(Small.self) {
                 """
                 @Small {
                     This is my copyright text.
@@ -56,7 +56,7 @@ class SmallTests: XCTestCase {
         }
         
         do {
-            let (renderBlockContent, problems, small) = try parseDirective(Small.self) {
+            let (renderBlockContent, problems, small) = try await parseDirective(Small.self) {
                 """
                 @Small {
                     This is my copyright text.
@@ -85,7 +85,7 @@ class SmallTests: XCTestCase {
         }
         
         do {
-            let (renderBlockContent, problems, small) = try parseDirective(Small.self) {
+            let (renderBlockContent, problems, small) = try await parseDirective(Small.self) {
                 """
                 @Small {
                     This is my *formatted* `copyright` **text**.
@@ -115,9 +115,9 @@ class SmallTests: XCTestCase {
         }
     }
     
-    func testEmitsWarningWhenContainsStructuredMarkup() throws {
+    func testEmitsWarningWhenContainsStructuredMarkup() async throws {
         do {
-            let (renderBlockContent, problems, small) = try parseDirective(Small.self) {
+            let (renderBlockContent, problems, small) = try await parseDirective(Small.self) {
                 """
                 @Small {
                     This is my copyright text.
@@ -143,9 +143,9 @@ class SmallTests: XCTestCase {
         }
     }
     
-    func testSmallInsideOfColumn() throws {
+    func testSmallInsideOfColumn() async throws {
         do {
-            let (renderBlockContent, problems, row) = try parseDirective(Row.self) {
+            let (renderBlockContent, problems, row) = try await parseDirective(Row.self) {
                 """
                 @Row {
                     @Column {

--- a/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class TabNavigatorTests: XCTestCase {
-    func testNoTabs() throws {
-        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+    func testNoTabs() async throws {
+        let (renderBlockContent, problems, tabNavigator) = try await parseDirective(TabNavigator.self) {
             """
             @TabNavigator
             """
@@ -36,8 +36,8 @@ class TabNavigatorTests: XCTestCase {
         )
     }
     
-    func testEmptyTab() throws {
-        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+    func testEmptyTab() async throws {
+        let (renderBlockContent, problems, tabNavigator) = try await parseDirective(TabNavigator.self) {
             """
             @TabNavigator {
                 @Tab("hiya") {
@@ -63,8 +63,8 @@ class TabNavigatorTests: XCTestCase {
         
     }
     
-    func testInvalidParametersAndContent() throws {
-        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+    func testInvalidParametersAndContent() async throws {
+        let (renderBlockContent, problems, tabNavigator) = try await parseDirective(TabNavigator.self) {
             """
             @TabNavigator(tabs: 3) {
                 @Tab("hi") {
@@ -127,8 +127,8 @@ class TabNavigatorTests: XCTestCase {
         )
     }
     
-    func testNestedStructuredMarkup() throws {
-        let (renderBlockContent, problems, tabNavigator) = try parseDirective(TabNavigator.self) {
+    func testNestedStructuredMarkup() async throws {
+        let (renderBlockContent, problems, tabNavigator) = try await parseDirective(TabNavigator.self) {
             """
             @TabNavigator {
                 @Tab("hi") {

--- a/Tests/SwiftDocCTests/Semantics/ResourcesTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/ResourcesTests.swift
@@ -13,11 +13,11 @@ import XCTest
 import Markdown
 
 class ResourcesTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@\(Resources.directiveName)"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let resources = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(resources)
@@ -33,7 +33,7 @@ class ResourcesTests: XCTestCase {
         XCTAssert(problems.map { $0.diagnostic.severity }.allSatisfy { $0 == .warning })
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
 @\(Resources.directiveName) {
    Find the tools and a comprehensive set of resources for creating AR experiences on iOS.
@@ -67,7 +67,7 @@ class ResourcesTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let resources = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(resources)
@@ -92,7 +92,7 @@ Resources @1:1-29:2
         }
     }
 
-    func testMissingLinksWarning() throws {
+    func testMissingLinksWarning() async throws {
         let source = """
 @\(Resources.directiveName) {
    Find the tools and a comprehensive set of resources for creating AR experiences on iOS.
@@ -120,7 +120,7 @@ Resources @1:1-29:2
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let resources = Resources(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(resources)

--- a/Tests/SwiftDocCTests/Semantics/SectionTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SectionTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class TutorialSectionTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Section"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let section = TutorialSection(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(section)

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class SnippetTests: XCTestCase {
-    func testNoPath() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testNoPath() async throws {
+        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet()
         """
@@ -29,8 +29,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.path", problems[0].diagnostic.identifier)
     }
 
-    func testHasInnerContent() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testHasInnerContent() async throws {
+        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "path/to/snippet") {
             This content shouldn't be here.
@@ -45,8 +45,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.Snippet.NoInnerContentAllowed", problems[0].diagnostic.identifier)
     }
 
-    func testLinkResolves() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testLinkResolves() async throws {
+        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet")
         """
@@ -59,8 +59,8 @@ class SnippetTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testUnresolvedSnippetPathDiagnostic() throws {
-        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+    func testUnresolvedSnippetPathDiagnostic() async throws {
+        let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "Test/Snippets/DoesntExist")
         """
@@ -73,8 +73,8 @@ class SnippetTests: XCTestCase {
         }
     }
     
-    func testSliceResolves() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testSliceResolves() async throws {
+        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet", slice: "foo")
         """

--- a/Tests/SwiftDocCTests/Semantics/StackTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/StackTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class StackTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Stack"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -34,7 +34,7 @@ class StackTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
         @Stack {
           @ContentAndMedia {
@@ -48,7 +48,7 @@ class StackTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -59,7 +59,7 @@ class StackTests: XCTestCase {
         }
     }
 
-    func testTooManyChildren() throws {
+    func testTooManyChildren() async throws {
         var source = "@Stack {"
         for _ in 0...Stack.childrenLimit {
             source += """
@@ -78,7 +78,7 @@ class StackTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()

--- a/Tests/SwiftDocCTests/Semantics/StepTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/StepTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class StepTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @Step
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let step = Step(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertEqual([
@@ -32,7 +32,7 @@ class StepTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
 @Step {
    This is the step's content.
@@ -46,7 +46,7 @@ class StepTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let step = Step(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertTrue(problems.isEmpty)
@@ -83,7 +83,7 @@ Step @1:1-9:2
         }
     }
     
-    func testExtraneousContent() throws {
+    func testExtraneousContent() async throws {
         let source = """
 @Step {
    This is the step's content.
@@ -104,7 +104,7 @@ Step @1:1-9:2
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let step = Step(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertEqual(2, problems.count)

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -16,8 +16,8 @@ import SwiftDocCTestUtilities
 
 class SymbolTests: XCTestCase {
     
-    func testDocCommentWithoutArticle() throws {
-        let (withoutArticle, problems) = try makeDocumentationNodeSymbol(
+    func testDocCommentWithoutArticle() async throws {
+        let (withoutArticle, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -43,9 +43,9 @@ class SymbolTests: XCTestCase {
         XCTAssertNil(withoutArticle.topics)
     }
     
-    func testOverridingInSourceDocumentationWithEmptyArticle() throws {
+    func testOverridingInSourceDocumentationWithEmptyArticle() async throws {
         // The article heading—which should always be the symbol link header—is not considered part of the article's content
-        let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+        let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -75,8 +75,8 @@ class SymbolTests: XCTestCase {
                      "The article did override the topics section.")
     }
     
-     func testOverridingInSourceDocumentationWithDetailedArticle() throws {
-        let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+    func testOverridingInSourceDocumentationWithDetailedArticle() async throws {
+        let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -138,9 +138,9 @@ class SymbolTests: XCTestCase {
         }
     }
     
-    func testAppendingInSourceDocumentationWithArticle() throws {
+    func testAppendingInSourceDocumentationWithArticle() async throws {
         // The article heading—which should always be the symbol link header—is not considered part of the article's content
-        let (withEmptyArticleOverride, problems) = try makeDocumentationNodeSymbol(
+        let (withEmptyArticleOverride, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -169,13 +169,13 @@ class SymbolTests: XCTestCase {
         XCTAssertNil(withEmptyArticleOverride.topics)
     }
         
-    func testAppendingArticleToInSourceDocumentation() throws {
+    func testAppendingArticleToInSourceDocumentation() async throws {
         // When no DocumentationExtension behavior is specified, the default behavior is "append to doc comment".
         let withAndWithoutAppendConfiguration = ["", "@Metadata { \n @DocumentationExtension(mergeBehavior: append) \n }"]
         
         // Append curation to doc comment
         for metadata in withAndWithoutAppendConfiguration {
-            let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+            let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
                 docComment: """
                     A cool API to call.
 
@@ -221,7 +221,7 @@ class SymbolTests: XCTestCase {
 
         // Append overview and curation to doc comment
         for metadata in withAndWithoutAppendConfiguration {
-            let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+            let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
                 docComment: """
                     A cool API to call.
 
@@ -274,7 +274,7 @@ class SymbolTests: XCTestCase {
 
         // Append overview and curation to doc comment
         for metadata in withAndWithoutAppendConfiguration {
-            let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+            let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
                 docComment: """
                     A cool API to call.
 
@@ -327,7 +327,7 @@ class SymbolTests: XCTestCase {
 
         // Append with only abstract in doc comment
         for metadata in withAndWithoutAppendConfiguration {
-            let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+            let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
                 docComment: """
                     A cool API to call.
                     """,
@@ -381,7 +381,7 @@ class SymbolTests: XCTestCase {
 
         // Append by extending overview and adding parameters
         for metadata in withAndWithoutAppendConfiguration {
-            let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+            let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
                 docComment: """
                     A cool API to call.
 
@@ -421,7 +421,7 @@ class SymbolTests: XCTestCase {
 
         // Append by extending the overview (with parameters in the doc comment)
         for metadata in withAndWithoutAppendConfiguration {
-            let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+            let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
                 docComment: """
                     A cool API to call.
 
@@ -460,8 +460,8 @@ class SymbolTests: XCTestCase {
         }
     }
     
-    func testRedirectFromArticle() throws {
-        let (withRedirectInArticle, problems) = try makeDocumentationNodeSymbol(
+    func testRedirectFromArticle() async throws {
+        let (withRedirectInArticle, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -477,8 +477,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(withRedirectInArticle.redirects?.map { $0.oldPath.absoluteString }, ["some/previous/path/to/this/symbol"])
     }
     
-    func testWarningWhenDocCommentContainsUnsupportedDirective() throws {
-        let (withRedirectInArticle, problems) = try makeDocumentationNodeSymbol(
+    func testWarningWhenDocCommentContainsUnsupportedDirective() async throws {
+        let (withRedirectInArticle, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -496,8 +496,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(problems.first?.diagnostic.range?.lowerBound.column, 1)
     }
 
-    func testNoWarningWhenDocCommentContainsDirective() throws {
-        let (_, problems) = try makeDocumentationNodeSymbol(
+    func testNoWarningWhenDocCommentContainsDirective() async throws {
+        let (_, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -510,7 +510,7 @@ class SymbolTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testNoWarningWhenDocCommentContainsDoxygen() throws {
+    func testNoWarningWhenDocCommentContainsDoxygen() async throws {
         let tempURL = try createTemporaryDirectory()
         
         let bundleURL = try Folder(name: "Inheritance.docc", content: [
@@ -520,18 +520,18 @@ class SymbolTests: XCTestCase {
                 subdirectory: "Test Resources")!),
         ]).write(inside: tempURL)
         
-        let (_, _, context) = try loadBundle(from: bundleURL)
+        let (_, _, context) = try await loadBundle(from: bundleURL)
         let problems = context.diagnosticEngine.problems
         XCTAssertEqual(problems.count, 0)
     }
 
-    func testParseDoxygen() throws {
+    func testParseDoxygen() async throws {
         let deckKitSymbolGraph = Bundle.module.url(
             forResource: "DeckKit-Objective-C",
             withExtension: "symbols.json",
             subdirectory: "Test Resources"
         )!
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             try? FileManager.default.copyItem(at: deckKitSymbolGraph, to: url.appendingPathComponent("DeckKit.symbols.json"))
         }
         let symbol = try XCTUnwrap(context.documentationCache["c:objc(cs)PlayingCard(cm)newWithRank:ofSuit:"]?.semantic as? Symbol)
@@ -548,8 +548,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(symbol.returnsSection?.content.map({ $0.format() }), ["A new card with the given configuration."])
     }
 
-    func testUnresolvedReferenceWarningsInDocumentationExtension() throws {
-        let (url, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+    func testUnresolvedReferenceWarningsInDocumentationExtension() async throws {
+        let (url, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             let myKitDocumentationExtensionComment = """
             # ``MyKit/MyClass``
 
@@ -940,7 +940,7 @@ class SymbolTests: XCTestCase {
         """)
     }
     
-    func testUnresolvedReferenceWarningsInDocComment() throws {
+    func testUnresolvedReferenceWarningsInDocComment() async throws {
         let docComment = """
         A cool API to call.
 
@@ -959,7 +959,7 @@ class SymbolTests: XCTestCase {
         - <doc://com.test.external/ExternalPage>
         """
         
-        let (_, _, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+        let (_, _, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             var graph = try JSONDecoder().decode(SymbolGraph.self, from: Data(contentsOf: url.appendingPathComponent("mykit-iOS.symbols.json")))
             let myFunctionUSR = "s:5MyKit0A5ClassC10myFunctionyyF"
 
@@ -1036,8 +1036,8 @@ class SymbolTests: XCTestCase {
         XCTAssertTrue(unresolvedTopicProblems.contains(where: { $0.diagnostic.summary == "No external resolver registered for 'com.test.external'." }))
     }
     
-    func testTopicSectionInDocComment() throws {
-        let (withArticleOverride, problems) = try makeDocumentationNodeSymbol(
+    func testTopicSectionInDocComment() async throws {
+        let (withArticleOverride, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                 This is an abstract.
 
@@ -1111,8 +1111,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(engine.problems.count, 0)
     }
 
-    func testAddingConstraintsToSymbol() throws {
-        let (withoutArticle, _) = try makeDocumentationNodeSymbol(
+    func testAddingConstraintsToSymbol() async throws {
+        let (withoutArticle, _) = try await makeDocumentationNodeSymbol(
             docComment: """
                 A cool API to call.
 
@@ -1199,8 +1199,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(1, withoutArticle.declarationVariants[trait]!.count)
     }
     
-    func testParsesMetadataDirectiveFromDocComment() throws {
-        let (node, problems) = try makeDocumentationNodeForSymbol(
+    func testParsesMetadataDirectiveFromDocComment() async throws {
+        let (node, problems) = try await makeDocumentationNodeForSymbol(
             docComment: """
                 The symbol's abstract.
 
@@ -1218,8 +1218,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(availability.introduced.description, "1.2.3")
     }
     
-    func testEmitsWarningsInMetadataDirectives() throws {
-        let (_, problems) = try makeDocumentationNodeForSymbol(
+    func testEmitsWarningsInMetadataDirectives() async throws {
+        let (_, problems) = try await makeDocumentationNodeForSymbol(
             docComment: """
                 The symbol's abstract.
 
@@ -1239,8 +1239,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(diagnostic.range?.lowerBound.column, 1)
     }
     
-    func testEmitsWarningForDuplicateMetadata() throws {
-        let (node, problems) = try makeDocumentationNodeForSymbol(
+    func testEmitsWarningForDuplicateMetadata() async throws {
+        let (node, problems) = try await makeDocumentationNodeForSymbol(
             docComment: """
                 The symbol's abstract.
 
@@ -1270,8 +1270,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(availability.platform, .other("Platform from documentation extension"))
     }
     
-    func testEmitsWarningsForInvalidMetadataChildrenInDocumentationComments() throws {
-        let (_, problems) = try makeDocumentationNodeForSymbol(
+    func testEmitsWarningsForInvalidMetadataChildrenInDocumentationComments() async throws {
+        let (_, problems) = try await makeDocumentationNodeForSymbol(
             docComment: """
                 The symbol's abstract.
 
@@ -1313,8 +1313,8 @@ class SymbolTests: XCTestCase {
         )
     }
     
-    func testParsesDeprecationSummaryDirectiveFromDocComment() throws {
-        let (node, problems) = try makeDocumentationNodeForSymbol(
+    func testParsesDeprecationSummaryDirectiveFromDocComment() async throws {
+        let (node, problems) = try await makeDocumentationNodeForSymbol(
             docComment: """
                 The symbol's abstract.
 
@@ -1339,8 +1339,8 @@ class SymbolTests: XCTestCase {
         )
     }
     
-    func testAllowsCommentDirectiveInDocComment() throws {
-        let (_, problems) = try makeDocumentationNodeForSymbol(
+    func testAllowsCommentDirectiveInDocComment() async throws {
+        let (_, problems) = try await makeDocumentationNodeForSymbol(
             docComment: """
                 The symbol's abstract.
 
@@ -1481,8 +1481,8 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(lines.linesWithoutLeadingWhitespace(), linesWithoutLeadingWhitespace)
     }
 
-    func testLeadingWhitespaceInDocComment() throws {
-        let (semanticWithLeadingWhitespace, problems) = try makeDocumentationNodeSymbol(
+    func testLeadingWhitespaceInDocComment() async throws {
+        let (semanticWithLeadingWhitespace, problems) = try await makeDocumentationNodeSymbol(
             docComment: """
                     This is an abstract.
                      
@@ -1513,9 +1513,9 @@ class SymbolTests: XCTestCase {
         diagnosticEngineFilterLevel: DiagnosticSeverity = .warning,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws -> (DocumentationNode, [Problem]) {
+    ) async throws -> (DocumentationNode, [Problem]) {
         let myFunctionUSR = "s:5MyKit0A5ClassC10myFunctionyyF"
-        let (_, bundle, context) = try testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
+        let (_, bundle, context) = try await testBundleAndContext(copying: "LegacyBundle_DoNotUseInNewTests") { url in
             var graph = try JSONDecoder().decode(SymbolGraph.self, from: Data(contentsOf: url.appendingPathComponent("mykit-iOS.symbols.json")))
             
             let newDocComment = self.makeLineList(
@@ -1575,8 +1575,8 @@ class SymbolTests: XCTestCase {
         articleContent: String?,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws -> (Symbol, [Problem]) {
-        let (node, problems) = try makeDocumentationNodeForSymbol(
+    ) async throws -> (Symbol, [Problem]) {
+        let (node, problems) = try await makeDocumentationNodeForSymbol(
             docComment: docComment,
             articleContent: articleContent,
             file: file,

--- a/Tests/SwiftDocCTests/Semantics/TechnologyTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TechnologyTests.swift
@@ -15,11 +15,11 @@ import XCTest
 import Markdown
 
 class TechnologyTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Tutorials"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let technology = TutorialTableOfContents(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(technology)

--- a/Tests/SwiftDocCTests/Semantics/TileTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TileTests.swift
@@ -14,7 +14,7 @@ import Markdown
 
 class TileTests: XCTestCase {
     
-    func testComplex() throws {
+    func testComplex() async throws {
         let directiveNamesAndTitles = [
             (Tile.DirectiveNames.documentation, Tile.Semantics.Title.documentation),
             (Tile.DirectiveNames.sampleCode, Tile.Semantics.Title.sampleCode),
@@ -26,7 +26,7 @@ class TileTests: XCTestCase {
                 let source = "@\(directiveName)"
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
                 let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
@@ -49,7 +49,7 @@ class TileTests: XCTestCase {
 """
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
                 let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
@@ -62,7 +62,7 @@ class TileTests: XCTestCase {
         }
     }
     
-    func testGeneric() throws {
+    func testGeneric() async throws {
         let directiveNamesAndTitles = [
             (Tile.DirectiveNames.downloads, Tile.Semantics.Title.downloads),
             (Tile.DirectiveNames.videos, Tile.Semantics.Title.videos),
@@ -75,7 +75,7 @@ class TileTests: XCTestCase {
                 let source = "@\(directiveName)"
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
                 let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
@@ -97,7 +97,7 @@ class TileTests: XCTestCase {
 """
                 let document = Document(parsing: source, options: .parseBlockDirectives)
                 let directive = document.child(at: 0)! as! BlockDirective
-                let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+                let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
                 var problems = [Problem]()
                 let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
                 XCTAssertNotNil(tile)
@@ -110,7 +110,7 @@ class TileTests: XCTestCase {
         }
     }
     
-    func testDestination() throws {
+    func testDestination() async throws {
         do {
             let destination = URL(string: "https://www.example.com/documentation/technology")!
             let source = """
@@ -120,7 +120,7 @@ class TileTests: XCTestCase {
     """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+            let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             var problems = [Problem]()
             let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
             // Destination is set.
@@ -136,7 +136,7 @@ class TileTests: XCTestCase {
     """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+            let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             var problems = [Problem]()
             let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
             // Destination is nil.
@@ -145,11 +145,11 @@ class TileTests: XCTestCase {
         }
     }
     
-    func testUnknownTile() throws {
+    func testUnknownTile() async throws {
         let source = "@UnknownTile"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let tile = Tile(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(tile)

--- a/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialArticleTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class TutorialArticleTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Article"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -35,7 +35,7 @@ class TutorialArticleTests: XCTestCase {
         }
     }
     
-    func testSimpleNoIntro() throws {
+    func testSimpleNoIntro() async throws {
         let source = """
 @Article {
    ## The first section
@@ -56,7 +56,7 @@ class TutorialArticleTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -75,7 +75,7 @@ TutorialArticle @1:1-13:2
     }
     
     /// Tests that we parse correctly and emit proper warnings when the author provides non-sequential headers.
-    func testHeaderMix() throws {
+    func testHeaderMix() async throws {
         let source = """
 @Article {
    ## The first section
@@ -106,7 +106,7 @@ TutorialArticle @1:1-13:2
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -124,7 +124,7 @@ TutorialArticle @1:1-23:2
         }
     }
     
-    func testIntroAndContent() throws {
+    func testIntroAndContent() async throws {
         let source = """
 @Article(time: 20) {
 
@@ -155,7 +155,7 @@ TutorialArticle @1:1-23:2
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -176,7 +176,7 @@ TutorialArticle @1:1-23:2 title: 'Basic Augmented Reality App' time: '20'
         }
     }
     
-    func testLayouts() throws {
+    func testLayouts() async throws {
         let source = """
 @Article {
 
@@ -265,7 +265,7 @@ TutorialArticle @1:1-23:2 title: 'Basic Augmented Reality App' time: '20'
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -311,7 +311,7 @@ TutorialArticle @1:1-81:2
         }
     }
     
-    func testAssessment() throws {
+    func testAssessment() async throws {
             let source = """
 @Article(time: 20) {
    @Intro(title: "Basic Augmented Reality App") {
@@ -361,7 +361,7 @@ TutorialArticle @1:1-81:2
             let directive = document.child(at: 0) as? BlockDirective
             XCTAssertNotNil(directive)
             
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
             
             directive.map { directive in
                 var problems = [Problem]()
@@ -393,12 +393,12 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
             }
         }
 
-    func testAnalyzeNode() throws {
+    func testAnalyzeNode() async throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         context.topicGraph.addNode(node)
 
         let engine = DiagnosticEngine()
@@ -412,12 +412,12 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
         XCTAssertTrue(source.isFileURL)
     }
 
-    func testAnalyzeExternalNode() throws {
+    func testAnalyzeExternalNode() async throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .external, title: title)
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         context.topicGraph.addNode(node)
 
         let engine = DiagnosticEngine()
@@ -430,14 +430,14 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
         XCTAssertNil(problem.diagnostic.source)
     }
 
-    func testAnalyzeFragmentNode() throws {
+    func testAnalyzeFragmentNode() async throws {
         let title = "unreferenced-tutorial"
         let url = URL(fileURLWithPath: "/path/to/\(title)")
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .range(range, url: url) , title: title)
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         context.topicGraph.addNode(node)
 
         let engine = DiagnosticEngine()
@@ -451,7 +451,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
     }
 
     /// Verify that a `TutorialArticle` only recognizes chapter, volume, or tutorial table-of-contents nodes as valid parents.
-    func testAnalyzeForValidParent() throws {
+    func testAnalyzeForValidParent() async throws {
         func node(withTitle title: String, ofKind kind: DocumentationNode.Kind) -> TopicGraph.Node {
             let url = URL(fileURLWithPath: "/path/to/\(title)")
             let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TutorialArticleTests", path:  "/\(title)", sourceLanguage: .swift)
@@ -459,7 +459,7 @@ TutorialArticle @1:1-42:2 title: 'Basic Augmented Reality App' time: '20'
             return TopicGraph.Node(reference: reference, kind: kind, source: .range(range, url: url) , title: title)
         }
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let tutorialArticleNode = node(withTitle: "tutorial-article", ofKind: .tutorialArticle)
 

--- a/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialReferenceTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class TutorialReferenceTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @TutorialReference
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(tutorialReference)
@@ -30,14 +30,14 @@ class TutorialReferenceTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let tutorialLink = "doc:MyTutorial"
         let source = """
 @TutorialReference(tutorial: "\(tutorialLink)")
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(tutorialReference)
@@ -50,14 +50,14 @@ class TutorialReferenceTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testMissingPath() throws {
+    func testMissingPath() async throws {
         let tutorialLink = "doc:"
         let source = """
         @TutorialReference(tutorial: "\(tutorialLink)")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         var problems = [Problem]()
         let tutorialReference = TutorialReference(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(tutorialReference)

--- a/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/TutorialTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class TutorialTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@Tutorial"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -38,7 +38,7 @@ class TutorialTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let source = """
 @Tutorial(time: 20) {
    @XcodeRequirement(title: "Xcode X.Y Beta Z", destination: "https://www.example.com/download")
@@ -195,7 +195,7 @@ class TutorialTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -280,7 +280,7 @@ Tutorial @1:1-150:2 projectFiles: nil
         }
     }
     
-    func testDuplicateSectionTitle() throws {
+    func testDuplicateSectionTitle() async throws {
         let source = """
 @Tutorial(time: 20) {
    @XcodeRequirement(title: "Xcode X.Y Beta Z", destination: "https://www.example.com/download")
@@ -354,7 +354,7 @@ Tutorial @1:1-150:2 projectFiles: nil
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (bundle, _) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         
         directive.map { directive in
             var problems = [Problem]()
@@ -368,12 +368,12 @@ Tutorial @1:1-150:2 projectFiles: nil
         }
     }
 
-    func testAnalyzeNode() throws {
+    func testAnalyzeNode() async throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .file(url: URL(fileURLWithPath: "/path/to/\(title)")), title: title)
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         context.topicGraph.addNode(node)
 
         let engine = DiagnosticEngine()
@@ -387,12 +387,12 @@ Tutorial @1:1-150:2 projectFiles: nil
         XCTAssertTrue(source.isFileURL)
     }
 
-    func testAnalyzeExternalNode() throws {
+    func testAnalyzeExternalNode() async throws {
         let title = "unreferenced-tutorial"
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .external, title: title)
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         context.topicGraph.addNode(node)
 
         let engine = DiagnosticEngine()
@@ -405,14 +405,14 @@ Tutorial @1:1-150:2 projectFiles: nil
         XCTAssertNil(problem.diagnostic.source)
     }
 
-    func testAnalyzeFragmentNode() throws {
+    func testAnalyzeFragmentNode() async throws {
         let title = "unreferenced-tutorial"
         let url = URL(fileURLWithPath: "/path/to/\(title)")
         let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TopicGraphTests", path: "/\(title)", sourceLanguage: .swift)
         let range = SourceLocation(line: 1, column: 1, source: url)..<SourceLocation(line: 1, column: 1, source: url)
         let node = TopicGraph.Node(reference: reference, kind: .tutorialTableOfContents, source: .range(range, url: url) , title: title)
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
         context.topicGraph.addNode(node)
 
         let engine = DiagnosticEngine()
@@ -426,7 +426,7 @@ Tutorial @1:1-150:2 projectFiles: nil
     }
 
     /// Verify that a `Tutorial` only recognizes chapter, volume, or tutorial table-of-contents nodes as valid parents.
-    func testAnalyzeForValidParent() throws {
+    func testAnalyzeForValidParent() async throws {
         func node(withTitle title: String, ofKind kind: DocumentationNode.Kind) -> TopicGraph.Node {
             let url = URL(fileURLWithPath: "/path/to/\(title)")
             let reference = ResolvedTopicReference(bundleID: "org.swift.docc.TutorialArticleTests", path:  "/\(title)", sourceLanguage: .swift)
@@ -434,7 +434,7 @@ Tutorial @1:1-150:2 projectFiles: nil
             return TopicGraph.Node(reference: reference, kind: kind, source: .range(range, url: url) , title: title)
         }
 
-        let (_, context) = try testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
+        let (_, context) = try await testBundleAndContext(named: "LegacyBundle_DoNotUseInNewTests")
 
         let tutorialNode = node(withTitle: "tutorial-article", ofKind: .tutorial)
 

--- a/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VideoMediaTests.swift
@@ -14,13 +14,13 @@ import Markdown
 import SwiftDocCTestUtilities
 
 class VideoMediaTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @Video
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(video)
@@ -31,7 +31,7 @@ class VideoMediaTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let videoSource = "/path/to/video"
         let poster = "/path/to/poster"
         let source = """
@@ -39,7 +39,7 @@ class VideoMediaTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(video)
@@ -50,7 +50,7 @@ class VideoMediaTests: XCTestCase {
         }
     }
 
-    func testSpacesInSourceAndPoster() throws {
+    func testSpacesInSourceAndPoster() async throws {
         for videoSource in ["my image.mov", "my%20image.mov"] {
             let poster = videoSource.replacingOccurrences(of: ".mov", with: ".png")
             let source = """
@@ -58,7 +58,7 @@ class VideoMediaTests: XCTestCase {
             """
             let document = Document(parsing: source, options: .parseBlockDirectives)
             let directive = document.child(at: 0)! as! BlockDirective
-            let (bundle, _) = try testBundleAndContext()
+            let (bundle, _) = try await testBundleAndContext()
             var problems = [Problem]()
             let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
             XCTAssertNotNil(video)
@@ -70,14 +70,14 @@ class VideoMediaTests: XCTestCase {
         }
     }
     
-    func testIncorrectArgumentLabels() throws {
+    func testIncorrectArgumentLabels() async throws {
         let source = """
         @Video(sourceURL: "/video/path", posterURL: "/poster/path")
         """
         
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let video = VideoMedia(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(video)
@@ -100,10 +100,10 @@ class VideoMediaTests: XCTestCase {
         DataFile(name: "introvideo~dark.mp4", data: Data()),
     ])
     
-    func testRenderVideoDirectiveInReferenceMarkup() throws {
+    func testRenderVideoDirectiveInReferenceMarkup() async throws {
         
         do {
-            let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+            let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
                 """
                 @Video(source: "introvideo")
                 """
@@ -125,7 +125,7 @@ class VideoMediaTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+            let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
                 """
                 @Video(source: "unknown-video")
                 """
@@ -139,7 +139,7 @@ class VideoMediaTests: XCTestCase {
         }
         
         do {
-            let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+            let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
                 """
                 @Video(source: "introvideo", poster: "unknown-poster")
                 """
@@ -161,8 +161,8 @@ class VideoMediaTests: XCTestCase {
         }
     }
     
-    func testRenderVideoDirectiveWithCaption() throws {
-        let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+    func testRenderVideoDirectiveWithCaption() async throws {
+        let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
             """
             @Video(source: "introvideo") {
                 This is my caption.
@@ -185,8 +185,8 @@ class VideoMediaTests: XCTestCase {
         )
     }
     
-    func testRenderVideoDirectiveWithCaptionAndPosterImage() throws {
-        let (renderedContent, problems, video, references) = try parseDirective(VideoMedia.self, catalog: catalog) {
+    func testRenderVideoDirectiveWithCaptionAndPosterImage() async throws {
+        let (renderedContent, problems, video, references) = try await parseDirective(VideoMedia.self, catalog: catalog) {
             """
             @Video(source: "introvideo", alt: "An introductory video", poster: "introposter") {
                 This is my caption.
@@ -217,8 +217,8 @@ class VideoMediaTests: XCTestCase {
         XCTAssertTrue(references.keys.contains("introposter"))
     }
     
-    func testVideoMediaDiagnosesDeviceFrameByDefault() throws {
-        let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+    func testVideoMediaDiagnosesDeviceFrameByDefault() async throws {
+        let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
             """
             @Video(source: "introvideo", deviceFrame: watch)
             """
@@ -239,10 +239,10 @@ class VideoMediaTests: XCTestCase {
         )
     }
     
-    func testRenderVideoDirectiveWithDeviceFrame() throws {
+    func testRenderVideoDirectiveWithDeviceFrame() async throws {
         enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
         
-        let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+        let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
             """
             @Video(source: "introvideo", deviceFrame: watch)
             """
@@ -263,10 +263,10 @@ class VideoMediaTests: XCTestCase {
         )
     }
     
-    func testRenderVideoDirectiveWithCaptionAndDeviceFrame() throws {
+    func testRenderVideoDirectiveWithCaptionAndDeviceFrame() async throws {
         enableFeatureFlag(\.isExperimentalDeviceFrameSupportEnabled)
         
-        let (renderedContent, problems, video, references) = try parseDirective(VideoMedia.self, catalog: catalog) {
+        let (renderedContent, problems, video, references) = try await parseDirective(VideoMedia.self, catalog: catalog) {
             """
             @Video(source: "introvideo", alt: "An introductory video", poster: "introposter", deviceFrame: laptop) {
                 This is my caption.
@@ -297,11 +297,11 @@ class VideoMediaTests: XCTestCase {
         XCTAssertTrue(references.keys.contains("introposter"))
     }
     
-    func testVideoDirectiveDoesNotResolveImageMedia() throws {
+    func testVideoDirectiveDoesNotResolveImageMedia() async throws {
         // The rest of the test in this file will fail if 'introposter' and 'introvideo'
         // do not exist. We just reverse them here to make sure the reference resolving is
         // media-type specific.
-        let (renderedContent, problems, video, _) = try parseDirective(VideoMedia.self, catalog: catalog) {
+        let (renderedContent, problems, video, _) = try await parseDirective(VideoMedia.self, catalog: catalog) {
             """
             @Video(source: "introposter", poster: "introvideo")
             """
@@ -320,13 +320,13 @@ class VideoMediaTests: XCTestCase {
         XCTAssertEqual(renderedContent, [])
     }
     
-    func testVideoDirectiveWithAltText() throws {
+    func testVideoDirectiveWithAltText() async throws {
         let source = """
         @Video(source: "introvideo", alt: "A short video of a sloth jumping down from a branch and smiling.")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, context) = try loadBundle(
+        let (bundle, context) = try await loadBundle(
             catalog: Folder(name: "unit-test.docc", content: [
                 DataFile(name: "introvideo.mov", data: Data())
             ])

--- a/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/VolumeTests.swift
@@ -14,13 +14,13 @@ import Markdown
 import SwiftDocCTestUtilities
 
 class VolumeTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = """
 @Volume
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let volume = Volume(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNil(volume)
@@ -33,7 +33,7 @@ class VolumeTests: XCTestCase {
         ], problems.map { $0.diagnostic.identifier })
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let name = "Always Be Voluming"
         let expectedContent = "Here is some content explaining what this volume is."
         let source = """
@@ -51,7 +51,7 @@ class VolumeTests: XCTestCase {
 """
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0)! as! BlockDirective
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         var problems = [Problem]()
         let volume = Volume(from: directive, source: nil, for: bundle, problems: &problems)
         XCTAssertNotNil(volume)
@@ -62,7 +62,7 @@ class VolumeTests: XCTestCase {
         }
     }
 
-    func testChapterWithSameName() throws {
+    func testChapterWithSameName() async throws {
         let name = "Always Be Voluming"
 
         let catalog = Folder(name: "unit-test.docc", content: [
@@ -97,7 +97,7 @@ class VolumeTests: XCTestCase {
             """)
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         let node = try context.entity(
             with: ResolvedTopicReference(bundleID: bundle.id, path: "/tutorials/TestOverview", sourceLanguage: .swift)
         )

--- a/Tests/SwiftDocCTests/Semantics/XcodeRequirementTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/XcodeRequirementTests.swift
@@ -13,13 +13,13 @@ import XCTest
 import Markdown
 
 class XcodeRequirementTests: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() async throws {
         let source = "@XcodeRequirement"
         let document = Document(parsing: source, options: .parseBlockDirectives)
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()
@@ -38,7 +38,7 @@ class XcodeRequirementTests: XCTestCase {
         }
     }
     
-    func testValid() throws {
+    func testValid() async throws {
         let title = "Xcode 10.2 Beta 3"
         let destination = "https://www.example.com/download"
         let source = """
@@ -48,7 +48,7 @@ class XcodeRequirementTests: XCTestCase {
         let directive = document.child(at: 0) as? BlockDirective
         XCTAssertNotNil(directive)
         
-        let (bundle, _) = try testBundleAndContext()
+        let (bundle, _) = try await testBundleAndContext()
         
         directive.map { directive in
             var problems = [Problem]()

--- a/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
+++ b/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
@@ -87,8 +87,8 @@ extension XCTestCase {
         for bundleName: String,
         sourceRepository: SourceRepository? = nil,
         configureBundle: ((URL) throws -> Void)? = nil
-    ) throws -> TestRenderNodeOutputConsumer {
-        let (_, bundle, context) = try testBundleAndContext(
+    ) async throws -> TestRenderNodeOutputConsumer {
+        let (_, bundle, context) = try await testBundleAndContext(
             copying: bundleName,
             configureBundle: configureBundle
         )

--- a/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -74,8 +74,8 @@ class ListItemExtractorTests: XCTestCase {
         XCTAssert(extractedTags("- PossibleValue: Missing value name.").possiblePropertyListValues.isEmpty)
     }
     
-    func testExtractingTags() throws {
-        try assertExtractsRichContentFor(
+    func testExtractingTags() async throws {
+        try await assertExtractsRichContentFor(
             tagName: "Returns",
             findModelContent: { semantic in
                 semantic.returnsSection?.content
@@ -83,7 +83,7 @@ class ListItemExtractorTests: XCTestCase {
             renderContentSectionTitle: "Return Value"
         )
 
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "Note",
             isAside: true,
             findModelContent: { semantic in
@@ -105,7 +105,7 @@ class ListItemExtractorTests: XCTestCase {
             })
         )
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "Precondition",
             isAside: true,
             findModelContent: { semantic in
@@ -127,7 +127,7 @@ class ListItemExtractorTests: XCTestCase {
             })
         )
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "Parameter someParameterName",
             findModelContent: { semantic in
                 semantic.parametersSection?.parameters.first?.contents
@@ -140,7 +140,7 @@ class ListItemExtractorTests: XCTestCase {
             })
         )
         
-        try assertExtractsRichContentOutlineFor(
+        try await assertExtractsRichContentOutlineFor(
             tagName: "Parameters",
             findModelContent: { semantic in
                 semantic.parametersSection?.parameters.first?.contents
@@ -156,7 +156,7 @@ class ListItemExtractorTests: XCTestCase {
         // Dictionary and HTTP tags are filtered out from the rendering without symbol information.
         // These test helpers can't easily set up a bundle that supports general tags, REST tags, and HTTP tags.
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "DictionaryKey someKey",
             findModelContent: { semantic in
                 semantic.dictionaryKeysSection?.dictionaryKeys.first?.contents
@@ -164,7 +164,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentOutlineFor(
+        try await assertExtractsRichContentOutlineFor(
             tagName: "DictionaryKeys",
             findModelContent: { semantic in
                 semantic.dictionaryKeysSection?.dictionaryKeys.first?.contents
@@ -172,7 +172,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "HTTPResponse 200",
             findModelContent: { semantic in
                 semantic.httpResponsesSection?.responses.first?.contents
@@ -180,7 +180,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentOutlineFor(
+        try await assertExtractsRichContentOutlineFor(
             tagName: "HTTPResponses",
             findModelContent: { semantic in
                 semantic.httpResponsesSection?.responses.first?.contents
@@ -188,7 +188,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "httpBody",
             findModelContent: { semantic in
                 semantic.httpBodySection?.body.contents
@@ -196,7 +196,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "HTTPParameter someParameter",
             findModelContent: { semantic in
                 semantic.httpParametersSection?.parameters.first?.contents
@@ -204,7 +204,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentOutlineFor(
+        try await assertExtractsRichContentOutlineFor(
             tagName: "HTTPParameters",
             findModelContent: { semantic in
                 semantic.httpParametersSection?.parameters.first?.contents
@@ -212,7 +212,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentFor(
+        try await assertExtractsRichContentFor(
             tagName: "HTTPBodyParameter someParameter",
             findModelContent: { semantic in
                 semantic.httpBodySection?.body.parameters.first?.contents
@@ -220,7 +220,7 @@ class ListItemExtractorTests: XCTestCase {
             renderVerification: .skip
         )
         
-        try assertExtractsRichContentOutlineFor(
+        try await assertExtractsRichContentOutlineFor(
             tagName: "HTTPBodyParameters",
             findModelContent: { semantic in
                 semantic.httpBodySection?.body.parameters.first?.contents
@@ -237,8 +237,8 @@ class ListItemExtractorTests: XCTestCase {
         renderContentSectionTitle: String,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws {
-        try assertExtractsRichContentFor(
+    ) async throws {
+        try await assertExtractsRichContentFor(
             tagName: tagName,
             isAside: false,
             findModelContent: findModelContent,
@@ -270,10 +270,10 @@ class ListItemExtractorTests: XCTestCase {
         renderVerification: RenderVerification,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws {
+    ) async throws {
         // Build documentation for a module page with one tagged item with a lot of different
         
-        let (bundle, context) = try loadBundle(
+        let (bundle, context) = try await loadBundle(
             catalog: Folder(name: "Something.docc", content: [
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
                 TextFile(name: "Extension.md", utf8Content: """
@@ -336,10 +336,10 @@ class ListItemExtractorTests: XCTestCase {
         renderVerification: RenderVerification,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws {
+    ) async throws {
         // Build documentation for a module page with one tagged item with a lot of different
         
-        let (bundle, context) = try loadBundle(
+        let (bundle, context) = try await loadBundle(
             catalog: Folder(name: "Something.docc", content: [
                 JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
                 TextFile(name: "Extension.md", utf8Content: """

--- a/Tests/SwiftDocCTests/Utility/XCTestCase+MentionedIn.swift
+++ b/Tests/SwiftDocCTests/Utility/XCTestCase+MentionedIn.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,7 @@ import SymbolKit
 
 extension XCTestCase {
     /// Creates a test bundle for testing "Mentioned In" features.
-    func createMentionedInTestBundle() throws -> (DocumentationBundle, DocumentationContext) {
+    func createMentionedInTestBundle() async throws -> (DocumentationBundle, DocumentationContext) {
         let catalog = Folder(name: "MentionedIn.docc", content: [
             JSONFile(name: "MentionedIn.symbols.json", content: makeSymbolGraph(
                 moduleName: "MentionedIn",
@@ -72,7 +72,7 @@ extension XCTestCase {
                  """),
         ])
 
-        let (bundle, context) = try loadBundle(catalog: catalog)
+        let (bundle, context) = try await loadBundle(catalog: catalog)
         return (bundle, context)
     }
 }

--- a/Tests/SwiftDocCUtilitiesTests/ConvertActionIndexerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/ConvertActionIndexerTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,11 +16,11 @@ import Foundation
 class ConvertActionIndexerTests: XCTestCase {
     
     // Tests the standalone indexer
-    func testConvertActionIndexer() throws {
+    func testConvertActionIndexer() async throws {
         let (bundle, dataProvider) = try DocumentationContext.InputsProvider()
             .inputsAndDataProvider(startingPoint: testCatalogURL(named: "LegacyBundle_DoNotUseInNewTests"), options: .init())
         
-        let context = try DocumentationContext(bundle: bundle, dataProvider: dataProvider)
+        let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider)
         let converter = DocumentationNodeConverter(bundle: bundle, context: context)
         
         // Add /documentation/MyKit to the index, verify the tree dump

--- a/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/MergeActionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -849,7 +849,7 @@ class MergeActionTests: XCTestCase {
         let baseOutputDir = URL(fileURLWithPath: "/path/to/some-output-dir")
         try fileSystem.createDirectory(at: baseOutputDir, withIntermediateDirectories: true)
         
-        func convertCatalog(named name: String, file: StaticString = #filePath, line: UInt = #line) throws -> URL {
+        func convertCatalog(named name: String, file: StaticString = #filePath, line: UInt = #line) async throws -> URL {
             let catalog = Folder(name: "\(name).docc", content: [
                 TextFile(name: "\(name).md", utf8Content: """
                 # My root
@@ -882,7 +882,7 @@ class MergeActionTests: XCTestCase {
                 "\(name.lowercased())-card.png",
             ])
             
-            let context = try DocumentationContext(bundle: bundle, dataProvider: dataProvider, configuration: .init())
+            let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider, configuration: .init())
 
             XCTAssert(
                 context.problems.filter { $0.diagnostic.identifier != "org.swift.docc.SummaryContainsLink" }.isEmpty,
@@ -933,8 +933,8 @@ class MergeActionTests: XCTestCase {
             return outputPath
         }
         
-        let firstArchiveDir  = try convertCatalog(named: "First")
-        let secondArchiveDir = try convertCatalog(named: "Second")
+        let firstArchiveDir  = try await convertCatalog(named: "First")
+        let secondArchiveDir = try await convertCatalog(named: "Second")
         
         let combinedArchiveDir = URL(fileURLWithPath: "/Output.doccarchive")
         let action = MergeAction(

--- a/Tests/SwiftDocCUtilitiesTests/SemanticAnalyzerTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/SemanticAnalyzerTests.swift
@@ -54,14 +54,14 @@ class SemanticAnalyzerTests: XCTestCase {
         InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
     ])
     
-    func testDoNotCrashOnInvalidContent() throws {
-        let (bundle, context) = try loadBundle(catalog: catalogHierarchy)
+    func testDoNotCrashOnInvalidContent() async throws {
+        let (bundle, context) = try await loadBundle(catalog: catalogHierarchy)
         
         XCTAssertThrowsError(try context.entity(with: ResolvedTopicReference(bundleID: bundle.id, path: "/Oops", sourceLanguage: .swift)))
     }
     
-    func testWarningsAboutDirectiveSupport() throws {
-        func problemsConvertingTestContent(withFileExtension fileExtension: String) throws -> (unsupportedTopLevelChildProblems: [Problem], missingTopLevelChildProblems: [Problem]) {
+    func testWarningsAboutDirectiveSupport() async throws {
+        func problemsConvertingTestContent(withFileExtension fileExtension: String) async throws -> (unsupportedTopLevelChildProblems: [Problem], missingTopLevelChildProblems: [Problem]) {
             let catalogHierarchy = Folder(name: "SemanticAnalyzerTests.docc", content: [
                 TextFile(name: "FileWithDirective.\(fileExtension)", utf8Content: """
                 @Article
@@ -73,7 +73,7 @@ class SemanticAnalyzerTests: XCTestCase {
                 """),
                 InfoPlist(displayName: "TestBundle", identifier: "com.test.example"),
             ])
-            let (_, context) = try loadBundle(catalog: catalogHierarchy)
+            let (_, context) = try await loadBundle(catalog: catalogHierarchy)
             
             return (
                 context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.unsupportedTopLevelChild" }),
@@ -82,7 +82,7 @@ class SemanticAnalyzerTests: XCTestCase {
         }
         
         do {
-            let problems = try problemsConvertingTestContent(withFileExtension: "md")
+            let problems = try await problemsConvertingTestContent(withFileExtension: "md")
             
             XCTAssertEqual(problems.missingTopLevelChildProblems.count, 0)
             XCTAssertEqual(problems.unsupportedTopLevelChildProblems.count, 1)
@@ -95,7 +95,7 @@ class SemanticAnalyzerTests: XCTestCase {
         }
         
         do {
-            let problems = try problemsConvertingTestContent(withFileExtension: "tutorial")
+            let problems = try await problemsConvertingTestContent(withFileExtension: "tutorial")
             
             XCTAssertEqual(problems.missingTopLevelChildProblems.count, 1)
             XCTAssertEqual(problems.unsupportedTopLevelChildProblems.count, 0)
@@ -109,8 +109,8 @@ class SemanticAnalyzerTests: XCTestCase {
         }
     }
     
-    func testDoesNotWarnOnEmptyTutorials() throws {
-        let (bundle, _) = try loadBundle(catalog: catalogHierarchy)
+    func testDoesNotWarnOnEmptyTutorials() async throws {
+        let (bundle, _) = try await loadBundle(catalog: catalogHierarchy)
         
         let document = Document(parsing: "", options: .parseBlockDirectives)
         var analyzer = SemanticAnalyzer(source: URL(string: "/empty.tutorial"), bundle: bundle)

--- a/Tests/SwiftDocCUtilitiesTests/XCTestCase+LoadingData.swift
+++ b/Tests/SwiftDocCUtilitiesTests/XCTestCase+LoadingData.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -25,13 +25,13 @@ extension XCTestCase {
         catalog: Folder,
         otherFileSystemDirectories: [Folder] = [],
         configuration: DocumentationContext.Configuration = .init()
-    ) throws -> (DocumentationBundle, DocumentationContext) {
+    ) async throws -> (DocumentationBundle, DocumentationContext) {
         let fileSystem = try TestFileSystem(folders: [catalog] + otherFileSystemDirectories)
         
         let (bundle, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
             .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/\(catalog.name)"), options: .init())
 
-        let context = try DocumentationContext(bundle: bundle, dataProvider: dataProvider, configuration: configuration)
+        let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider, configuration: configuration)
         return (bundle, context)
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable:

## Summary

Today we use GCD in `DocumentationContext.register(_:)` to concurrently load articles, decode json, and do other work.
Because `DispatchGroup.wait()` waits _synchronously_, `register(_:)` can also be a synchronous call.

This is a 200 line change with 2000 lines of unavoidable modifications in tests.

Assuming that we want to start using Swift Concurrency in this code _someday_, we need to make this an _asynchronous_ call instead.
We can mark an API as `async` without making any awaiting calls in its implementation but all callers need to `await` when calling this API (and the callers needs to be marked `async` which means that their callers need to `await` etc.). See also [What Color is Your Function?](https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/).

Because `DocumentationContext.register(_:)` is used by the deprecated public `DocumentationContext.init(dataProvider:diagnosticEngine:configuration:)` initializer, we would need to make that initializer `async` if we made `register(_:)` asynchronous but that would be a source breaking change because callers who depend on Swift DocC would need to add an `await` keyword in their code (and potentially mark their calling code `async` as well).
However, we _can_ mark the new `DocumentationContext.init(bundle:dataProvider:diagnosticEngine:configuration:)` initializer as asynchronous without breaking library consumers because it is still only accessible within the package.

### Why do this now?

After 6.2 is released we will remove the deprecated `DocumentationContext` initializer.
However, we don't have any other API for library consumers to create a documentation context, so we need to add _some_ public replacement.

If we promote the new initializer from package access to public access while it is still a synchronous call, we add another synchronous caller to `register(_:)` and therefore delay when we can start adopting Swift Concurrency by at least another release cycle (because we'd need to deprecate the new initializer, and introduce an asynchronous replacement, and wait until we can remove the _new_ deprecated initializer before we can make anything it calls asynchronous).

However, if we make the new public replacement API for creating documentation contexts asynchronous from the start, we have nothing technically preventing us from adopting Swift Concurrency in this code after 6.2 is released.

### What "shape" should this new API have?

It's not really important how this new API for creating documentation context "looks". For our ability to start adopting Swift Concurrency it only matters that it's asynchronous.

Three possible alternatives could be:

- An initializer (like in this PR)
  ```swift
  let context = try await DocumentationContext(...)
  ```
  
- An static method on the context type itself (or another type)
  ```swift
  let context = try await DocumentationContext.makeContext(...)
  ```
  
- An (consuming) method on another type itself (like a hypothetical "builder")
  ```swift
  let builder = DocumentationContext.Builder(...)
  let context = try await builder.build()
  ```
  
The "shape" of this public API doesn't meaningfully impact the internal implementation. For example, we could have a private builder type internal to the initializer if we wanted to separate the context creation code from the rest of the context code.

Also, needing to deprecate one "shape" of asynchronous API to replace it with another "shape" of asynchronous API doesn't affect our ability to adopt Swift Concurrency.

### More details about these change

The key change in this PR is adding the `async` keyword to the package access `DocumentationContext` initializer [here](https://github.com/swiftlang/swift-docc/pull/1244/files#diff-c452db10128fc43b2e77212a1a282fe0834e541e10852fa8dd50f7c9b480b4e7R326)

Two of the three places that calls this initializer (except for tests) is `ConvertAction.perform(logHandle:)` and `EmitGeneratedCurationAction.perform(logHandle:)` and which are already asynchronous.
The ConvertAction code needed [one small update to a signpost call](https://github.com/swiftlang/swift-docc/pull/1244/files#diff-be716f893a903f4ca669b5d3a4306bb39e745fffbcdea448bcb3640831bc25b5) to support awaiting the context creation.

The only other place that calls this initializer is the `ConvertService.process(_:completion:)`.
Despite the completion handler parameter, this is actually a synchronous API which is possibly unexpected for the caller.
However, the fact that it has a completion handler means that we can easily make it non-blocking for the caller.
I did this my introducing an `async` alternative and having the completion handler version of the API call the asynchronous API inside a Task.
The internal implementation of `process(...)` made heavy use of `Result` type to no real benefit but negative impacts on its readability—requiring the reader to jump between 3 private helper functions that unwrapped an optional, decoded a codable value, and encoded a codable value—and the ability to use asynchronous calls.
By inlining these simple one-liners and abandoning the use of `Result` types in this code, the code got half as long and all the basic message processing code can be read linearly in one place with only the business logic in a separate private helper function.

All the other ~2000 lines modified are all in unit tests. These changes are unavoidable no matter the "shape" of the asynchronous context creation API.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary

