### PR TITLE
Improve handling of snippet symbol graph files

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -81,6 +81,9 @@ public class DocumentationContext {
     /// > Important: The topic graph has no awareness of source language specific edges.
     var topicGraph = TopicGraph()
     
+    /// Will be assigned during context initialization
+    var snippetResolver: SnippetResolver!
+    
     /// User-provided global options for this documentation conversion.
     var options: Options?
     
@@ -2038,6 +2041,8 @@ public class DocumentationContext {
                         knownDisambiguatedPathComponents: configuration.convertServiceConfiguration.knownDisambiguatedSymbolPathComponents
                     ))
                 }
+                
+                self.snippetResolver = SnippetResolver(symbolGraphLoader: symbolGraphLoader)
             } catch {
                 // Pipe the error out of the dispatch queue.
                 discoveryError.sync({

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -285,7 +285,7 @@ private extension PathHierarchy.Node {
     }
 }
 
-private extension SourceRange {
+extension SourceRange {
     static func makeRelativeRange(startColumn: Int, endColumn: Int) -> SourceRange {
         return SourceLocation(line: 0, column: startColumn, source: nil) ..< SourceLocation(line: 0, column: endColumn, source: nil)
     }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
@@ -1,0 +1,79 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SymbolKit
+import Markdown
+
+/// A type that resolves snippet paths.
+final class SnippetResolver {
+    typealias SnippetMixin = SymbolKit.SymbolGraph.Symbol.Snippet
+    typealias Explanation  = Markdown.Document
+    
+    /// Information about a resolved snippet
+    struct ResolvedSnippet {
+        var mixin: SnippetMixin
+        var explanation: Explanation?
+    }
+    /// A snippet that has been resolved, either successfully or not.
+    enum SnippetResolutionResult {
+        case success(ResolvedSnippet)
+        case failure(TopicReferenceResolutionErrorInfo)
+    }
+    
+    private var snippets: [String: ResolvedSnippet] = [:]
+    
+    init(symbolGraphLoader: SymbolGraphLoader) {
+        var snippets: [String: ResolvedSnippet] = [:]
+        
+        for graph in symbolGraphLoader.snippetSymbolGraphs.values {
+            for symbol in graph.symbols.values {
+                guard let snippetMixin = symbol[mixin: SnippetMixin.self] else { continue }
+                
+                let path: String = if symbol.pathComponents.first == "Snippets" {
+                    symbol.pathComponents.dropFirst().joined(separator: "/")
+                } else {
+                    symbol.pathComponents.joined(separator: "/")
+                }
+                
+                snippets[path] = .init(mixin: snippetMixin, explanation: symbol.docComment.map {
+                    Document(parsing: $0.lines.map(\.text).joined(separator: "\n"), options: .parseBlockDirectives)
+                })
+            }
+        }
+        
+        self.snippets = snippets
+    }
+ 
+    func resolveSnippet(path authoredPath: String) -> SnippetResolutionResult {
+        // Snippet paths are relative to the root of the Swift Package.
+        // The first to components are always the same (the package name followed by "Snippets").
+        // The later components can either be subdirectories of the "Snippets" directory or the base name of a snippet '.swift' file (without the extension).
+          
+        // Drop the common package name + "Snippets" prefix (that's always the same), if the authored path includes it.
+        // This enables the author to omit this prefix (but include it for backwards compatibility with older DocC versions).
+        var components = authoredPath.split(separator: "/", omittingEmptySubsequences: true)
+        
+        // It's possible that the package name is "Snippets", resulting in two identical components. Skip until the last of those two.
+        if let snippetsPrefixIndex = components.prefix(2).lastIndex(of: "Snippets"),
+           // Don't search for an empty string if the snippet happens to be named "Snippets"
+           let relativePathStart = components.index(snippetsPrefixIndex, offsetBy: 1, limitedBy: components.endIndex - 1)
+        {
+            components.removeFirst(relativePathStart)
+        }
+        
+        let path = components.joined(separator: "/")
+        if let found = snippets[path] {
+            return .success(found)
+        } else {
+            return .failure(.init("Snippet named '\(path)' couldn't be found."))
+        }
+    }
+}
+

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
@@ -55,7 +55,7 @@ final class SnippetResolver {
  
     func resolveSnippet(path authoredPath: String) -> SnippetResolutionResult {
         // Snippet paths are relative to the root of the Swift Package.
-        // The first to components are always the same (the package name followed by "Snippets").
+        // The first two components are always the same (the package name followed by "Snippets").
         // The later components can either be subdirectories of the "Snippets" directory or the base name of a snippet '.swift' file (without the extension).
           
         // Drop the common package name + "Snippets" prefix (that's always the same), if the authored path includes it.

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
@@ -83,7 +83,7 @@ final class SnippetResolver {
                 ])
             }
             
-            return .failure(.init("Snippet named '\(path)' couldn't be found", solutions: solutions))
+            return .failure(.init("Snippet named '\(path)' couldn't be found", solutions: solutions, rangeAdjustment: replacementRange))
         }
     }
     

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -903,7 +903,7 @@ private extension BlockDirective {
     }
 }
 
-extension [String] {
+extension Collection<String> {
 
     /// Strip the minimum leading whitespace from all the strings in this array, as follows:
     /// - Find the line with least amount of leading whitespace. Ignore blank lines during this search.

--- a/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
+++ b/Sources/SwiftDocC/Semantics/MarkupReferenceResolver.swift
@@ -166,8 +166,8 @@ struct MarkupReferenceResolver: MarkupRewriter {
         let source = blockDirective.range?.source
         switch blockDirective.name {
         case Snippet.directiveName:
-            var problems = [Problem]() // ???: DAVID IS IGNORED?
-            guard let snippet = Snippet(from: blockDirective, source: source, for: bundle, problems: &problems) else {
+            var ignoredParsingProblems = [Problem]() // Any argument parsing problems have already been reported elsewhere
+            guard let snippet = Snippet(from: blockDirective, source: source, for: bundle, problems: &ignoredParsingProblems) else {
                 return blockDirective
             }
             
@@ -176,11 +176,11 @@ struct MarkupReferenceResolver: MarkupRewriter {
                 if let requestedSlice = snippet.slice,
                    let errorInfo = context.snippetResolver.validate(slice: requestedSlice, for: resolvedSnippet)
                 {
-                    self.problems.append(SnippetResolver.unknownSnippetSliceProblem(source: source, range: blockDirective.arguments()["slice"]?.valueRange, errorInfo: errorInfo))
+                    problems.append(SnippetResolver.unknownSnippetSliceProblem(source: source, range: blockDirective.arguments()["slice"]?.valueRange, errorInfo: errorInfo))
                 }
                 return blockDirective
             case .failure(let errorInfo):
-                self.problems.append(SnippetResolver.unresolvedSnippetPathProblem(source: source, range: blockDirective.arguments()["path"]?.valueRange, errorInfo: errorInfo))
+                problems.append(SnippetResolver.unresolvedSnippetPathProblem(source: source, range: blockDirective.arguments()["path"]?.valueRange, errorInfo: errorInfo))
                 return blockDirective
             }
         case ImageMedia.directiveName:

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -14,31 +14,40 @@ import SymbolKit
 
 /// Embeds a code example from the project's code snippets.
 ///
+/// Use a `Snippet` directive to embed a code example from the project's "Snippets" directory on the page.
+/// The `path` argument is the relative path from the package's top-level "Snippets" directory to your snippet file without the `.swift` extension.
+///
 /// ```markdown
-/// @Snippet(path: "my-package/Snippets/example-snippet", slice: "setup")
+/// @Snippet(path: "example-snippet", slice: "setup")
 /// ```
 ///
-/// Place the `Snippet` directive to embed a code example from the project's snippet directory.
-/// The path that references the snippet is identified with three parts:
+/// If you prefer, you can specify the relative path from the package's _root_ directory (by including a "Snippets/" prefix).
+/// You can also include the package name---as defined in `Package.swift`---before the "Snippets/" prefix.
+/// Neither of these leading path components are necessary because all your snippet code files are always located in your package's "Snippets" directory.
 ///
-/// 1. The package name as defined in `Package.swift`
+/// > Earlier Versions:
+/// > Before Swift-DocC 6.2, the `@Snippet` path needed to include both the package name component and the "Snippets" component:
+/// >
+/// > ```markdown
+/// > @Snippet(path: "my-package/Snippets/example-snippet")
+/// > ```
 ///
-/// 2. The directory path to the snippet file, starting with "Snippets".
+/// You can define named slices of your snippet by annotating the snippet file with `// snippet.<name>` and `// snippet.end` lines.
+/// A named slice automatically ends at the start of the next named slice, without an explicit `snippet.end` annotation.
 ///
-/// 3. The name of your snippet file without the `.swift` extension
-///
-/// If the snippet had slices annotated within it, an individual slice of the snippet can be referenced with the `slice` option.
-/// Without the option defined, the directive embeds the entire snippet.
+/// If the referenced snippet includes annotated slices, you can limit the embedded code example to a certain line range by specifying a `slice` name.
+/// By default, the embedded code example includes the full snippet. For more information, see <doc:adding-code-snippets-to-your-content#Slice-up-your-snippet-to-break-it-up-in-your-content>.
 public final class Snippet: Semantic, AutomaticDirectiveConvertible {
     public static let introducedVersion = "5.7"
     public let originalMarkup: BlockDirective
     
-    /// The path components of a symbol link that would be used to resolve a reference to a snippet,
-    /// only occurring as a block directive argument.
+    /// The relative path from your package's top-level "Snippets" directory to the snippet file that you want to embed in the page, without the `.swift` file extension.
     @DirectiveArgumentWrapped
     public var path: String
     
-    /// An optional named range to limit the lines shown.
+    /// The name of a snippet slice to limit the embedded code example to a certain line range.
+    ///
+    /// By default, the embedded code example includes the full snippet.
     @DirectiveArgumentWrapped
     public var slice: String? = nil
     

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -26,7 +26,7 @@ import SymbolKit
 /// Neither of these leading path components are necessary because all your snippet code files are always located in your package's "Snippets" directory.
 ///
 /// > Earlier Versions:
-/// > Before Swift-DocC 6.2, the `@Snippet` path needed to include both the package name component and the "Snippets" component:
+/// > Before Swift-DocC 6.2.1, the `@Snippet` path needed to include both the package name component and the "Snippets" component:
 /// >
 /// > ```markdown
 /// > @Snippet(path: "my-package/Snippets/example-snippet")

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -70,7 +70,11 @@ extension Snippet: RenderableDirectiveConvertible {
         }
         let mixin = resolvedSnippet.mixin
         
-        if let sliceRange = slice.flatMap({ mixin.slices[$0] }) {
+        if let slice {
+            guard let sliceRange = mixin.slices[slice] else {
+                // The warning says that unrecognized snippet slices will ignore the entire snippet.
+                return []
+            }
             // Render only this slice without the explanatory content.
             let lines = mixin.lines
                 // Trim the lines

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -5353,7 +5353,7 @@
             "text" : "> Earlier Versions:"
           },
           {
-            "text" : "> Before Swift-DocC 6.2, the `@Snippet` path needed to include both the package name component and the \"Snippets\" component:"
+            "text" : "> Before Swift-DocC 6.2.1, the `@Snippet` path needed to include both the package name component and the \"Snippets\" component:"
           },
           {
             "text" : ">"

--- a/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
+++ b/Sources/docc/DocCDocumentation.docc/DocC.symbols.json
@@ -5317,10 +5317,19 @@
             "text" : ""
           },
           {
+            "text" : "Use a `Snippet` directive to embed a code example from the project's \"Snippets\" directory on the page."
+          },
+          {
+            "text" : "The `path` argument is the relative path from the package's top-level \"Snippets\" directory to your snippet file without the `.swift` extension."
+          },
+          {
+            "text" : ""
+          },
+          {
             "text" : "```markdown"
           },
           {
-            "text" : "@Snippet(path: \"my-package\/Snippets\/example-snippet\", slice: \"setup\")"
+            "text" : "@Snippet(path: \"example-snippet\", slice: \"setup\")"
           },
           {
             "text" : "```"
@@ -5329,55 +5338,73 @@
             "text" : ""
           },
           {
-            "text" : "Place the `Snippet` directive to embed a code example from the project's snippet directory."
+            "text" : "If you prefer, you can specify the relative path from the package's _root_ directory (by including a \"Snippets\/\" prefix)."
           },
           {
-            "text" : "The path that references the snippet is identified with three parts:"
+            "text" : "You can also include the package name---as defined in `Package.swift`---before the \"Snippets\/\" prefix."
           },
           {
-            "text" : ""
-          },
-          {
-            "text" : "1. The package name as defined in `Package.swift`"
+            "text" : "Neither of these leading path components are necessary because all your snippet code files are always located in your package's \"Snippets\" directory."
           },
           {
             "text" : ""
           },
           {
-            "text" : "2. The directory path to the snippet file, starting with \"Snippets\"."
+            "text" : "> Earlier Versions:"
+          },
+          {
+            "text" : "> Before Swift-DocC 6.2, the `@Snippet` path needed to include both the package name component and the \"Snippets\" component:"
+          },
+          {
+            "text" : ">"
+          },
+          {
+            "text" : "> ```markdown"
+          },
+          {
+            "text" : "> @Snippet(path: \"my-package\/Snippets\/example-snippet\")"
+          },
+          {
+            "text" : "> ```"
           },
           {
             "text" : ""
           },
           {
-            "text" : "3. The name of your snippet file without the `.swift` extension"
+            "text" : "You can define named slices of your snippet by annotating the snippet file with `\/\/ snippet.<name>` and `\/\/ snippet.end` lines."
+          },
+          {
+            "text" : "A named slice automatically ends at the start of the next named slice, without an explicit `snippet.end` annotation."
           },
           {
             "text" : ""
           },
           {
-            "text" : "If the snippet had slices annotated within it, an individual slice of the snippet can be referenced with the `slice` option."
+            "text" : "If the referenced snippet includes annotated slices, you can limit the embedded code example to a certain line range by specifying a `slice` name."
           },
           {
-            "text" : "Without the option defined, the directive embeds the entire snippet."
+            "text" : "By default, the embedded code example includes the full snippet. For more information, see <doc:adding-code-snippets-to-your-content#Slice-up-your-snippet-to-break-it-up-in-your-content>."
           },
           {
             "text" : "- Parameters:"
           },
           {
-            "text" : "  - path: The path components of a symbol link that would be used to resolve a reference to a snippet,"
-          },
-          {
-            "text" : "     only occurring as a block directive argument."
+            "text" : "  - path: The relative path from your package's top-level \"Snippets\" directory to the snippet file that you want to embed in the page, without the `.swift` file extension."
           },
           {
             "text" : "     **(required)**"
           },
           {
-            "text" : "  - slice: An optional named range to limit the lines shown."
+            "text" : "  - slice: The name of a snippet slice to limit the embedded code example to a certain line range."
           },
           {
             "text" : "     **(optional)**"
+          },
+          {
+            "text" : "     "
+          },
+          {
+            "text" : "     By default, the embedded code example includes the full snippet."
           }
         ]
       },

--- a/Sources/docc/DocCDocumentation.docc/adding-code-snippets-to-your-content.md
+++ b/Sources/docc/DocCDocumentation.docc/adding-code-snippets-to-your-content.md
@@ -91,16 +91,21 @@ swift run example-snippet
 
 To embed your snippet in an article or within the symbol reference pages, use the `@Snippet` directive.
 ```markdown
-@Snippet(path: "my-package/Snippets/example-snippet")
+@Snippet(path: "example-snippet")
 ```
 
-The `path` argument has three parts:
+The `path` argument is the relative path from the package's top-level "Snippets" directory to your snippet file without the `.swift` extension.
 
-1. The package name as defined in `Package.swift`
+If you prefer, you can specify the relative path from the package's _root_ directory (by including a "Snippets/" prefix).
+You can also include the package name---as defined in `Package.swift`---before the "Snippets/" prefix. 
+Neither of these leading path components are necessary because all your snippet code files are always located in your package's "Snippets" directory.  
 
-2. The directory path to the snippet file, starting with "Snippets".
-
-3. The name of your snippet file without the `.swift` extension
+> Earlier Versions:
+> Before Swift-DocC 6.2, the `@Snippet` path needed to include both the package name component and the "Snippets" component:
+>
+> ```markdown
+> @Snippet(path: "my-package/Snippets/example-snippet")
+> ```
 
 A snippet reference displays as a block between other paragraphs.
 In the example package above, the `YourProject.md` file might contain this markdown:
@@ -114,7 +119,7 @@ Add a single sentence or sentence fragment, which DocC uses as the page’s abst
 
 Add one or more paragraphs that introduce your content overview.
 
-@Snippet(path: "YourProject/Snippets/example-snippet")
+@Snippet(path: "example-snippet")
 ```
 
 If your snippet code requires setup — like imports or variable definitions — that distract from the snippet's main focus, you can add `// snippet.hide` and `// snippet.show` lines in the snippet code to exclude the lines in between from displaying in your documentation.
@@ -145,12 +150,12 @@ Replace `YourTarget` with a target from your package to preview:
 swift package --disable-sandbox preview-documentation --target YourTarget
 ```
 
-### Slice up your snippet to break it up in your content.
+### Slice up your snippet to break it up in your content
 
 Long snippets dropped into documentation can result in a wall of text that is harder to parse and understand.
 Instead, annotate non-overlapping slices in the snippet, which allows you to reference and embed the slice portion of the example code.
 
-Annotating slices in a snippet looks similiar to annotating `snippet.show` and `snippet.hide`.
+Annotating slices in a snippet looks similar to annotating `snippet.show` and `snippet.hide`.
 You define the slice's identity in the comment, and that slice continues until the next instance of `// snippet.end` appears on a new line.
 When selecting your identifiers, use URL-compatible path characters.
 
@@ -174,7 +179,7 @@ For example, the follow code examples are effectively the same:
 var item = MyObject.init()
 // snippet.end
 
-// snipppet.configure
+// snippet.configure
 item.size = 3
 // snippet.end
 ```
@@ -183,7 +188,7 @@ item.size = 3
 // snippet.setup
 var item = MyObject.init()
 
-// snipppet.configure
+// snippet.configure
 item.size = 3
 ```
 
@@ -191,7 +196,7 @@ Use the `@Snippet` directive with the `slice` parameter to embed that slice as s
 Extending the earlier snippet example, the slice `setup` would be referenced with 
 
 ```markdown
-@Snippet(path: "my-package/Snippets/example-snippet", slice: "setup")
+@Snippet(path: "example-snippet", slice: "setup")
 ```
 
 ## Topics

--- a/Sources/docc/DocCDocumentation.docc/adding-code-snippets-to-your-content.md
+++ b/Sources/docc/DocCDocumentation.docc/adding-code-snippets-to-your-content.md
@@ -101,7 +101,7 @@ You can also include the package name---as defined in `Package.swift`---before t
 Neither of these leading path components are necessary because all your snippet code files are always located in your package's "Snippets" directory.  
 
 > Earlier Versions:
-> Before Swift-DocC 6.2, the `@Snippet` path needed to include both the package name component and the "Snippets" component:
+> Before Swift-DocC 6.2.1, the `@Snippet` path needed to include both the package name component and the "Snippets" component:
 >
 > ```markdown
 > @Snippet(path: "my-package/Snippets/example-snippet")

--- a/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
@@ -203,7 +203,7 @@ func aBlackListedFunc() {
             ])
             var configuration = DocumentationContext.Configuration()
             configuration.externalMetadata.diagnosticLevel = severity
-            let (_, context) = try await loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: severity), configuration: configuration)
+            let (_, context) = try await loadBundle(catalog: catalog, diagnosticFilterLevel: severity, configuration: configuration)
             
             // Verify that checker diagnostics were emitted or not, depending on the diagnostic level set.
             XCTAssertEqual(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.NonInclusiveLanguage" }), enabled)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -5315,7 +5315,7 @@ let expected = """
     func testContextDiagnosesInsufficientDisambiguationWithCorrectRange() async throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind && !symbolKindID.isSnippetKind {
             // Generate a 4 symbols with the same name for every non overloadable symbol kind
             let symbols: [SymbolGraph.Symbol] = [
                 makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
@@ -5369,7 +5369,7 @@ let expected = """
     func testContextDiagnosesIncorrectDisambiguationWithCorrectRange() async throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind && !symbolKindID.isSnippetKind {
             // Generate a 4 symbols with the same name for every non overloadable symbol kind
             let symbols: [SymbolGraph.Symbol] = [
                 makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
@@ -5421,7 +5421,7 @@ let expected = """
     func testContextDiagnosesIncorrectSymbolNameWithCorrectRange() async throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind && !symbolKindID.isSnippetKind {
             // Generate a 4 symbols with the same name for every non overloadable symbol kind
             let symbols: [SymbolGraph.Symbol] = [
                 makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2229,7 +2229,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try await loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: .information))
+        let (bundle, context) = try await loadBundle(catalog: catalog, diagnosticFilterLevel: .information)
         XCTAssertNil(context.soleRootModuleReference)
         
         let curationDiagnostics = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.ArticleUncurated" }).map(\.diagnostic)

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -2337,31 +2337,6 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testSnippets() async throws {
-        let (_, context) = try await testBundleAndContext(named: "Snippets")
-        let tree = context.linkResolver.localResolver.pathHierarchy
-        
-        try assertFindsPath("/Snippets/Snippets/MySnippet", in: tree, asSymbolID: "$snippet__Test.Snippets.MySnippet")
-        
-        let paths = tree.caseInsensitiveDisambiguatedPaths()
-        XCTAssertEqual(paths["$snippet__Test.Snippets.MySnippet"],
-                       "/Snippets/Snippets/MySnippet")
-        
-        // Test relative links from the article that overlap with the snippet's path
-        let snippetsArticleID = try tree.find(path: "/Snippets/Snippets", onlyFindSymbols: false)
-        XCTAssertEqual(try tree.findSymbol(path: "MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/Snippets/MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "/Snippets/Snippets/MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        
-        // Test relative links from another article (which doesn't overlap with the snippet's path)
-        let sliceArticleID = try tree.find(path: "/Snippets/SliceIndentation", onlyFindSymbols: false)
-        XCTAssertThrowsError(try tree.findSymbol(path: "MySnippet", parent: sliceArticleID))
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "/Snippets/Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-    }
-    
     func testInheritedOperators() async throws {
         let (_, context) = try await testBundleAndContext(named: "InheritedOperators")
         let tree = context.linkResolver.localResolver.pathHierarchy

--- a/Tests/SwiftDocCTests/Infrastructure/SnippetResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SnippetResolverTests.swift
@@ -123,7 +123,7 @@ class SnippetResolverTests: XCTestCase {
     }
     
     func testWarningsAboutMisspelledSnippetPathsAndMisspelledSlice() async throws {
-        for pathPrefix in optionalPathPrefixes {
+        for pathPrefix in optionalPathPrefixes.prefix(1) {
             let (problems, logOutput, snippetRenderBlocks) = try await makeSnippetContext(
                 snippets: [
                     makeSnippet(
@@ -182,10 +182,10 @@ class SnippetResolverTests: XCTestCase {
             let prefixLength = pathPrefix.count
             XCTAssertEqual(logOutput, """
             \u{001B}[1;33mwarning: Snippet named 'Frst' couldn't be found\u{001B}[0;0m
-             --> ModuleName.md:7:16-7:\(20 + prefixLength)
+             --> ModuleName.md:7:\(16 + prefixLength)-7:\(20 + prefixLength)
             5 | ## Overview
             6 |
-            7 + @Snippet(path: \u{001B}[1;32m\(pathPrefix)Frst\u{001B}[0;0m)
+            7 + @Snippet(path: \(pathPrefix)\u{001B}[1;32mFrst\u{001B}[0;0m)
               | \(String(repeating: " ", count: prefixLength))               ╰─\u{001B}[1;39msuggestion: Replace 'Frst' with 'First'\u{001B}[0;0m
             8 |
             9 | @Snippet(path: \(pathPrefix)First, slice: commt)

--- a/Tests/SwiftDocCTests/Infrastructure/SnippetResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SnippetResolverTests.swift
@@ -1,0 +1,185 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+import SymbolKit
+import SwiftDocCTestUtilities
+
+class SnippetResolverTests: XCTestCase {
+    
+    let optionalPathPrefixes = [
+        // The module name as the first component
+        "/ModuleName/Snippets/",
+         "ModuleName/Snippets/",
+        
+         // The catalog name as the first component
+         "/Something/Snippets/",
+          "Something/Snippets/",
+        
+          // Snippets repeated as the first component
+          "/Snippets/Snippets/",
+           "Snippets/Snippets/",
+        
+                   // Only the "Snippets" prefix
+                   "/Snippets/",
+                    "Snippets/",
+        
+                            // No prefix
+                            "/",
+                             "",
+    ]
+    
+    func testRenderingSnippetsWithOptionalPathPrefixes() async throws {
+        for pathPrefix in optionalPathPrefixes {
+            let (problems, snippetRenderBlocks) = try await makeSnippetContext(
+                snippets: [
+                    makeSnippet(
+                        pathComponents: ["Snippets", "First"],
+                        explanation: """
+                        Some _formatted_ **content** that provides context to the snippet.
+                        """,
+                        code: """
+                        // Some code comment
+                        print("Hello, world!")
+                        """,
+                        slices: ["comment": 0..<1]
+                    ),
+                    makeSnippet(
+                        pathComponents: ["Snippets", "Path", "To", "Second"],
+                        explanation: nil,
+                        code: """
+                        print("1 + 2 = \\(1+2)")
+                        """
+                    )
+                ],
+                rootContent: """
+                @Snippet(path: \(pathPrefix)First)
+                
+                @Snippet(path: \(pathPrefix)Path/To/Second)
+                
+                @Snippet(path: \(pathPrefix)First, slice: comment)
+                """
+            )
+            
+            // These links should all resolve, regardless of optional prefix
+            XCTAssertTrue(problems.isEmpty, "Unexpected problems for path prefix '\(pathPrefix)': \(problems.map(\.diagnostic.summary))")
+            
+            // Because the snippet links resolved, their content should render on the page.
+            
+            // The explanation for the first snippet
+            if case .paragraph(let paragraph) = snippetRenderBlocks.first {
+                XCTAssertEqual(paragraph.inlineContent, [
+                    .text("Some "),
+                    .emphasis(inlineContent: [.text("formatted")]),
+                    .text(" "),
+                    .strong(inlineContent: [.text("content")]),
+                    .text(" that provides context to the snippet."),
+                ])
+            } else {
+                XCTFail("Missing expected rendered explanation.")
+            }
+            
+            // The first snippet code
+            if case .codeListing(let codeListing) = snippetRenderBlocks.dropFirst().first {
+                XCTAssertEqual(codeListing.syntax, "swift")
+                XCTAssertEqual(codeListing.code, [
+                    #"// Some code comment"#,
+                    #"print("Hello, world!")"#,
+                ])
+            } else {
+                XCTFail("Missing expected rendered code block.")
+            }
+            
+            // The second snippet (without an explanation)
+            if case .codeListing(let codeListing) = snippetRenderBlocks.dropFirst(2).first {
+                XCTAssertEqual(codeListing.syntax, "swift")
+                XCTAssertEqual(codeListing.code, [
+                    #"print("1 + 2 = \(1+2)")"#
+                ])
+            } else {
+                XCTFail("Missing expected rendered code block.")
+            }
+            
+            // The third snippet is a slice, so it doesn't display its explanation
+            if case .codeListing(let codeListing) = snippetRenderBlocks.dropFirst(3).first {
+                XCTAssertEqual(codeListing.syntax, "swift")
+                XCTAssertEqual(codeListing.code, [
+                    #"// Some code comment"#,
+                ])
+            } else {
+                XCTFail("Missing expected rendered code block.")
+            }
+            
+            XCTAssertNil(snippetRenderBlocks.dropFirst(4).first, "There's no more content after the snippets")
+        }
+    }
+    
+    private func makeSnippetContext(
+        snippets: [SymbolGraph.Symbol],
+        rootContent: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> ([Problem], some Collection<RenderBlockContent>) {
+        let catalog = Folder(name: "Something.docc", content: [
+            JSONFile(name: "something-snippets.symbols.json", content: makeSymbolGraph(moduleName: "Snippets", symbols: snippets)),
+            // Include a "real" module that's separate from the snippet symbol graph.
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
+            
+            TextFile(name: "ModuleName.md", utf8Content: """
+            # ``ModuleName``
+                
+            Always include an abstract here before the custom markup
+            
+            \(rootContent)
+            """)
+        ])
+        
+        let (_, context) = try await loadBundle(catalog: catalog)
+        
+        XCTAssertEqual(context.knownIdentifiers.count, 1, "The snippets don't have their own identifiers", file: file, line: line)
+        
+        let reference = try XCTUnwrap(context.soleRootModuleReference, file: file, line: line)
+        let moduleNode = try context.entity(with: reference)
+        let renderNode = DocumentationNodeConverter(bundle: context.bundle, context: context).convert(moduleNode)
+        
+        let renderBlocks = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection, file: file, line: line).content
+        
+        if case .heading(let heading) = renderBlocks.first  {
+            XCTAssertEqual(heading.level, 2, file: file, line: line)
+            XCTAssertEqual(heading.text, "Overview", file: file, line: line)
+        } else {
+            XCTFail("The rendered page didn't have a synthesized 'Overview' heading. It might be missing all its content.", file: file, line: line)
+        }
+        
+        return (context.problems, renderBlocks.dropFirst())
+    }
+    
+    private func makeSnippet(
+        pathComponents: [String],
+        explanation: String?,
+        code: String,
+        slices: [String: Range<Int>] = [:]
+    ) -> SymbolGraph.Symbol {
+        makeSymbol(
+            id: "$snippet__module-name.\(pathComponents.map { $0.lowercased() }.joined(separator: "."))",
+            kind: .snippet,
+            pathComponents: pathComponents,
+            docComment: explanation,
+            otherMixins: [
+                SymbolGraph.Symbol.Snippet(
+                    language: SourceLanguage.swift.id,
+                    lines: code.components(separatedBy: "\n"),
+                    slices: slices
+                )
+            ]
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
@@ -160,15 +160,11 @@ class TabNavigatorTests: XCTestCase {
         
         XCTAssertNotNil(tabNavigator)
 
-        // UnresolvedTopicReference warning expected since the reference to the snippet "Snippets/Snippets/MySnippet" 
-        // should fail to resolve here and then nothing would be added to the content.
-        XCTAssertEqual(
-            problems,
-            ["23: warning – org.swift.docc.unresolvedTopicReference"]
-        )
+        // One warning is expected. This empty context has no snippets so the "Snippets/Snippets/MySnippet" path should fail to resolve.
+        XCTAssertEqual(problems, [
+            "23: warning – org.swift.docc.unresolvedSnippetPath"
+        ])
 
-        
-        
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
             renderBlockContent.first,
@@ -202,6 +198,8 @@ class TabNavigatorTests: XCTestCase {
                             "Hey there.",
     
                             .small(RenderBlockContent.Small(inlineContent: [.text("Hey but small.")])),
+                            
+                            // Because the the "Snippets/Snippets/MySnippet" snippet failed to resolve, we're not including any snippet content here.
                         ]
                     ),
                 ]

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class SnippetTests: XCTestCase {
-    func testNoPath() async throws {
-        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
+    func testWarningAboutMissingPathPath() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         let source = """
         @Snippet()
         """
@@ -29,8 +29,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.path", problems[0].diagnostic.identifier)
     }
 
-    func testHasInnerContent() async throws {
-        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
+    func testWarningAboutInnerContent() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         let source = """
         @Snippet(path: "path/to/snippet") {
             This content shouldn't be here.
@@ -45,8 +45,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.Snippet.NoInnerContentAllowed", problems[0].diagnostic.identifier)
     }
 
-    func testLinkResolves() async throws {
-        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
+    func testParsesPath() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet")
         """
@@ -59,7 +59,7 @@ class SnippetTests: XCTestCase {
         XCTAssertTrue(problems.isEmpty)
     }
     
-    func testUnresolvedSnippetPathDiagnostic() async throws {
+    func testWarningAboutUnresolvedSnippetPath() async throws {
         let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let source = """
         @Snippet(path: "Test/Snippets/DoesNotExist")
@@ -74,8 +74,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual(problem.possibleSolutions.count, 0)
     }
     
-    func testSliceResolves() async throws {
-        let (bundle, _) = try await testBundleAndContext(named: "Snippets")
+    func testParsesSlice() async throws {
+        let (bundle, _) = try await testBundleAndContext()
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet", slice: "foo")
         """

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -62,15 +62,16 @@ class SnippetTests: XCTestCase {
     func testUnresolvedSnippetPathDiagnostic() async throws {
         let (bundle, context) = try await testBundleAndContext(named: "Snippets")
         let source = """
-        @Snippet(path: "Test/Snippets/DoesntExist")
+        @Snippet(path: "Test/Snippets/DoesNotExist")
         """
         let document = Document(parsing: source, options: .parseBlockDirectives)
-        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: context.rootModules[0])
+        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: try XCTUnwrap(context.soleRootModuleReference))
         _ = resolver.visit(document)
         XCTAssertEqual(1, resolver.problems.count)
-        resolver.problems.first.map {
-            XCTAssertEqual("org.swift.docc.unresolvedTopicReference", $0.diagnostic.identifier)
-        }
+        let problem = try XCTUnwrap(resolver.problems.first)
+        XCTAssertEqual(problem.diagnostic.identifier, "org.swift.docc.unresolvedSnippetPath")
+        XCTAssertEqual(problem.diagnostic.summary, "Snippet named 'DoesNotExist' couldn't be found.")
+        XCTAssertEqual(problem.possibleSolutions.count, 0)
     }
     
     func testSliceResolves() async throws {

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -95,7 +95,7 @@ class SnippetTests: XCTestCase {
             XCTAssertEqual(1, resolver.problems.count)
             let problem = try XCTUnwrap(resolver.problems.first)
             XCTAssertEqual(problem.diagnostic.identifier, "org.swift.docc.unresolvedSnippetPath")
-            XCTAssertEqual(problem.diagnostic.summary, "Snippet named 'DoesNotExist' couldn't be found.")
+            XCTAssertEqual(problem.diagnostic.summary, "Snippet named 'DoesNotExist' couldn't be found")
             XCTAssertEqual(problem.possibleSolutions.count, 0)
         }
     }

--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1611,8 +1611,7 @@ class SymbolTests: XCTestCase {
             )
         }
         
-        let diagnosticEngine = DiagnosticEngine(filterLevel: diagnosticEngineFilterLevel)
-        let (_, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: catalogContent), diagnosticEngine: diagnosticEngine)
+        let (_, context) = try await loadBundle(catalog: Folder(name: "unit-test.docc", content: catalogContent), diagnosticFilterLevel: diagnosticEngineFilterLevel)
         
         let node = try XCTUnwrap(context.documentationCache[methodUSR], file: file, line: line)
         

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -43,21 +43,30 @@ extension XCTestCase {
     /// - Parameters:
     ///   - catalog: The directory structure of the documentation catalog
     ///   - otherFileSystemDirectories: Any other directories in the test file system.
-    ///   - diagnosticEngine: The diagnostic engine for the created context.
+    ///   - diagnosticFilterLevel: The minimum severity for diagnostics to emit.
+    ///   - logOutput: An output stream to capture log output from creating the context.
     ///   - configuration: Configuration for the created context.
     /// - Returns: The loaded documentation bundle and context for the given catalog input.
     func loadBundle(
         catalog: Folder,
         otherFileSystemDirectories: [Folder] = [],
-        diagnosticEngine: DiagnosticEngine = .init(),
+        diagnosticFilterLevel: DiagnosticSeverity = .warning,
+        logOutput: some TextOutputStream = LogHandle.none,
         configuration: DocumentationContext.Configuration = .init()
     ) async throws -> (DocumentationBundle, DocumentationContext) {
         let fileSystem = try TestFileSystem(folders: [catalog] + otherFileSystemDirectories)
+        let catalogURL = URL(fileURLWithPath: "/\(catalog.name)")
+        
+        let diagnosticEngine = DiagnosticEngine(filterLevel: diagnosticFilterLevel)
+        diagnosticEngine.add(DiagnosticConsoleWriter(logOutput, formattingOptions: [], baseURL: catalogURL, highlight: false, dataProvider: fileSystem))
         
         let (bundle, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
-            .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/\(catalog.name)"), options: .init())
+            .inputsAndDataProvider(startingPoint: catalogURL, options: .init())
 
         let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
+        
+        diagnosticEngine.flush() // Write to the logOutput
+        
         return (bundle, context)
     }
     

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -58,7 +58,7 @@ extension XCTestCase {
         let catalogURL = URL(fileURLWithPath: "/\(catalog.name)")
         
         let diagnosticEngine = DiagnosticEngine(filterLevel: diagnosticFilterLevel)
-        diagnosticEngine.add(DiagnosticConsoleWriter(logOutput, formattingOptions: [], baseURL: catalogURL, highlight: false, dataProvider: fileSystem))
+        diagnosticEngine.add(DiagnosticConsoleWriter(logOutput, formattingOptions: [], baseURL: catalogURL, highlight: true, dataProvider: fileSystem))
         
         let (bundle, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
             .inputsAndDataProvider(startingPoint: catalogURL, options: .init())


### PR DESCRIPTION
<!--
If you're opening a PR to cherry-pick a change for a release branch, use this template instead:
https://github.com/apple/swift-docc/blob/main/.github/PULL_REQUEST_TEMPLATE/CHERRY_PICK.md
-->

Bug/issue #, if applicable: rdar://147926589&161164434 #1280

## Summary

This improves the handling of snippet symbol graph files by no longer relying on main module / bystander logic and instead detecting snippets based on their symbol kind and handling them in a dedicated code path. 

By avoiding the main bystander symbol graph logic, this avoid issues with DocC miscategorizing the snippets symbol graph file as a separate module, resulting in their being two different "roots" of the documentation hierarchy (which is undefined behavior, with known nondeterminism, in DocC). The effect of this is that:
- Snippets are no longer added to the `PathHierarchy`
- Snippets no longer have `ResolvedTopicReference` identifiers
- Snippets no longer have `DocumentationNode` or `TopicGraph/Node` values that need to be skipped over.

This doesn't result in any loss of functionality. Because snippet paths aren't resolved relative to the linked page—but relative to the package's root—and because snippet paths don't have overloads/disambiguation there wasn't any benefit from storing them in the `PathHierarchy`. Because snippets aren't pages, they also didn't benefit from having nodes in the context.

Now, all the snippet logic is "custom" but it's so simple that it's ~150 LOC including comments.

With custom logic for the snippets, it was easier to refine their path "resolution" and diagnostics. 

I've long felt that it was unnecessary for snippets to all have the "my-package/Snippets" prefix, now with the new implementation it was easy to make that optional (while still supported for backwards compatibility). It was also easier to customize the diagnosis message and add near-miss suggestions for both paths and slices. The new tests cover both the optional path prefixes, rendering, and snippet diagnostics.

Lastly, I updated the user-facing documentation to cover these improvements.

Because #1280 is a regression in 6.2, the plan is to cherry-pick this into 6.2 (that's why the new documentation says that this works in 6.2)

## Dependencies

None.

## Testing

- Add a snippet to a package by following the steps in the "Adding Code Snippets to Your Content" documentation.
- Link to those snippets from a module in the package, with and without slices.
- Build documentation using `swift package generate-documentation` (so that snippets are included in the build)
  - The snippets should resolve (or have actionable warnings if the snippets aren't found)
- Preview the built documentation
  - The relevant snippet content and slices should display inline on the pages that used `@Snippet` directives.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
