### PR TITLE
Remove unused private code from the symbol graph loader

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -188,33 +188,7 @@ struct SymbolGraphLoader {
     }
     
     // Alias to declutter code
-    typealias AvailabilityItem = SymbolGraph.Symbol.Availability.AvailabilityItem
-    
-    /// Cache default availability items as we create them on demand.
-    private var cachedAvailabilityItems = [DefaultAvailability.ModuleAvailability: AvailabilityItem]()
-    
-    /// Returns a symbol graph availability item, given a module availability.
-    /// - returns: An availability item, or `nil` if the input data is invalid.
-    private func availabilityItem(for defaultAvailability: DefaultAvailability.ModuleAvailability) -> AvailabilityItem? {
-        if let cached = cachedAvailabilityItems[defaultAvailability] {
-            return cached
-        }
-        return AvailabilityItem(defaultAvailability)
-    }
-    
-    private func loadSymbolGraph(at url: URL) throws -> (SymbolGraph, isMainSymbolGraph: Bool) {
-        // This is a private method, the `url` key is known to exist
-        var symbolGraph = symbolGraphs[url]!
-        let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(symbolGraph, at: url)
-        
-        if !isMainSymbolGraph && symbolGraph.module.bystanders == nil {
-            // If this is an extending another module, change the module name to match the extended module.
-            // This makes the symbols in this graph have a path that starts with the extended module's name.
-            symbolGraph.module.name = moduleName
-        }
-
-        return (symbolGraph, isMainSymbolGraph)
-    }
+    private typealias AvailabilityItem = SymbolGraph.Symbol.Availability.AvailabilityItem
     
     /// Adds the missing fallback and default availability information to the unified symbol graph
     /// in case it didn't exists in the loaded symbol graphs.


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This removes a little bit of unused private code in the symbol graph loader.

It's not clear to me if there's some place that's expected to call this code that doesn't.

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ n/a

