### PR TITLE
Fix single "Objective-C" typo in developer facing documentation

### DIFF
--- a/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
+++ b/Sources/SwiftDocC/Semantics/Metadata/AlternateRepresentation.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ public import Markdown
 ///
 /// Whenever possible, prefer to define alternative language representations for a symbol by using in-source annotations
 /// such as the `@objc` and `@_objcImplementation` attributes in Swift,
-/// or the `NS_SWIFT_NAME` macro in Objective C.
+/// or the `NS_SWIFT_NAME` macro in Objective-C.
 ///
 /// If your source language doesn’t have a mechanism for specifying alternate representations or if your intended alternate representation isn't compatible with those attributes,
 /// you can use the `@AlternateRepresentation` directive to specify another symbol that should be considered an alternate representation of the documented symbol.

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -93,7 +93,7 @@
             "text" : "such as the `@objc` and `@_objcImplementation` attributes in Swift,"
           },
           {
-            "text" : "or the `NS_SWIFT_NAME` macro in Objective C."
+            "text" : "or the `NS_SWIFT_NAME` macro in Objective-C."
           },
           {
             "text" : ""


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://154206938

## Summary

This fixes a single "Objective C" → "Objective-C" typo in the developer facing documentation for the `@AlternateRepresentation` directive.

## Dependencies

None

## Testing

- Build and preview the documentation
- Visit the local documentation for the `@AlternateRepresentation` directive
  - The 2nd paragraph of the discussion should end with 
    > [...], or the `NS_SWIFT_NAME` macro in Objective-C.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~ n/a
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
