### PR TITLE
Populate symbol kind in external render nodes

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/External Data/OutOfProcessReferenceResolver.swift
@@ -182,7 +182,12 @@ public class OutOfProcessReferenceResolver: ExternalDocumentationSource, GlobalE
             imageReferences: (resolvedInformation.references ?? []).compactMap { $0 as? ImageReference }
         )
         
-        return LinkResolver.ExternalEntity(topicRenderReference: renderReference, renderReferenceDependencies: dependencies, sourceLanguages: resolvedInformation.availableLanguages)
+        return LinkResolver.ExternalEntity(
+            topicRenderReference: renderReference,
+            renderReferenceDependencies: dependencies,
+            sourceLanguages: resolvedInformation.availableLanguages,
+            symbolKind: DocumentationNode.symbolKind(for: resolvedInformation.kind)
+        )
     }
     
     // MARK: Implementation

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/ExternalPathHierarchyResolver.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -109,7 +109,8 @@ final class ExternalPathHierarchyResolver {
         return .init(
             topicRenderReference: resolvedInformation.topicRenderReference(),
             renderReferenceDependencies: dependencies,
-            sourceLanguages: resolvedInformation.availableLanguages
+            sourceLanguages: resolvedInformation.availableLanguages,
+            symbolKind: DocumentationNode.symbolKind(for: resolvedInformation.kind)
         )
     }
     

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver+NavigatorIndex.swift
@@ -39,9 +39,10 @@ package struct ExternalRenderNode {
     }
     
     /// The symbol kind of this documentation node.
+    ///
+    /// This value is `nil` if the referenced page is not a symbol.
     var symbolKind: SymbolGraph.Symbol.KindIdentifier? {
-        // Symbol kind information is not available for external entities
-        return nil
+        externalEntity.symbolKind
     }
     
     /// The additional "role" assigned to the symbol, if any
@@ -116,7 +117,7 @@ struct NavigatorExternalRenderNode: NavigatorIndexableRenderNodeRepresentation {
             navigatorTitle: renderNode.navigatorTitleVariants.value(for: traits),
             externalID: renderNode.externalIdentifier.identifier,
             role: renderNode.role,
-            symbolKind: renderNode.symbolKind?.identifier,
+            symbolKind: renderNode.symbolKind?.renderingIdentifier,
             images: renderNode.images,
             isBeta: renderNode.isBeta
         )

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver.swift
@@ -9,7 +9,7 @@
 */
 
 import Foundation
