### PR TITLE
Formalize LinkCompletionTools as public API

### DIFF
--- a/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
+++ b/Sources/SwiftDocC/DocumentationService/Convert/Symbol Link Resolution/LinkCompletionTools.swift
@@ -21,7 +21,6 @@ public import SymbolKit
 /// - Third, determine the minimal unique disambiguation for each completion suggestion using ``suggestedDisambiguation(forCollidingSymbols:)``
 ///
 /// > Tip: You can use ``SymbolInformation/hash(uniqueSymbolID:)`` to compute the hashed symbol identifiers needed for steps 2 and 3 above.
-@_spi(LinkCompletion)  // LinkCompletionTools isn't stable API yet
 public enum LinkCompletionTools {
     
     // MARK: Parsing

--- a/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/Symbol Link Resolution/LinkCompletionToolsTests.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 import XCTest
-@_spi(LinkCompletion) @testable import SwiftDocC
+@testable import SwiftDocC
 
 class LinkCompletionToolsTests: XCTestCase {
     func testParsingLinkStrings() {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This formally changes the `LinkCompletionTools` from SPI to public API.

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
