### PR TITLE
prefer longer doc comments when selecting commented symbols

### DIFF
--- a/Sources/SwiftDocC/Semantics/Symbol/UnifiedSymbol+Extensions.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/UnifiedSymbol+Extensions.swift
@@ -99,9 +99,16 @@ extension UnifiedSymbolGraph.Symbol {
             if (lhs.key.interfaceLanguage == "swift") != (rhs.key.interfaceLanguage == "swift") {
                 // sort swift selectors before non-swift ones
                 return lhs.key.interfaceLanguage == "swift"
-            } else if lhs.value.lines.totalCount == rhs.value.lines.totalCount {
+            }
+
+            // if the comments are equal, bail early without iterating them again
+            guard lhs.value != rhs.value else {
+                return false
+            }
+
+            if lhs.value.lines.totalCount == rhs.value.lines.totalCount {
                 // if the comments are the same length, just sort them lexicographically
-                return lhs.value.lines.fullText < rhs.value.lines.fullText
+                return lhs.value.lines.isLexicographicallyBefore(rhs.value.lines)
             } else {
                 // otherwise, sort by the length of the doc comment,
                 // so that `min` returns the longest comment
@@ -135,5 +142,9 @@ extension [SymbolGraph.LineList.Line] {
 
     fileprivate var fullText: String {
         map(\.text).joined(separator: "\n")
+    }
+
+    fileprivate func isLexicographicallyBefore(_ other: Self) -> Bool {
+        self.lexicographicallyPrecedes(other) { $0.text < $1.text }
     }
 }

--- a/Sources/SwiftDocC/Semantics/Symbol/UnifiedSymbol+Extensions.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/UnifiedSymbol+Extensions.swift
@@ -106,13 +106,16 @@ extension UnifiedSymbolGraph.Symbol {
                 return false
             }
 
-            if lhs.value.lines.totalCount == rhs.value.lines.totalCount {
+            let lhsLength = lhs.value.lines.totalCount
+            let rhsLength = rhs.value.lines.totalCount
+
+            if lhsLength == rhsLength {
                 // if the comments are the same length, just sort them lexicographically
                 return lhs.value.lines.isLexicographicallyBefore(rhs.value.lines)
             } else {
                 // otherwise, sort by the length of the doc comment,
                 // so that `min` returns the longest comment
-                return lhs.value.lines.totalCount > rhs.value.lines.totalCount
+                return lhsLength > rhsLength
             }
         })?.key
     }
