### PR TITLE
Fix warnings about retroactive conformance to protocols in 'generate-symbol-graph' tool

### DIFF
--- a/Sources/generate-symbol-graph/main.swift
+++ b/Sources/generate-symbol-graph/main.swift
@@ -61,7 +61,7 @@ func directiveUSR(_ directiveName: String) -> String {
 // The `@retroactive` attribute is new in the Swift 6 compiler. The backwards compatible syntax for a retroactive conformance is fully-qualified types.
 //
 // This conformance it only relevant to the `generate-symbol-graph` script.
-extension SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment: Swift.ExpressibleByStringInterpolation {
+extension SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment: Swift.ExpressibleByStringInterpolation, Swift.ExpressibleByUnicodeScalarLiteral, Swift.ExpressibleByExtendedGraphemeClusterLiteral, Swift.ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self.init(kind: .text, spelling: value, preciseIdentifier: nil)
     }
@@ -79,7 +79,7 @@ extension SymbolKit.SymbolGraph.Symbol.DeclarationFragments.Fragment: Swift.Expr
 // The `@retroactive` attribute is new in the Swift 6 compiler. The backwards compatible syntax for a retroactive conformance is fully-qualified types.
 //
 // This conformance it only relevant to the `generate-symbol-graph` script. 
-extension SymbolKit.SymbolGraph.LineList.Line: Swift.ExpressibleByStringInterpolation {
+extension SymbolKit.SymbolGraph.LineList.Line: Swift.ExpressibleByStringInterpolation, Swift.ExpressibleByUnicodeScalarLiteral, Swift.ExpressibleByExtendedGraphemeClusterLiteral, Swift.ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self.init(text: value, range: nil)
     }


### PR DESCRIPTION


Bug/issue #, if applicable: 

## Summary

This fixes two new warnings about retroactive conformance to protocols in 'generate-symbol-graph' tool.

## Dependencies

None

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
