### PR TITLE
sort Default Implementations section contents when rendering

### DIFF
--- a/Sources/SwiftDocC/Model/Section/Sections/DefaultImplementations.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/DefaultImplementations.swift
@@ -65,7 +65,7 @@ public struct DefaultImplementationsSection {
                 
                 return ImplementationsGroup(
                     heading: "\(groupName)Implementations",
-                    references: grouped[name]!.map { $0.reference }
+                    references: grouped[name]!.map { $0.reference }.sorted(by: \.description)
                 )
             }
     }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://156311548

## Summary

If there are multiple default implementations for a protocol method (currently happening in Swift symbol graphs due a bug when such methods are overloaded), the listed methods are unordered on the final rendered page. This can result in rendered content differing between builds, even when using the same build of DocC and the same content.

This PR enforces an order by sorting symbols via their topic reference URL before rendering.

## Dependencies

None

## Testing

As this is a nondeterminism bug, testing can be difficult and requires repeated executions for comparison. The unit test included in this PR only erratically would pass or fail, and required repeated attempts to ensure resolution.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
