### PR TITLE
Document yaml as supported language for syntax highlighting

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
+++ b/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
@@ -181,6 +181,7 @@ have one or more aliases.
 | shell       | console, shellsession                                  |
 | swift       |                                                        |
 | xml         | html, xhtml, rss, atom, xjb, xsd, xsl, plist, wsf, svg |
+| yaml        | yml                                                    |
 
 ### Add Bulleted, Numbered, and Term Lists
 


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: 

## Summary

Document that `yaml` code listings can now be syntax highlighted with DocC-Render.

Adds an entry to the table in the "Add Code Listings" section of the "Formatting your documentation content" article that documents which languages are expected to have syntax highlighting support in the renderer.

## Dependencies

https://github.com/swiftlang/swift-docc-render/pull/960 (thanks @heckj!)

## Testing

Steps:
1. Run `bin/preview-docs DocC` and verify that the new table entry can be found at http://localhost:8080/documentation/docc/formatting-your-documentation-content#Add-Code-Listings

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary
