### PR TITLE
sort platform-specific declarations by their platforms

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderSectionTranslator/DeclarationsSectionTranslator.swift
@@ -187,13 +187,15 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                 return declarations
             }
 
-            func sortPlatformNames(_ platforms: [PlatformName?]) -> [PlatformName?] {
-                platforms.sorted { (lhs, rhs) -> Bool in
-                    guard let lhsValue = lhs, let rhsValue = rhs else {
-                        return lhs == nil
-                    }
-                    return lhsValue.rawValue < rhsValue.rawValue
+            func comparePlatformNames(_ lhs: PlatformName?, _ rhs: PlatformName?) -> Bool {
+                guard let lhsValue = lhs, let rhsValue = rhs else {
+                    return lhs == nil
                 }
+                return lhsValue.rawValue < rhsValue.rawValue
+            }
+
+            func sortPlatformNames(_ platforms: [PlatformName?]) -> [PlatformName?] {
+                platforms.sorted(by: comparePlatformNames(_:_:))
             }
 
             var declarations: [DeclarationRenderSection] = []
@@ -263,6 +265,15 @@ struct DeclarationsSectionTranslator: RenderSectionTranslator {
                         )
                     }
                 }
+            }
+
+            declarations.sort { (lhs, rhs) -> Bool in
+                // We only need to compare the first platform in each list against the
+                // first platform in any other list, so pull them out here
+                guard let lhsPlatform = lhs.platforms.first, let rhsPlatform = rhs.platforms.first else {
+                    return lhs.platforms.isEmpty
+                }
+                return comparePlatformNames(lhsPlatform, rhsPlatform)
             }
 
             return DeclarationsRenderSection(declarations: declarations)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://155966155

## Summary

When a symbol's declaration is different depending on what platform it's used from, DocC will display all the variations of the declaration on the symbol page. However, the order of these declarations follows a kind of "first come, first served" approach where which platform's declaration appears first can differ depending on which symbol graph was loaded first. This can cause documentation to nondeterministically look different between builds of the same content.

This PR addresses this nondeterminism by sorting the declarations in the same order as the platforms would appear if they were in the same record (i.e. lexicographically by the platform name).

## Dependencies

None

## Testing

As this is a nondeterminism bug, the issue at hand is the way that data may be ordered differently from build to build. Therefore, any test will need to be run many times to ensure that the ordering of declarations is as expected. The unit test added in this PR captures the nondeterminism behavior *mostly* well; i have run into situations where running a test actually passed prior to the code change, but i ran into far more situations where the test failed due to the order being different, especially with a repetition count around 100.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
