### PR TITLE
Ignore all build dirs in `bin/check-source`

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -134,8 +134,7 @@ EOF
   (
     cd "$here/.."
     find . \
-      \( \! -path './.build/*' -a \
-      \! -path './bin/benchmark/.build/*' -a \
+      \( \! -path '*/.build/*' -a \
       \! -name '.' -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do


### PR DESCRIPTION
The `bin/check-source` script performs checks to ensure that headers are correctly updated in the modified files in a commit. This script ignored certain build directories since they contain generated Swift files. Some build directories were missing in this list (particularly the build directory emitted by `make-test-bundle`). The script has been modified to indiscrimanately ignore all `.build` directories.