### PR TITLE
Update the bin/benchmark script to Swift 6

### DIFF
--- a/bin/benchmark/Package.swift
+++ b/bin/benchmark/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 6.0
 /*
  This source file is part of the Swift.org open source project
 
@@ -14,7 +14,7 @@ import PackageDescription
 let package = Package(
     name: "benchmark",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v13)
     ],
     products: [
         .executable(

--- a/bin/benchmark/Sources/benchmark/BenchmarkResultSeries.swift
+++ b/bin/benchmark/Sources/benchmark/BenchmarkResultSeries.swift
@@ -77,7 +77,7 @@ struct BenchmarkResultSeries: Codable, Equatable {
     /// The list of metrics gathered in these benchmark runs.
     public var metrics: [MetricSeries]
     
-    static var empty = BenchmarkResultSeries(platformName: "", timestamp: Date(), doccArguments: [], metrics: [])
+    static let empty = BenchmarkResultSeries(platformName: "", timestamp: Date(), doccArguments: [], metrics: [])
     
     enum Error: Swift.Error, CustomStringConvertible {
         case addedResultHasDifferentConfiguration

--- a/bin/benchmark/Sources/benchmark/Commands.swift
+++ b/bin/benchmark/Sources/benchmark/Commands.swift
@@ -12,15 +12,16 @@ import ArgumentParser
 import Foundation
 
 @main
-struct BenchmarkCommand: ParsableCommand {
-    static var configuration = CommandConfiguration(
+struct BenchmarkCommand: @MainActor ParsableCommand {
+    @MainActor
+    static let configuration = CommandConfiguration(
             abstract: "A utility for performing benchmarks for Swift-DocC.",
             subcommands: [Measure.self, Diff.self, CompareTo.self, MeasureCommits.self, RenderTrend.self],
             defaultSubcommand: Measure.self)
 }
 
 let doccProjectRootURL: URL = {
-    let url = URL(fileURLWithPath: #file)
+    let url = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent() // Commands.swift
         .deletingLastPathComponent() // benchmark
         .deletingLastPathComponent() // Sources

--- a/bin/benchmark/Sources/benchmark/Diff/DiffAnalysis.swift
+++ b/bin/benchmark/Sources/benchmark/Diff/DiffAnalysis.swift
@@ -22,6 +22,7 @@ extension DiffResults {
         }
     }
     
+    @MainActor
     static func analyze(before beforeMetric: BenchmarkResultSeries.MetricSeries?, after afterMetric: BenchmarkResultSeries.MetricSeries) throws -> DiffResults.MetricAnalysis {
         guard let beforeMetric else {
             return DiffResults.MetricAnalysis(
@@ -129,6 +130,7 @@ extension DiffResults {
         )
     }
     
+    @MainActor
     private static func inputBiasDescription(metric: BenchmarkResultSeries.MetricSeries, sampleName: String, numbers: [Double]) -> String {
         // Turn the single metric series into an array of single values metric series to render the trend bars.
         
@@ -164,6 +166,7 @@ extension DiffResults {
 }
 
 extension BenchmarkResultSeries.MetricSeries.ValueSeries {
+    @MainActor
     func formatted() -> String {
         switch self {
             case .duration(let value):
@@ -190,6 +193,7 @@ extension BenchmarkResultSeries.MetricSeries.ValueSeries {
 }
 
 #if os(macOS) || os(iOS)
+@MainActor
 private let durationFormatter: MeasurementFormatter = {
     let fmt = MeasurementFormatter()
     fmt.unitStyle = .medium

--- a/bin/benchmark/Sources/benchmark/Subcommands/CommitCommands.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/CommitCommands.swift
@@ -12,7 +12,7 @@ import Foundation
 import ArgumentParser
 import SwiftDocC
 
-struct CompareTo: ParsableCommand {
+struct CompareTo: @MainActor ParsableCommand {
     @Argument(
         help: "The baseline 'commit-ish' to compare the current checkout against."
     )
@@ -31,6 +31,7 @@ struct CompareTo: ParsableCommand {
         return outputDirectory ?? URL(fileURLWithPath: ".") // fallback to the current directory
     }
     
+    @MainActor
     mutating func run() throws {
         let currentDocCExecutable = try MeasureAction.buildDocC(at: doccProjectRootURL)
         let currentBenchmarkResult = try MeasureAction.gatherMeasurements(

--- a/bin/benchmark/Sources/benchmark/Subcommands/Measure.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/Measure.swift
@@ -56,7 +56,7 @@ struct MeasureOptions: ParsableCommand {
     }
 }
 
-struct Measure: ParsableCommand {
+struct Measure: @MainActor ParsableCommand {
     @Option(
         name: .customLong("output"),
         help: "The path to write the output benchmark measurements file.",
@@ -93,6 +93,7 @@ struct Measure: ParsableCommand {
         }
     }
     
+    @MainActor
     mutating func run() throws {
         try MeasureAction(
             repeatCount: measureOptions.repeatCount,
@@ -111,6 +112,7 @@ struct MeasureAction {
     var doccConvertCommand: [String]
     var computeMissingOutputSizeMetrics: Bool
     
+    @MainActor
     func run() throws {
         print("Building docc in release configuration".styled(.bold))
         let doccURL = try Self.buildDocC(at: doccProjectRootURL)

--- a/bin/benchmark/Sources/benchmark/Subcommands/RenderTrend.swift
+++ b/bin/benchmark/Sources/benchmark/Subcommands/RenderTrend.swift
@@ -14,7 +14,7 @@ import SwiftDocC
 
 // For argument parsing and validation
 
-struct RenderTrend: ParsableCommand {
+struct RenderTrend: @MainActor ParsableCommand {
     @Option(
         name: .customLong("filter"),
         help: "A list metric IDs to render trends for. If no filters are specified, trends are rendered for all numeric metrics."
@@ -27,6 +27,7 @@ struct RenderTrend: ParsableCommand {
     )
     var benchmarkResults: [URL]
     
+    @MainActor
     mutating func run() throws {
         try RenderTrendAction(
             metricFilters: metricFilters,
@@ -41,6 +42,7 @@ struct RenderTrendAction {
     var metricFilters: [String]
     var benchmarkResults: [URL]
     
+    @MainActor
     func run() throws {
         // Map the metric ID to the measured values across the benchmarks
         var trendValues: [String: [BenchmarkResultSeries.MetricSeries]] = [:]
@@ -76,6 +78,7 @@ struct RenderTrendAction {
         }
     }
 
+    @MainActor
     static func renderTrendBars(metrics: [BenchmarkResultSeries.MetricSeries]) -> String {
         var output = ""
         


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

With https://github.com/swiftlang/swift-docc/pull/1268 updating the minimum macOS version from 12 to 13, the benchmark scripts could no longer use the local DocC. 

This update the benchmark scripts to use Swift 6 and to also require macOS 13.

## Dependencies

None.

## Testing

Run the benchmark scripts. There shouldn't be any compiler errors.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- ~[ ] Ran the `./bin/test` script and it succeeded~
- ~[ ] Updated documentation if necessary~