-import SymbolKit
+public import SymbolKit
 
 /// A class that resolves documentation links by orchestrating calls to other link resolver implementations.
 public class LinkResolver {
@@ -48,11 +48,18 @@ public class LinkResolver {
         ///   - topicRenderReference: The render reference for this external topic.
         ///   - renderReferenceDependencies: Any dependencies for the render reference.
         ///   - sourceLanguages: The different source languages for which this page is available.
+        ///   - symbolKind: The kind of symbol that's being referenced.
         @_spi(ExternalLinks)
-        public init(topicRenderReference: TopicRenderReference, renderReferenceDependencies: RenderReferenceDependencies, sourceLanguages: Set<SourceLanguage>) {
+        public init(
+            topicRenderReference: TopicRenderReference,
+            renderReferenceDependencies: RenderReferenceDependencies,
+            sourceLanguages: Set<SourceLanguage>,
+            symbolKind: SymbolGraph.Symbol.KindIdentifier? = nil
+        ) {
             self.topicRenderReference = topicRenderReference
             self.renderReferenceDependencies = renderReferenceDependencies
             self.sourceLanguages = sourceLanguages
+            self.symbolKind = symbolKind
         }
         
         /// The render reference for this external topic.
@@ -63,7 +70,13 @@ public class LinkResolver {
         var renderReferenceDependencies: RenderReferenceDependencies
         /// The different source languages for which this page is available.
         var sourceLanguages: Set<SourceLanguage>
-        
+        /// The kind of symbol that's being referenced.
+        ///
+        /// This value is `nil` if the entity does not reference a symbol.
+        ///
+        /// For example, the navigator requires specific knowledge about what type of external symbol is being linked to.
+        var symbolKind: SymbolGraph.Symbol.KindIdentifier?
+
         /// Creates a pre-render new topic content value to be added to a render context's reference store.
         func topicContent() -> RenderReferenceStore.TopicContent {
             return .init(

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -674,6 +674,7 @@ public struct DocumentationNode {
         case .union: return .union
         case .`var`: return .globalVariable
         case .module: return .module
+        case .extension: return .extension
         case .extendedModule: return .extendedModule
         case .extendedStructure: return .extendedStructure
         case .extendedClass: return .extendedClass
@@ -681,6 +682,55 @@ public struct DocumentationNode {
         case .extendedProtocol: return .extendedProtocol
         case .unknownExtendedType: return .unknownExtendedType
         default: return .unknown
+        }
+    }
+    
+    /// Returns a symbol kind for the given documentation node.
+    /// - Parameter symbol: A documentation node kind.
+    /// - Returns: A symbol graph symbol.
+    static func symbolKind(for kind: Kind) -> SymbolGraph.Symbol.KindIdentifier? {
+        switch kind {
+        case .associatedType: return .`associatedtype`
+        case .class: return .`class`
+        case .deinitializer: return .`deinit`
+        case .dictionary, .object: return .dictionary
+        case .dictionaryKey: return .dictionaryKey
+        case .enumeration: return .`enum`
+        case .enumerationCase: return .`case`
+        case .function: return .`func`
+        case .httpRequest: return .httpRequest
+        case .httpParameter: return .httpParameter
+        case .httpBody: return .httpBody
+        case .httpResponse: return .httpResponse
+        case .operator: return .`operator`
+        case .initializer: return .`init`
+        case .instanceVariable: return .ivar
+        case .macro: return .macro
+        case .instanceMethod: return .`method`
+        case .namespace: return .namespace
+        case .instanceProperty: return .`property`
+        case .protocol: return .`protocol`
+        case .snippet: return .snippet
+        case .structure: return .`struct`
+        case .instanceSubscript: return .`subscript`
+        case .typeMethod: return .`typeMethod`
+        case .typeProperty, .typeConstant: return .`typeProperty`
+        case .typeSubscript: return .`typeSubscript`
+        case .typeAlias, .typeDef: return .`typealias`
+        case .union: return .union
+        case .globalVariable, .localVariable: return .`var`
+        case .module: return .module
+        case .extension: return .extension
+        case .extendedModule: return .extendedModule
+        case .extendedStructure: return .extendedStructure
+        case .extendedClass: return .extendedClass
+        case .extendedEnumeration: return .extendedEnumeration
+        case .extendedProtocol: return .extendedProtocol
+        case .unknownExtendedType: return .unknownExtendedType
+        default:
+            // For non-symbol kinds (like .article, .tutorial, etc.),
+            // return nil since these don't have corresponding SymbolGraph.Symbol.KindIdentifier values
+            return nil
         }
     }
     

--- a/Tests/SwiftDocCTests/Benchmark/ExternalTopicsHashTests.swift
+++ b/Tests/SwiftDocCTests/Benchmark/ExternalTopicsHashTests.swift
@@ -31,7 +31,8 @@ class ExternalTopicsGraphHashTests: XCTestCase {
                     estimatedTime: nil
                 ),
                 renderReferenceDependencies: .init(),
-                sourceLanguages: [.swift]
+                sourceLanguages: [.swift],
+                symbolKind: .class
             )
             return (reference, entity)
         }

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -97,7 +97,7 @@ class ExternalRenderNodeTests: XCTestCase {
 
         XCTAssertEqual(externalRenderNodes[1].identifier.absoluteString, "doc://org.swift.MixedLanguageFramework/example/path/to/external/objCSymbol")
         XCTAssertEqual(externalRenderNodes[1].kind, .symbol)
-        XCTAssertEqual(externalRenderNodes[1].symbolKind, nil)
+        XCTAssertEqual(externalRenderNodes[1].symbolKind, .func)
         XCTAssertEqual(externalRenderNodes[1].role, "symbol")
         XCTAssertEqual(externalRenderNodes[1].externalIdentifier.identifier, "doc://com.test.external/path/to/external/objCSymbol")
         XCTAssertFalse(externalRenderNodes[1].isBeta)
@@ -111,7 +111,7 @@ class ExternalRenderNodeTests: XCTestCase {
         
         XCTAssertEqual(externalRenderNodes[3].identifier.absoluteString, "doc://org.swift.MixedLanguageFramework/example/path/to/external/swiftSymbol")
         XCTAssertEqual(externalRenderNodes[3].kind, .symbol)
-        XCTAssertEqual(externalRenderNodes[3].symbolKind, nil)
+        XCTAssertEqual(externalRenderNodes[3].symbolKind, .class)
         XCTAssertEqual(externalRenderNodes[3].role, "symbol")
         XCTAssertEqual(externalRenderNodes[3].externalIdentifier.identifier, "doc://com.test.external/path/to/external/swiftSymbol")
         XCTAssertTrue(externalRenderNodes[3].isBeta)
@@ -143,7 +143,8 @@ class ExternalRenderNodeTests: XCTestCase {
                 navigatorTitleVariants: .init(defaultValue: navigatorTitle, objectiveCValue: occNavigatorTitle)
             ),
             renderReferenceDependencies: .init(),
-            sourceLanguages: [SourceLanguage(name: "swift"), SourceLanguage(name: "objc")])
+            sourceLanguages: [SourceLanguage(name: "swift"), SourceLanguage(name: "objc")],
+            symbolKind: .func)
         let externalRenderNode = ExternalRenderNode(
             externalEntity: externalEntity,
             bundleIdentifier: "com.test.external"
@@ -222,6 +223,8 @@ class ExternalRenderNodeTests: XCTestCase {
         XCTAssert(swiftExternalNodes.first { $0.title == "SwiftSymbol" }?.isBeta == true)
         XCTAssert(occExternalNodes.first { $0.title == "ObjCArticle" }?.isBeta == true)
         XCTAssert(occExternalNodes.first { $0.title == "ObjCSymbol" }?.isBeta == false)
+        XCTAssertEqual(swiftExternalNodes.map(\.type), ["article", "class"])
+        XCTAssertEqual(occExternalNodes.map(\.type), ["article", "func"])
     }
     
     func testNavigatorWithExternalNodesOnlyAddsCuratedNodesToNavigator() async throws {
@@ -282,6 +285,8 @@ class ExternalRenderNodeTests: XCTestCase {
         XCTAssertEqual(occExternalNodes.map(\.title), ["ObjCSymbol"])
         XCTAssert(swiftExternalNodes.allSatisfy(\.isExternal))
         XCTAssert(occExternalNodes.allSatisfy(\.isExternal))
+        XCTAssertEqual(swiftExternalNodes.map(\.type), ["article"])
+        XCTAssertEqual(occExternalNodes.map(\.type), ["func"])
     }
 
     func testExternalRenderNodeVariantRepresentationWhenIsBeta() throws {

--- a/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/ExternalReferenceResolverTests.swift
@@ -52,7 +52,8 @@ class ExternalReferenceResolverTests: XCTestCase {
                     }
                 ),
                 renderReferenceDependencies: RenderReferenceDependencies(),
-                sourceLanguages: [resolvedEntityLanguage]
+                sourceLanguages: [resolvedEntityLanguage],
+                symbolKind: nil
             )
         }
     }
@@ -641,7 +642,8 @@ class ExternalReferenceResolverTests: XCTestCase {
                         estimatedTime: nil
                     ),
                     renderReferenceDependencies: RenderReferenceDependencies(),
-                    sourceLanguages: [.swift]
+                    sourceLanguages: [.swift],
+                    symbolKind: .property
                 )
             }
         }

