### PR TITLE
Avoid a few possible unnecessary copies in low level implementation details

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+PathComponent.swift
@@ -210,7 +210,7 @@ extension PathHierarchy.PathParser {
     }
 }
 
-private struct PathComponentScanner {
+private struct PathComponentScanner: ~Copyable {
     private var remaining: Substring
     
     static let separator: Character = "/"

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignature.swift
@@ -230,7 +230,7 @@ extension PathHierarchy {
     }
     
     /// A small helper type that tracks the scope of nested brackets; `()`, `[]`, or `<>`.
-    private struct SwiftBracketsStack {
+    private struct SwiftBracketsStack: ~Copyable {
         enum Bracket {
             case angle  // <>
             case square // []
@@ -522,7 +522,7 @@ extension PathHierarchy.PathParser {
 
 // MARK: Scanning a substring
 
-private struct StringScanner {
+private struct StringScanner: ~Copyable {
     private var remaining: Substring
     
     init(_ original: Substring) {

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignatureDisambiguation.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+TypeSignatureDisambiguation.swift
@@ -63,7 +63,7 @@ extension PathHierarchy.DisambiguationContainer {
         }
     }
     
-    private static func _minimalSuggestedDisambiguationForFewParameters(typeNames: Table<String>) -> [[String]?] {
+    private static func _minimalSuggestedDisambiguationForFewParameters(typeNames: consuming Table<String>) -> [[String]?] {
         typealias IntSet = _TinySmallValueIntSet
         // We find the minimal suggested type-signature disambiguation in two steps.
         //
@@ -216,7 +216,7 @@ extension PathHierarchy.DisambiguationContainer {
         }
     }
     
-    private static func _minimalSuggestedDisambiguationForManyParameters(typeNames: Table<String>) -> [[String]?] {
+    private static func _minimalSuggestedDisambiguationForManyParameters(typeNames: consuming Table<String>) -> [[String]?] {
         // If there are more than 64 parameters or more than 64 overloads we only try to disambiguate by a single type name.
         //
         // In practice, the number of parameters goes down rather quickly.
@@ -418,7 +418,7 @@ extension _TinySmallValueIntSet {
 // MARK: Table
 
 /// A fixed-size grid of elements.
-private struct Table<Element> {
+private struct Table<Element>: ~Copyable {
     typealias Size = (width: Int, height: Int)
     @usableFromInline
     let size: Size

--- a/Sources/SwiftDocC/Utility/CollectionChanges.swift
+++ b/Sources/SwiftDocC/Utility/CollectionChanges.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -65,7 +65,7 @@ struct CollectionChanges {
 ///
 /// - Important:
 /// Removals need to be applied in reverse order. All removals need to be applied before applying any insertions. Insertions need to be applied in order.
-private struct ChangeSegmentBuilder {
+private struct ChangeSegmentBuilder: ~Copyable {
     typealias Segment = CollectionChanges.Segment
     
     private(set) var segments: [Segment]


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This PR adds ownership and non-copyable annotations to some low level implementation details to avoid a few possible unnecessaries copies of data (and to get warnings about changes that may introduce unwanted copies in this code).

On the scale of a full documentation build of a large multi-language framework, these changes have no measurable impact:

``` 
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Metric                                   │ Change          │ main                 │ current              │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Duration for 'convert-total-time'        │ no change¹      │ 9,067 sec            │ 9,004 sec            │
│ Duration for 'documentation-processing'  │ no change²      │ 2,893 sec            │ 2,897 sec            │
│ Duration for 'finalize-navigation-index' │ no change³      │ 1,263 sec            │ 1,233 sec            │
│ Peak memory footprint                    │ no change⁴      │ 1,18 GB              │ 1,19 GB              │
│ Data subdirectory size                   │ no change⁵      │ 257,5 MB             │ 257,5 MB             │
│ Index subdirectory size                  │ no change⁶      │ 15,6 MB              │ 15,6 MB              │
│ Total DocC archive size                  │ no change⁷      │ 284,1 MB             │ 284,1 MB             │
│ Topic Anchor Checksum                    │ no change       │ c288f5f9b2f3cd5b5f38 │ c288f5f9b2f3cd5b5f38 │
│ Topic Graph Checksum                     │ no change       │ 91653e1a25d07b8ae8a1 │ 91653e1a25d07b8ae8a1 │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
