### PR TITLE
enforce overload declaration ordering when computing the highlighted differences

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -44,13 +44,17 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
     /// Fetch the common fragments for the given references, or compute it if necessary.
     func commonFragments(
         for mainDeclaration: OverloadDeclaration,
-        overloadDeclarations: [OverloadDeclaration]
+        overloadDeclarations: [OverloadDeclaration],
+        mainDeclarationIndex: Int
     ) -> [SymbolGraph.Symbol.DeclarationFragments.Fragment] {
         if let fragments = commonFragments(for: mainDeclaration.reference) {
             return fragments
         }
 
-        let preProcessedDeclarations = [mainDeclaration.declaration] + overloadDeclarations.map(\.declaration)
+        var preProcessedDeclarations = overloadDeclarations.map(\.declaration)
+        // Insert the main declaration according to the display index so the ordering is consistent
+        // between overloaded symbols
+        preProcessedDeclarations.insert(mainDeclaration.declaration, at: mainDeclarationIndex)
 
         // Collect the "common fragments" so we can highlight the ones that are different
         // in each declaration
@@ -216,7 +220,9 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                     // in each declaration
                     let commonFragments = commonFragments(
                         for: (mainDeclaration, renderNode.identifier, nil),
-                        overloadDeclarations: processedOverloadDeclarations)
+                        overloadDeclarations: processedOverloadDeclarations,
+                        mainDeclarationIndex: overloads.displayIndex
+                    )
 
                     renderedTokens = translateDeclaration(
                         mainDeclaration,

--- a/Tests/SwiftDocCTests/Test Resources/FancierOverloads.symbols.json
+++ b/Tests/SwiftDocCTests/Test Resources/FancierOverloads.symbols.json
@@ -1,0 +1,404 @@
+{
+  "metadata": {
+    "formatVersion": {
+      "major": 0,
+      "minor": 6,
+      "patch": 0
+    },
+    "generator": "Apple Swift version 6.2 (swiftlang-6.2.0.13.10 clang-1700.3.13.4)"
+  },
+  "module": {
+    "name": "FancierOverloads",
+    "platform": {
+      "architecture": "arm64",
+      "vendor": "apple",
+      "operatingSystem": {
+        "name": "macosx",
+        "minimumVersion": {
+          "major": 12,
+          "minor": 4
+        }
+      }
+    }
+  },
+  "symbols": [
+    {
+      "kind": {
+        "identifier": "swift.class",
+        "displayName": "Class"
+      },
+      "identifier": {
+        "precise": "s:13FancierOverloads7MyClassC",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "MyClass"
+      ],
+      "names": {
+        "title": "MyClass",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "class"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "MyClass"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "MyClass"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.protocol",
+        "displayName": "Protocol"
+      },
+      "identifier": {
+        "precise": "s:13FancierOverloads20ConvertibleToMyClassP",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "ConvertibleToMyClass"
+      ],
+      "names": {
+        "title": "ConvertibleToMyClass",
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "ConvertibleToMyClass"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "protocol"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "ConvertibleToMyClass"
+          }
+        ]
+      },
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "protocol"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "ConvertibleToMyClass"
+        }
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:13FancierOverloads11doSomething4withyAA7MyClassC_tF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "doSomething(with:)"
+      ],
+      "names": {
+        "title": "doSomething(with:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "doSomething"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "with"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "MyClass",
+            "preciseIdentifier": "s:13FancierOverloads7MyClassC"
+          },
+          {
+            "kind": "text",
+            "spelling": ") "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "throws"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "with",
+            "internalName": "object",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "object"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "MyClass",
+                "preciseIdentifier": "s:13FancierOverloads7MyClassC"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "declarationFragments": [
+          {
+            "kind" : "keyword",
+            "spelling" : "init"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "externalParam",
+            "spelling" : "_"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "internalParam",
+            "spelling" : "content"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:13FancierOverloads7MyClassC",
+            "spelling" : "MyClass"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ") "
+          },
+          {
+            "kind" : "keyword",
+            "spelling" : "throws"
+          }
+
+      ],
+      "accessLevel": "public"
+    },
+    {
+      "kind": {
+        "identifier": "swift.func",
+        "displayName": "Function"
+      },
+      "identifier": {
+        "precise": "s:13FancierOverloads11doSomething4withyx_tAA20ConvertibleToMyClassRzlF",
+        "interfaceLanguage": "swift"
+      },
+      "pathComponents": [
+        "doSomething(with:)"
+      ],
+      "names": {
+        "title": "doSomething(with:)",
+        "subHeading": [
+          {
+            "kind": "keyword",
+            "spelling": "func"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "identifier",
+            "spelling": "doSomething"
+          },
+          {
+            "kind": "text",
+            "spelling": "("
+          },
+          {
+            "kind": "externalParam",
+            "spelling": "with"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "keyword",
+            "spelling": "some"
+          },
+          {
+            "kind": "text",
+            "spelling": " "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "ConvertibleToMyClass",
+            "preciseIdentifier": "s:13FancierOverloads20ConvertibleToMyClassP"
+          },
+          {
+            "kind": "text",
+            "spelling": ")"
+          }
+        ]
+      },
+      "functionSignature": {
+        "parameters": [
+          {
+            "name": "with",
+            "internalName": "factory",
+            "declarationFragments": [
+              {
+                "kind": "identifier",
+                "spelling": "factory"
+              },
+              {
+                "kind": "text",
+                "spelling": ": "
+              },
+              {
+                "kind": "keyword",
+                "spelling": "some"
+              },
+              {
+                "kind": "text",
+                "spelling": " "
+              },
+              {
+                "kind": "typeIdentifier",
+                "spelling": "ConvertibleToMyClass",
+                "preciseIdentifier": "s:13FancierOverloads20ConvertibleToMyClassP"
+              }
+            ]
+          }
+        ],
+        "returns": [
+          {
+            "kind": "text",
+            "spelling": "()"
+          }
+        ]
+      },
+      "swiftGenerics": {
+        "constraints": [
+          {
+            "kind": "conformance",
+            "lhs": "some ConvertibleToMyClass",
+            "rhs": "ConvertibleToMyClass",
+            "rhsPrecise": "s:13FancierOverloads20ConvertibleToMyClassP"
+          }
+        ]
+      },
+      "declarationFragments": [
+          {
+            "kind" : "keyword",
+            "spelling" : "init"
+          },
+          {
+            "kind" : "text",
+            "spelling" : "("
+          },
+          {
+            "kind" : "externalParam",
+            "spelling" : "_"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "internalParam",
+            "spelling" : "content"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ": "
+          },
+          {
+            "kind" : "keyword",
+            "spelling" : "some"
+          },
+          {
+            "kind" : "text",
+            "spelling" : " "
+          },
+          {
+            "kind" : "typeIdentifier",
+            "preciseIdentifier" : "s:13FancierOverloads20ConvertibleToMyClassP",
+            "spelling" : "ConvertibleToMyClass"
+          },
+          {
+            "kind" : "text",
+            "spelling" : ")"
+          }
+      ],
+      "accessLevel": "public"
+    }
+  ],
+  "relationships": []
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://155975575

## Summary

When performing difference highlighting in the experimental overloaded symbol presentation (added in https://github.com/swiftlang/swift-docc/pull/928), the "longest common subsequence" is found based on the declaration fragments of all the overloaded symbols. However, there are some situations in which the order of declarations affects the resulting sequence, specifically when there can be multiple solutions with the same length. This can lead to situations where the same content can produce different rendered output, depending on which symbol's highlighting is computed first (since the results are memoized as of #992).

This PR removes this nondeterminism by enforcing that the declarations are ordered by their display order before computing the LCS.

## Dependencies

None

## Testing

Reducing this problem into a unit test is difficult, because the problem may not surface in a very small framework without many repetitions. The symbol graph added for this PR's test was modified from its original output to ensure the test data matched the real-world symbols that were exhibiting the issue, and even then the issue actually failed to show up in local testing. Still, the test does effectively demonstrate the issue.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