--- a/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/TestExternalReferenceResolvers.swift
@@ -110,7 +110,8 @@ class TestMultiResultExternalReferenceResolver: ExternalDocumentationSource {
                 images: entityInfo.topicImages?.map(\.0) ?? []
             ),
             renderReferenceDependencies: dependencies,
-            sourceLanguages: [entityInfo.language]
+            sourceLanguages: [entityInfo.language],
+            symbolKind: DocumentationNode.symbolKind(for: entityInfo.kind)
         )
     }
 }

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeTests.swift
@@ -1188,7 +1188,8 @@ class SemaToRenderNodeTests: XCTestCase {
                         estimatedTime: nil
                     ),
                     renderReferenceDependencies: .init(),
-                    sourceLanguages: [.objectiveC]
+                    sourceLanguages: [.objectiveC],
+                    symbolKind: .class
                 )
                 return (reference, entity)
             }
@@ -1218,7 +1219,8 @@ class SemaToRenderNodeTests: XCTestCase {
                         estimatedTime: nil
                     ),
                     renderReferenceDependencies: .init(),
-                    sourceLanguages: [.swift]
+                    sourceLanguages: [.swift],
+                    symbolKind: nil
                 )
             }
         }

--- a/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
+++ b/Tests/SwiftDocCUtilitiesTests/OutOfProcessReferenceResolverTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -53,7 +53,7 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
     
     func assertResolvesTopicLink(makeResolver: (OutOfProcessReferenceResolver.ResolvedInformation) throws -> OutOfProcessReferenceResolver) throws {
         let testMetadata = OutOfProcessReferenceResolver.ResolvedInformation(
-            kind: .init(name: "Kind Name", id: "com.test.kind.id", isSymbol: true),
+            kind: .function,
             url: URL(string: "doc://com.test.bundle/something")!,
             title: "Resolved Title",
             abstract: "Resolved abstract for this topic.",
@@ -133,6 +133,8 @@ class OutOfProcessReferenceResolverTests: XCTestCase {
         } else {
             XCTFail("Unexpected fragments variant patch")
         }
+        
+        XCTAssertEqual(entity.symbolKind, .func)
     }
     
     func testResolvingTopicLinkProcess() throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://156487928

## Summary

Fixes the navigator page type for external render nodes such that it takes into account the kind of symbol of the node.

In order to properly determine the navigator page type for a symbol, we need to know its symbol kind:
https://github.com/swiftlang/swift-docc/blob/65aaf926ec079ddbd40f29540d4180a70af99e5e/Sources/SwiftDocC/Indexing/Navigator/RenderNode%2BNavigatorIndex.swift#L148-L168

However, the symbol kind was not available for external nodes and all items were showing as their generic role, e.g. "article" or "symbol". 

This PR adds logic to derive an external render node's symbol kind:
1. Propagating the [`OutOfProcessReferenceResolver.ResolvedInformation`](https://github.com/swiftlang/swift-docc/blob/65aaf926ec079ddbd40f29540d4180a70af99e5e/Sources/SwiftDocC/Infrastructure/External%20Data/OutOfProcessReferenceResolver.swift#L564-L565)'s documentation kind to `LinkResolver.ExternalEntity`, the type which is used to deal with external entities.
2. Convert the documentation kind into a symbol kind, following an [already existing mapping](https://github.com/swiftlang/swift-docc/blob/65aaf926ec079ddbd40f29540d4180a70af99e5e/Sources/SwiftDocC/Model/DocumentationNode.swift#L645-L685) but in reverse. 
3. Use the symbol kind's [rendering identifier](https://github.com/swiftlang/swift-docc/blob/65aaf926ec079ddbd40f29540d4180a70af99e5e/Sources/SwiftDocC/Semantics/Graph/SymbolKind.Swift.swift#L24-L38) to determine the navigator page type, [same as for local render nodes](https://github.com/swiftlang/swift-docc/blob/65aaf926ec079ddbd40f29540d4180a70af99e5e/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift#L1300).

### Navigator comparison (using [swift-docc-render](https://github.com/swiftlang/swift-docc-render)):
| Before      | After |
| ----------- | ----------- |
| <img width="1674" height="925" alt="Screenshot 2025-07-21 at 14 02 22" src="https://github.com/user-attachments/assets/9e8b417b-d788-411a-8ca1-614784e607cf" /> | <img width="1687" height="927" alt="Screenshot 2025-07-21 at 13 58 13" src="https://github.com/user-attachments/assets/eaf907de-564f-48e0-abc1-ddb3c529be7f" /> |

The navigator icons on the right match the symbol kinds of the external pages.

The navigator `index.json` shows the correct page type as well:
```json
          {
            "external": true,
            "path": "/resolved/class",
            "title": "Resolved class",
            "type": "class"
          }
```

## Dependencies

N/A.

## Testing

Previewed a custom bundle locally which contained different types of external links (module, class, function and article). 
- Verified that they showed the relevant icon in the navigator when using [swift-docc-render](https://github.com/swiftlang/swift-docc-render).
- Verified that the resulting `index.json` looked as expected

Steps:
1. Use example bundle: [Example.docc.zip](https://github.com/user-attachments/files/21348005/Example.docc.zip)
     - The bundle contains a link resolver executable for resolving external entities
3. Run `DOCC_LINK_RESOLVER_EXECUTABLE=Example.docc/bin/test-data-external-resolver swift run docc preview Example.docc`
4. Verify that the navigator page icons in http://localhost:8080/documentation/article look as expected
5. Verify that the navigator JSON at `Example.docc/.docc-build/index/index.json` looks as expected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
