### PR TITLE
Remove unused internal properties

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver+NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/LinkResolver+NavigatorIndex.swift
@@ -61,11 +61,6 @@ package struct ExternalRenderNode {
         externalEntity.topicRenderReference.navigatorTitleVariants
     }
     
-    /// The variants of the abbreviated declaration of the symbol to display in links.
-    var fragmentsVariants: VariantCollection<[DeclarationRenderSection.Token]?> {
-        externalEntity.topicRenderReference.fragmentsVariants
-    }
-    
     /// Author provided images that represent this page.
     var images: [TopicImage] {
         externalEntity.topicRenderReference.images
@@ -87,7 +82,6 @@ package struct ExternalRenderNode {
 /// A language specific representation of an external render node value for building a navigator index.
 struct NavigatorExternalRenderNode: NavigatorIndexableRenderNodeRepresentation {
     var identifier: ResolvedTopicReference
-    var externalIdentifier: RenderReferenceIdentifier
     var kind: RenderNode.Kind
     var metadata: ExternalRenderNodeMetadataRepresentation
     
@@ -109,7 +103,6 @@ struct NavigatorExternalRenderNode: NavigatorIndexableRenderNodeRepresentation {
 
         self.identifier = renderNode.identifier.withSourceLanguages(Set(arrayLiteral: traitLanguage))
         self.kind = renderNode.kind
-        self.externalIdentifier = renderNode.externalIdentifier
         
         self.metadata = ExternalRenderNodeMetadataRepresentation(
             title: renderNode.titleVariants.value(for: traits),


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

This removes two unused properties in the type that represents an external reference in the navigator.

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~ n/a