@@ -138,10 +141,6 @@ extension [SymbolGraph.LineList.Line] {
         return reduce(into: 0) { result, line in
             result += line.text.count
         }
-    }
-
-    fileprivate var fullText: String {
-        map(\.text).joined(separator: "\n")
     }
 
     fileprivate func isLexicographicallyBefore(_ other: Self) -> Bool {

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1056,7 +1056,133 @@ class DocumentationContextTests: XCTestCase {
                        └─ Text "Return value"
                        """)
     }
-    
+
+    func testLoadsConflictingDocComments() async throws {
+        let macOSSymbolGraph = makeSymbolGraph(
+            moduleName: "TestProject",
+            platform: .init(operatingSystem: .init(name: "macOS")),
+            symbols: [
+                makeSymbol(
+                    id: "TestSymbol",
+                    kind: .func,
+                    pathComponents: ["TestSymbol"],
+                    docComment: "This is a comment.",
+                    otherMixins: [
+                        SymbolGraph.Symbol.DeclarationFragments(declarationFragments: [
+                            .init(
+                                kind: .text,
+                                spelling: "TestSymbol Mac",
+                                preciseIdentifier: nil)
+                        ])
+                    ])
+            ])
+        let iOSSymbolGraph = makeSymbolGraph(
+            moduleName: "TestProject",
+            platform: .init(operatingSystem: .init(name: "iOS")),
+            symbols: [
+                makeSymbol(
+                    id: "TestSymbol",
+                    kind: .func,
+                    pathComponents: ["TestSymbol"],
+                    docComment: "This is a longer comment that should be shown instead.",
+                    otherMixins: [
+                        SymbolGraph.Symbol.DeclarationFragments(declarationFragments: [
+                            .init(
+                                kind: .text,
+                                spelling: "TestSymbol iOS",
+                                preciseIdentifier: nil)
+                        ])
+                    ])
+            ])
+
+        func runAssertions(forwards: Bool) async throws {
+            let catalog = Folder(name: "unit-test.docc", content: [
+                InfoPlist(displayName: "TestProject", identifier: "com.test.example"),
+                JSONFile(name: "symbols\(forwards ? "1" : "2").symbols.json", content:macOSSymbolGraph),
+                JSONFile(name: "symbols\(forwards ? "2" : "1").symbols.json", content: iOSSymbolGraph),
+            ])
+
+            let (bundle, context) = try await loadBundle(catalog: catalog)
+
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path: "/documentation/TestProject/TestSymbol",
+                sourceLanguage: .swift
+            )
+            let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+            let abstract = try XCTUnwrap(symbol.abstractSection)
+            XCTAssertEqual(
+                abstract.paragraph.plainText,
+                "This is a longer comment that should be shown instead.")
+        }
+
+        try await runAssertions(forwards: true)
+        try await runAssertions(forwards: false)
+    }
+
+    func testLoadsConflictingDocCommentsOfSameLength() async throws {
+        let macOSSymbolGraph = makeSymbolGraph(
+            moduleName: "TestProject",
+            platform: .init(operatingSystem: .init(name: "macOS")),
+            symbols: [
+                makeSymbol(
+                    id: "TestSymbol",
+                    kind: .func,
+                    pathComponents: ["TestSymbol"],
+                    docComment: "Comment A.",
+                    otherMixins: [
+                        SymbolGraph.Symbol.DeclarationFragments(declarationFragments: [
+                            .init(
+                                kind: .text,
+                                spelling: "TestSymbol Mac",
+                                preciseIdentifier: nil)
+                        ])
+                    ])
+            ])
+        let iOSSymbolGraph = makeSymbolGraph(
+            moduleName: "TestProject",
+            platform: .init(operatingSystem: .init(name: "iOS")),
+            symbols: [
+                makeSymbol(
+                    id: "TestSymbol",
+                    kind: .func,
+                    pathComponents: ["TestSymbol"],
+                    docComment: "Comment B.",
+                    otherMixins: [
+                        SymbolGraph.Symbol.DeclarationFragments(declarationFragments: [
+                            .init(
+                                kind: .text,
+                                spelling: "TestSymbol iOS",
+                                preciseIdentifier: nil)
+                        ])
+                    ])
+            ])
+
+        func runAssertions(forwards: Bool) async throws {
+            let catalog = Folder(name: "unit-test.docc", content: [
+                InfoPlist(displayName: "TestProject", identifier: "com.test.example"),
+                JSONFile(name: "symbols\(forwards ? "1" : "2").symbols.json", content:macOSSymbolGraph),
+                JSONFile(name: "symbols\(forwards ? "2" : "1").symbols.json", content: iOSSymbolGraph),
+            ])
+
+            let (bundle, context) = try await loadBundle(catalog: catalog)
+
+            let reference = ResolvedTopicReference(
+                bundleID: bundle.id,
+                path: "/documentation/TestProject/TestSymbol",
+                sourceLanguage: .swift
+            )
+            let symbol = try XCTUnwrap(context.entity(with: reference).semantic as? Symbol)
+            let abstract = try XCTUnwrap(symbol.abstractSection)
+            XCTAssertEqual(
+                abstract.paragraph.plainText,
+                "Comment A.")
+        }
+
+        try await runAssertions(forwards: true)
+        try await runAssertions(forwards: false)
+    }
+
     func testMergesMultipleSymbolDeclarations() async throws {
         let graphContentiOS = try String(contentsOf: Bundle.module.url(
             forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -1095,7 +1095,7 @@ class DocumentationContextTests: XCTestCase {
                     ])
             ])
 
-        func runAssertions(forwards: Bool) async throws {
+        for forwards in [true, false] {
             let catalog = Folder(name: "unit-test.docc", content: [
                 InfoPlist(displayName: "TestProject", identifier: "com.test.example"),
                 JSONFile(name: "symbols\(forwards ? "1" : "2").symbols.json", content:macOSSymbolGraph),
@@ -1115,9 +1115,6 @@ class DocumentationContextTests: XCTestCase {
                 abstract.paragraph.plainText,
                 "This is a longer comment that should be shown instead.")
         }
-
-        try await runAssertions(forwards: true)
-        try await runAssertions(forwards: false)
     }
 
     func testLoadsConflictingDocCommentsOfSameLength() async throws {
@@ -1158,7 +1155,7 @@ class DocumentationContextTests: XCTestCase {
                     ])
             ])
 
-        func runAssertions(forwards: Bool) async throws {
+        for forwards in [true, false] {
             let catalog = Folder(name: "unit-test.docc", content: [
                 InfoPlist(displayName: "TestProject", identifier: "com.test.example"),
                 JSONFile(name: "symbols\(forwards ? "1" : "2").symbols.json", content:macOSSymbolGraph),
@@ -1178,9 +1175,6 @@ class DocumentationContextTests: XCTestCase {
                 abstract.paragraph.plainText,
                 "Comment A.")
         }
-
-        try await runAssertions(forwards: true)
-        try await runAssertions(forwards: false)
     }
 
     func testMergesMultipleSymbolDeclarations() async throws {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://156595902

## Summary

When a symbol's information is loaded from multiple symbol graphs, Swift-DocC selects the documentation content from "the first Swift symbol with a doc comment, or the first symbol of any kind with a doc comment if no documented Swift symbol exists", where"first" here depends on the ordering of a Dictionary's keys. Because the ordering of those keys is not guaranteed, this can lead to a symbol's prose content being completely different between runs of DocC, despite no changes in the tool or the content, if there is a different comment between different platform's symbol graphs.

This PR addresses this by changing the way that commented symbols are selected. There is now a priority list of various sortings that decide which comment is selected for view:

1. Swift symbols get priority over non-Swift symbols, as before.
2. Then, pick the one with the longest comment.
3. When there are multiple comments with the same length, pick the one that sorts first lexicographically.

This could introduce a performance regression when there are many symbol graphs with identical comments, and those comments are long. I've tried to mitigate this, and i've run a benchmark with a moderately-sized framework with several platforms' symbol graphs, and it didn't seem to affect the timing in a significant way:

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main                 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'convert-total-time'        │ no change¹      │ 1.176 sec            │ 1.166 sec            │
│ Duration for 'documentation-processing'  │ no change²,³    │ 0.367 sec            │ 0.351 sec            │
│ Duration for 'finalize-navigation-index' │ no change⁴,⁵    │ 0.011 sec            │ 0.011 sec            │
│ Peak memory footprint                    │ no change⁶      │ 343.9 MB             │ 344 MB               │
│ Data subdirectory size                   │ no change⁷      │ 12.6 MB              │ 12.6 MB              │
│ Index subdirectory size                  │ no change       │ 413 KB               │ 413 KB               │
│ Total DocC archive size                  │ no change⁸      │ 16.7 MB              │ 16.7 MB              │
│ Topic Anchor Checksum                    │ no change       │ d41d8cd98f00b204e980 │ d41d8cd98f00b204e980 │
│ Topic Graph Checksum                     │ no change       │ 566b7978f799c47e6113 │ 566b7978f799c47e6113 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Dependencies

None

## Testing

As this is a nondeterminism bug, the issue at hand is the way that data may be ordered differently from build to build. Therefore, any test will need to be run many times to ensure that the ordering of declarations is as expected. The unit test added in this PR captures the nondeterminism behavior mostly well; i have run into situations where running a test actually passed prior to the code change, but i ran into far more situations where the test failed due to the order being different, especially with a repetition count around 100.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
