### PR TITLE
optionalRequirementOf relationships take precedence over non-optional ones

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphRelationshipsBuilder.swift
@@ -346,7 +346,13 @@ struct SymbolGraphRelationshipsBuilder {
             assertionFailure(AssertionMessages.sourceNotFound(edge))
             return
         }
-        requiredSymbol.isRequired = required
+        // If both requirementOf and optionalRequirementOf relationships exist
+        // for the same symbol, let the optional relationship take precedence.
+        // Optional protocol requirements sometimes appear with both relationships,
+        // but non-optional requirements do not.
+        if !required || requiredSymbol.isRequiredVariants.isEmpty {
+            requiredSymbol.isRequired = required
+        }
     }
     
     /// Sets a node in the context as an inherited symbol.

--- a/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SymbolGraph/SymbolGraphRelationshipsBuilderTests.swift
@@ -186,4 +186,36 @@ class SymbolGraphRelationshipsBuilderTests: XCTestCase {
         // Test default implementation was added
         XCTAssertFalse((documentationCache["A"]!.semantic as! Symbol).isRequired)
     }
+
+    func testRequiredAndOptionalRequirementRelationships() throws {
+        do {
+            let (bundle, _) = try testBundleAndContext()
+            var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
+            let engine = DiagnosticEngine()
+
+            let edge = createSymbols(documentationCache: &documentationCache, bundle: bundle, sourceType: .init(parsedIdentifier: .method, displayName: "Method"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+
+            // Adding the "required" relationship before the "optional" one
+            SymbolGraphRelationshipsBuilder.addRequirementRelationship(edge: edge, localCache: documentationCache, engine: engine)
+            SymbolGraphRelationshipsBuilder.addOptionalRequirementRelationship(edge: edge, localCache: documentationCache, engine: engine)
+
+            // Make sure that the "optional" relationship wins
+            XCTAssertFalse((documentationCache["A"]!.semantic as! Symbol).isRequired)
+        }
+
+        do {
+            let (bundle, _) = try testBundleAndContext()
+            var documentationCache = DocumentationContext.ContentCache<DocumentationNode>()
+            let engine = DiagnosticEngine()
+
+            let edge = createSymbols(documentationCache: &documentationCache, bundle: bundle, sourceType: .init(parsedIdentifier: .method, displayName: "Method"), targetType: .init(parsedIdentifier: .protocol, displayName: "Protocol"))
+
+            // Adding the "optional" relationship before the "required" one
+            SymbolGraphRelationshipsBuilder.addOptionalRequirementRelationship(edge: edge, localCache: documentationCache, engine: engine)
+            SymbolGraphRelationshipsBuilder.addRequirementRelationship(edge: edge, localCache: documentationCache, engine: engine)
+
+            // Make sure that the "optional" relationship still wins
+            XCTAssertFalse((documentationCache["A"]!.semantic as! Symbol).isRequired)
+        }
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://155967920

## Summary

Prior to Swift 6.1 (specifically https://github.com/swiftlang/swift/pull/76983), Swift symbol graphs would contain both `requirementOf` and `optionalRequirementOf` relationships for imported optional Objective-C protocol methods. This can confuse Swift-DocC into nondeterministically displaying a "Required" marker for optional requirements based on which relationship it reads last. This PR addresses this nondeterminism by making `optionalRequirementOf` relationships take precedence over `requirementOf` ones in the `SymbolGraphRelationshipsBuilder`.

## Dependencies

None

## Testing

Steps:
1. Render documentation for a module with an imported Objective-C optional protocol requirement, as mentioned above.
2. Ensure that the "Required" indicator is not rendered for the optional requirement, even on repeated runs.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
