### PR TITLE
Update dependant packages to match 6.2.1 branch

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-symbolkit.git",
       "state" : {
-        "branch" : "release/6.2",
+        "branch" : "release/6.2.1",
         "revision" : "467084cd380d352abcd128b27927ecdc8cb5bae8"
       }
     },
@@ -77,7 +77,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-lmdb.git",
       "state" : {
-        "branch" : "release/6.2",
+        "branch" : "release/6.2.1",
         "revision" : "1ad9a2d80b6fcde498c2242f509bd1be7d667ff8"
       }
     },
@@ -86,7 +86,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-markdown.git",
       "state" : {
-        "branch" : "release/6.2",
+        "branch" : "release/6.2.1",
         "revision" : "3be4e1a09cef425602f11bdb4b4de252e4badd11"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -134,10 +134,10 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
-        .package(url: "https://github.com/swiftlang/swift-markdown.git", branch: "release/6.2"),
-        .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "release/6.2"),
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", branch: "release/6.2.1"),
+        .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "release/6.2.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
-        .package(url: "https://github.com/swiftlang/swift-docc-symbolkit.git", branch: "release/6.2"),
+        .package(url: "https://github.com/swiftlang/swift-docc-symbolkit.git", branch: "release/6.2.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.2.0"),
     ]


### PR DESCRIPTION
Update the dependant packages to match 6.2.1, so parent dependencies like sourcekit-lsp will not have version errors.
