### PR TITLE
[6.2] Add support for abstract Headerdoc tag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"
@@ -87,7 +87,7 @@
       "location" : "https://github.com/swiftlang/swift-markdown.git",
       "state" : {
         "branch" : "release/6.2",
-        "revision" : "bc668ada42187e6c18eac420d66050a76d4ed764"
+        "revision" : "3be4e1a09cef425602f11bdb4b4de252e4badd11"
       }
     },
     {

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -359,6 +359,10 @@ struct RenderContentCompiler: MarkupVisitor {
         return renderableDirective.render(blockDirective, with: &self)
     }
 
+    mutating func visitDoxygenAbstract(_ doxygenAbstract: DoxygenAbstract) -> [any RenderContent] {
+        doxygenAbstract.children.flatMap { self.visit($0)}
+    }
+
     mutating func visitDoxygenDiscussion(_ doxygenDiscussion: DoxygenDiscussion) -> [any RenderContent] {
         doxygenDiscussion.children.flatMap { self.visit($0) }
     }

--- a/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/DoxygenTests.swift
@@ -19,6 +19,7 @@ class DoxygenTests: XCTestCase {
     func testDoxygenDiscussionAndNote() throws {
         let documentationLines: [SymbolGraph.LineList.Line] = """
             This is an abstract.
+            @abstract This is description with abstract.
 
             @discussion This is a discussion linking to ``AnotherClass`` and ``AnotherClass/prop``.
 
@@ -96,6 +97,7 @@ class DoxygenTests: XCTestCase {
 
         XCTAssertEqual(symbol.abstract?.format(), "This is an abstract.")
         XCTAssertEqual(symbol.discussion?.content.map { $0.format() }, [
+            #"\abstract This is description with abstract."#,
             #"\discussion This is a discussion linking to ``doc://unit-test/documentation/ModuleName/AnotherClass`` and ``doc://unit-test/documentation/ModuleName/AnotherClass/prop``."#,
             #"\note This is a note linking to ``doc://unit-test/documentation/ModuleName/Class3`` and ``Class3/prop2``."#
         ])
@@ -108,10 +110,10 @@ class DoxygenTests: XCTestCase {
         XCTAssertEqual(renderNode.primaryContentSections.count, 1)
 
         let overviewSection = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection)
-        XCTAssertEqual(overviewSection.content.count, 3)
+        XCTAssertEqual(overviewSection.content.count, 4)
         XCTAssertEqual(overviewSection.content, [
             .heading(.init(level: 2, text: "Overview", anchor: "overview")),
-
+            .paragraph(.init(inlineContent: [.text("This is description with abstract.")])),
             .paragraph(.init(inlineContent: [
                 .text("This is a discussion linking to "),
                 .reference(


### PR DESCRIPTION
on behalf of @binamaniar 

  - **Explanation**: This turns parsed Doxygen/HeaderDoc `@abstract` and `@breif` into normal paragraphs (assumed to contain Markdown content). 
  - **Scope**: Parsing of Doxygen/HeaderDoc `@abstract` and `@breif` tags. 
  - **Issues**: rdar://147920933
  - **Original PRs**: #1215 
  - **Risk**: Low. This is isolated to `@abstract` and `@breif` tags in markup which weren't supported before.
  - **Testing**: Automated tests have been added.
  - **Reviewers**: @QuietMisdreavus @patshaughnessy 


----

Note this depend on https://github.com/swiftlang/swift-markdown/pull/235 which is merged as https://github.com/swiftlang/swift-markdown/commit/3be4e1a09cef425602f11bdb4b4de252e4badd11 and referenced in the updated Package.resolved file.