### PR TITLE
Add initializer to `LinkCompletionTools.SymbolInformation` that accepts a `SymbolGraph.Symbol`

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
@@ -9,6 +9,7 @@
 */
 
 import Foundation
+public import SymbolKit
 
 /// A collection of API for link completion.
 ///
@@ -183,6 +184,15 @@ public enum LinkCompletionTools {
             self.symbolIDHash = symbolIDHash
             self.parameterTypes = parameterTypes
             self.returnTypes = returnTypes
+        }
+
+        public init(symbol: SymbolGraph.Symbol) {
+            self.kind = symbol.kind.identifier.identifier
+            self.symbolIDHash = Self.hash(uniqueSymbolID: symbol.identifier.precise)
+            if let signature = PathHierarchy.functionSignatureTypeNames(for: symbol) {
+                self.parameterTypes = signature.parameterTypeNames
+                self.returnTypes = signature.returnTypeNames
+            }
         }
         
         /// Creates a hashed representation of a symbol's unique identifier.


### PR DESCRIPTION
## Summary

Adds a new public initializer to `LinkCompletionTools.SymbolInformation` that will extract the function signature (if any) from a `SymbolGraph.Symbol`. This will primarily be used by SourceKit-LSP so that it doesn't have to re-implement the logic for constructing parameter and return type disambiguations.

## Checklist

- ~~[ ] Added tests~~
- [x] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~

No new tests needed: this only exposes existing functionality to SourceKit-LSP.
