### PR TITLE
[6.2.1] Improve handling of snippet symbol graph files (#1302)

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
+++ b/Sources/SwiftDocC/Infrastructure/DocumentationContext.swift
@@ -167,6 +167,9 @@ public class DocumentationContext {
     /// > Important: The topic graph has no awareness of source language specific edges.
     var topicGraph = TopicGraph()
     
+    /// Will be assigned during context initialization
+    var snippetResolver: SnippetResolver!
+    
     /// User-provided global options for this documentation conversion.
     var options: Options?
     
@@ -2235,6 +2238,8 @@ public class DocumentationContext {
                         knownDisambiguatedPathComponents: configuration.convertServiceConfiguration.knownDisambiguatedSymbolPathComponents
                     ))
                 }
+                
+                self.snippetResolver = SnippetResolver(symbolGraphLoader: symbolGraphLoader)
             } catch {
                 // Pipe the error out of the dispatch queue.
                 discoveryError.sync({

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+Error.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -285,7 +285,7 @@ private extension PathHierarchy.Node {
     }
 }
 
-private extension SourceRange {
+extension SourceRange {
     static func makeRelativeRange(startColumn: Int, endColumn: Int) -> SourceRange {
         return SourceLocation(line: 0, column: startColumn, source: nil) ..< SourceLocation(line: 0, column: endColumn, source: nil)
     }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/SnippetResolver.swift
@@ -1,0 +1,156 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SymbolKit
+import Markdown
+
+/// A type that resolves snippet paths.
+final class SnippetResolver {
+    typealias SnippetMixin = SymbolKit.SymbolGraph.Symbol.Snippet
+    typealias Explanation  = Markdown.Document
+    
+    /// Information about a resolved snippet
+    struct ResolvedSnippet {
+        fileprivate var path: String // For use in diagnostics
+        var mixin: SnippetMixin
+        var explanation: Explanation?
+    }
+    /// A snippet that has been resolved, either successfully or not.
+    enum SnippetResolutionResult {
+        case success(ResolvedSnippet)
+        case failure(TopicReferenceResolutionErrorInfo)
+    }
+    
+    private var snippets: [String: ResolvedSnippet] = [:]
+    
+    init(symbolGraphLoader: SymbolGraphLoader) {
+        var snippets: [String: ResolvedSnippet] = [:]
+        
+        for graph in symbolGraphLoader.snippetSymbolGraphs.values {
+            for symbol in graph.symbols.values {
+                guard let snippetMixin = symbol[mixin: SnippetMixin.self] else { continue }
+                
+                let path: String = if symbol.pathComponents.first == "Snippets" {
+                    symbol.pathComponents.dropFirst().joined(separator: "/")
+                } else {
+                    symbol.pathComponents.joined(separator: "/")
+                }
+                
+                snippets[path] = .init(path: path, mixin: snippetMixin, explanation: symbol.docComment.map {
+                    Document(parsing: $0.lines.map(\.text).joined(separator: "\n"), options: .parseBlockDirectives)
+                })
+            }
+        }
+        
+        self.snippets = snippets
+    }
+ 
+    func resolveSnippet(path authoredPath: String) -> SnippetResolutionResult {
+        // Snippet paths are relative to the root of the Swift Package.
+        // The first two components are always the same (the package name followed by "Snippets").
+        // The later components can either be subdirectories of the "Snippets" directory or the base name of a snippet '.swift' file (without the extension).
+          
+        // Drop the common package name + "Snippets" prefix (that's always the same), if the authored path includes it.
+        // This enables the author to omit this prefix (but include it for backwards compatibility with older DocC versions).
+        var components = authoredPath.split(separator: "/", omittingEmptySubsequences: true)
+        
+        // It's possible that the package name is "Snippets", resulting in two identical components. Skip until the last of those two.
+        if let snippetsPrefixIndex = components.prefix(2).lastIndex(of: "Snippets"),
+           // Don't search for an empty string if the snippet happens to be named "Snippets"
+           let relativePathStart = components.index(snippetsPrefixIndex, offsetBy: 1, limitedBy: components.endIndex - 1)
+        {
+            components.removeFirst(relativePathStart)
+        }
+        
+        let path = components.joined(separator: "/")
+        if let found = snippets[path] {
+            return .success(found)
+        } else {
+            let replacementRange = SourceRange.makeRelativeRange(startColumn: authoredPath.utf8.count - path.utf8.count, length: path.utf8.count)
+            
+            let nearMisses = NearMiss.bestMatches(for: snippets.keys, against: path)
+            let solutions = nearMisses.map { candidate in
+                Solution(summary: "\(Self.replacementOperationDescription(from: path, to: candidate))", replacements: [
+                    Replacement(range: replacementRange, replacement: candidate)
+                ])
+            }
+            
+            return .failure(.init("Snippet named '\(path)' couldn't be found", solutions: solutions, rangeAdjustment: replacementRange))
+        }
+    }
+    
+    func validate(slice: String, for resolvedSnippet: ResolvedSnippet) -> TopicReferenceResolutionErrorInfo? {
+        guard resolvedSnippet.mixin.slices[slice] == nil else {
+            return nil
+        }
+        let replacementRange = SourceRange.makeRelativeRange(startColumn: 0, length: slice.utf8.count)
+        
+        let nearMisses = NearMiss.bestMatches(for: resolvedSnippet.mixin.slices.keys, against: slice)
+        let solutions = nearMisses.map { candidate in
+            Solution(summary: "\(Self.replacementOperationDescription(from: slice, to: candidate))", replacements: [
+                Replacement(range: replacementRange, replacement: candidate)
+            ])
+        }
+        
+        return .init("Slice named '\(slice)' doesn't exist in snippet '\(resolvedSnippet.path)'", solutions: solutions)
+    }
+}
+
+// MARK: Diagnostics
+
+extension SnippetResolver {
+    static func unknownSnippetSliceProblem(source: URL?, range: SourceRange?, errorInfo: TopicReferenceResolutionErrorInfo) -> Problem {
+        _problem(source: source, range: range, errorInfo: errorInfo, id: "org.swift.docc.unknownSnippetPath")
+    }
+
+    static func unresolvedSnippetPathProblem(source: URL?, range: SourceRange?, errorInfo: TopicReferenceResolutionErrorInfo) -> Problem {
+        _problem(source: source, range: range, errorInfo: errorInfo, id: "org.swift.docc.unresolvedSnippetPath")
+    }
+    
+    private static func _problem(source: URL?, range: SourceRange?, errorInfo: TopicReferenceResolutionErrorInfo, id: String) -> Problem {
+        var solutions: [Solution] = []
+        var notes: [DiagnosticNote] = []
+        if let range {
+            if let note = errorInfo.note, let source {
+                notes.append(DiagnosticNote(source: source, range: range, message: note))
+            }
+            
+            solutions.append(contentsOf: errorInfo.solutions(referenceSourceRange: range))
+        }
+        
+        let diagnosticRange: SourceRange?
+        if var rangeAdjustment = errorInfo.rangeAdjustment, let range {
+            rangeAdjustment.offsetWithRange(range)
+            assert(rangeAdjustment.lowerBound.column >= 0, """
+                Unresolved snippet reference range adjustment created range with negative column.
+                Source: \(source?.absoluteString ?? "nil")
+                Range: \(rangeAdjustment.lowerBound.description):\(rangeAdjustment.upperBound.description)
+                Summary: \(errorInfo.message)
+                """)
+            diagnosticRange = rangeAdjustment
+        } else {
+            diagnosticRange = range
+        }
+        
+        let diagnostic = Diagnostic(source: source, severity: .warning, range: diagnosticRange, identifier: id, summary: errorInfo.message, notes: notes)
+        return Problem(diagnostic: diagnostic, possibleSolutions: solutions)
+    }
+    
+    private static func replacementOperationDescription(from: some StringProtocol, to: some StringProtocol) -> String {
+        if from.isEmpty {
+            return "Insert \(to.singleQuoted)"
+        }
+        if to.isEmpty {
+            return "Remove \(from.singleQuoted)"
+        }
+        return "Replace \(from.singleQuoted) with \(to.singleQuoted)"
+    }
+}

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/SymbolGraphLoader.swift
@@ -17,6 +17,7 @@ import SymbolKit
 /// which makes detecting symbol collisions and overloads easier.
 struct SymbolGraphLoader {
     private(set) var symbolGraphs: [URL: SymbolKit.SymbolGraph] = [:]
+    private(set) var snippetSymbolGraphs: [URL: SymbolKit.SymbolGraph] = [:]
     private(set) var unifiedGraphs: [String: SymbolKit.UnifiedSymbolGraph] = [:]
     private(set) var graphLocations: [String: [SymbolKit.GraphCollector.GraphKind]] = [:]
     // FIXME: After 6.2, when we no longer have `DocumentationContextDataProvider` we can simply this code to not use a closure to read data.
@@ -58,7 +59,7 @@ struct SymbolGraphLoader {
         
         let loadingLock = Lock()
 
-        var loadedGraphs = [URL: (usesExtensionSymbolFormat: Bool?, graph: SymbolKit.SymbolGraph)]()
+        var loadedGraphs = [URL: (usesExtensionSymbolFormat: Bool?, isSnippetGraph: Bool, graph: SymbolKit.SymbolGraph)]()
         var loadError: (any Error)?
 
         let loadGraphAtURL: (URL) -> Void = { [dataLoader, bundle] symbolGraphURL in
@@ -99,9 +100,13 @@ struct SymbolGraphLoader {
                     usesExtensionSymbolFormat = symbolGraph.symbols.isEmpty ? nil : containsExtensionSymbols
                 }
                 
+                // If the graph doesn't have any symbols we treat it as a regular, but empty, graph.
+                //                                                   v
+                let isSnippetGraph = symbolGraph.symbols.values.first?.kind.identifier.isSnippetKind == true
+                
                 // Store the decoded graph in `loadedGraphs`
                 loadingLock.sync {
-                    loadedGraphs[symbolGraphURL] = (usesExtensionSymbolFormat, symbolGraph)
+                    loadedGraphs[symbolGraphURL] = (usesExtensionSymbolFormat, isSnippetGraph, symbolGraph)
                 }
             } catch {
                 // If the symbol graph was invalid, store the error
@@ -141,8 +146,9 @@ struct SymbolGraphLoader {
         let mergeSignpostHandle = signposter.beginInterval("Build unified symbol graph", id: signposter.makeSignpostID())
         let graphLoader = GraphCollector(extensionGraphAssociationStrategy: usingExtensionSymbolFormat ? .extendingGraph : .extendedGraph)
         
-        // feed the loaded graphs into the `graphLoader`
-        for (url, (_, graph)) in loadedGraphs {
+        
+        // feed the loaded non-snippet graphs into the `graphLoader`
+        for (url, (_, isSnippets, graph)) in loadedGraphs where !isSnippets {
             graphLoader.mergeSymbolGraph(graph, at: url)
         }
         
@@ -152,7 +158,8 @@ struct SymbolGraphLoader {
             throw loadError
         }
         
-        self.symbolGraphs = loadedGraphs.mapValues(\.graph)
+        self.symbolGraphs        = loadedGraphs.compactMapValues({ _, isSnippets, graph in isSnippets ? nil   : graph })
+        self.snippetSymbolGraphs = loadedGraphs.compactMapValues({ _, isSnippets, graph in isSnippets ? graph : nil   })
         (self.unifiedGraphs, self.graphLocations) = graphLoader.finishLoading(
             createOverloadGroups: FeatureFlags.current.isExperimentalOverloadedSymbolPresentationEnabled
         )
@@ -544,5 +551,11 @@ private extension SymbolGraph.Symbol.Availability {
 private extension SymbolGraph.Symbol.Availability.AvailabilityItem {
     func matches(_ platform: PlatformName) -> Bool {
         domain?.rawValue.lowercased() == platform.rawValue.lowercased()
+    }
+}
+
+extension SymbolGraph.Symbol.KindIdentifier {
+    var isSnippetKind: Bool {
+        self == .snippet || self == .snippetGroup
     }
 }

--- a/Sources/SwiftDocC/Model/DocumentationNode.swift
+++ b/Sources/SwiftDocC/Model/DocumentationNode.swift
@@ -853,7 +853,7 @@ private extension BlockDirective {
     }
 }
 
-extension [String] {
+extension Collection<String> {
 
     /// Strips the minimum leading whitespace from all the strings in the array.
     ///

--- a/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
+++ b/Tests/SwiftDocCTests/Checker/Checkers/NonInclusiveLanguageCheckerTests.swift
@@ -203,7 +203,7 @@ func aBlackListedFunc() {
             ])
             var configuration = DocumentationContext.Configuration()
             configuration.externalMetadata.diagnosticLevel = severity
-            let (_, context) = try loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: severity), configuration: configuration)
+            let (_, context) = try loadBundle(catalog: catalog, diagnosticFilterLevel: severity, configuration: configuration)
             
             // Verify that checker diagnostics were emitted or not, depending on the diagnostic level set.
             XCTAssertEqual(context.problems.contains(where: { $0.diagnostic.identifier == "org.swift.docc.NonInclusiveLanguage" }), enabled)

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -2184,7 +2184,7 @@ let expected = """
             """),
         ])
         
-        let (bundle, context) = try loadBundle(catalog: catalog, diagnosticEngine: .init(filterLevel: .information))
+        let (bundle, context) = try loadBundle(catalog: catalog, diagnosticFilterLevel: .information)
         XCTAssertNil(context.soleRootModuleReference)
         
         let curationDiagnostics = context.problems.filter({ $0.diagnostic.identifier == "org.swift.docc.ArticleUncurated" }).map(\.diagnostic)
@@ -5270,7 +5270,7 @@ let expected = """
     func testContextDiagnosesInsufficientDisambiguationWithCorrectRange() throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind && !symbolKindID.isSnippetKind {
             // Generate a 4 symbols with the same name for every non overloadable symbol kind
             let symbols: [SymbolGraph.Symbol] = [
                 makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
@@ -5324,7 +5324,7 @@ let expected = """
     func testContextDiagnosesIncorrectDisambiguationWithCorrectRange() throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind && !symbolKindID.isSnippetKind {
             // Generate a 4 symbols with the same name for every non overloadable symbol kind
             let symbols: [SymbolGraph.Symbol] = [
                 makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),
@@ -5376,7 +5376,7 @@ let expected = """
     func testContextDiagnosesIncorrectSymbolNameWithCorrectRange() throws {
         // This test deliberately does not turn on the overloads feature
         // to ensure the symbol link below does not accidentally resolve correctly.
-        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind {
+        for symbolKindID in SymbolGraph.Symbol.KindIdentifier.allCases where !symbolKindID.isOverloadableKind && !symbolKindID.isSnippetKind {
             // Generate a 4 symbols with the same name for every non overloadable symbol kind
             let symbols: [SymbolGraph.Symbol] = [
                 makeSymbol(id: "first-\(symbolKindID.identifier)-id",  kind: symbolKindID, pathComponents: ["SymbolName"]),

--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4890,7 +4890,11 @@ let expected = """
     func testContextDoesNotRecognizeNonOverloadableSymbolKinds() throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
         
-        let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { !$0.isOverloadableKind }
+        let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter {
+            !$0.isOverloadableKind &&
+            !$0.isSnippetKind      && // avoid mixing snippets with "real" symbols
+            $0 != .module             // avoid creating multiple modules
+        }
         // Generate a 4 symbols with the same name for every non overloadable symbol kind
         let symbols: [SymbolGraph.Symbol] = nonOverloadableKindIDs.flatMap { [
             makeSymbol(id: "first-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -2337,31 +2337,6 @@ class PathHierarchyTests: XCTestCase {
         }
     }
     
-    func testSnippets() throws {
-        let (_, context) = try testBundleAndContext(named: "Snippets")
-        let tree = context.linkResolver.localResolver.pathHierarchy
-        
-        try assertFindsPath("/Snippets/Snippets/MySnippet", in: tree, asSymbolID: "$snippet__Test.Snippets.MySnippet")
-        
-        let paths = tree.caseInsensitiveDisambiguatedPaths()
-        XCTAssertEqual(paths["$snippet__Test.Snippets.MySnippet"],
-                       "/Snippets/Snippets/MySnippet")
-        
-        // Test relative links from the article that overlap with the snippet's path
-        let snippetsArticleID = try tree.find(path: "/Snippets/Snippets", onlyFindSymbols: false)
-        XCTAssertEqual(try tree.findSymbol(path: "MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/Snippets/MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "/Snippets/Snippets/MySnippet", parent: snippetsArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        
-        // Test relative links from another article (which doesn't overlap with the snippet's path)
-        let sliceArticleID = try tree.find(path: "/Snippets/SliceIndentation", onlyFindSymbols: false)
-        XCTAssertThrowsError(try tree.findSymbol(path: "MySnippet", parent: sliceArticleID))
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "Snippets/Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-        XCTAssertEqual(try tree.findSymbol(path: "/Snippets/Snippets/MySnippet", parent: sliceArticleID).identifier.precise, "$snippet__Test.Snippets.MySnippet")
-    }
-    
     func testInheritedOperators() throws {
         let (_, context) = try testBundleAndContext(named: "InheritedOperators")
         let tree = context.linkResolver.localResolver.pathHierarchy

--- a/Tests/SwiftDocCTests/Infrastructure/SnippetResolverTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/SnippetResolverTests.swift
@@ -1,0 +1,272 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SwiftDocC
+import SymbolKit
+import SwiftDocCTestUtilities
+
+class SnippetResolverTests: XCTestCase {
+    
+    let optionalPathPrefixes = [
+        // The module name as the first component
+        "/ModuleName/Snippets/",
+         "ModuleName/Snippets/",
+        
+         // The catalog name as the first component
+         "/Something/Snippets/",
+          "Something/Snippets/",
+        
+          // Snippets repeated as the first component
+          "/Snippets/Snippets/",
+           "Snippets/Snippets/",
+        
+                   // Only the "Snippets" prefix
+                   "/Snippets/",
+                    "Snippets/",
+        
+                            // No prefix
+                            "/",
+                             "",
+    ]
+    
+    func testRenderingSnippetsWithOptionalPathPrefixes() throws {
+        for pathPrefix in optionalPathPrefixes {
+            let (problems, _, snippetRenderBlocks) = try makeSnippetContext(
+                snippets: [
+                    makeSnippet(
+                        pathComponents: ["Snippets", "First"],
+                        explanation: """
+                        Some _formatted_ **content** that provides context to the snippet.
+                        """,
+                        code: """
+                        // Some code comment
+                        print("Hello, world!")
+                        """,
+                        slices: ["comment": 0..<1]
+                    ),
+                    makeSnippet(
+                        pathComponents: ["Snippets", "Path", "To", "Second"],
+                        explanation: nil,
+                        code: """
+                        print("1 + 2 = \\(1+2)")
+                        """
+                    )
+                ],
+                rootContent: """
+                @Snippet(path: \(pathPrefix)First)
+                
+                @Snippet(path: \(pathPrefix)Path/To/Second)
+                
+                @Snippet(path: \(pathPrefix)First, slice: comment)
+                """
+            )
+            
+            // These links should all resolve, regardless of optional prefix
+            XCTAssertTrue(problems.isEmpty, "Unexpected problems for path prefix '\(pathPrefix)': \(problems.map(\.diagnostic.summary))")
+            
+            // Because the snippet links resolved, their content should render on the page.
+            
+            // The explanation for the first snippet
+            if case .paragraph(let paragraph) = snippetRenderBlocks.first {
+                XCTAssertEqual(paragraph.inlineContent, [
+                    .text("Some "),
+                    .emphasis(inlineContent: [.text("formatted")]),
+                    .text(" "),
+                    .strong(inlineContent: [.text("content")]),
+                    .text(" that provides context to the snippet."),
+                ])
+            } else {
+                XCTFail("Missing expected rendered explanation.")
+            }
+            
+            // The first snippet code
+            if case .codeListing(let codeListing) = snippetRenderBlocks.dropFirst().first {
+                XCTAssertEqual(codeListing.syntax, "swift")
+                XCTAssertEqual(codeListing.code, [
+                    #"// Some code comment"#,
+                    #"print("Hello, world!")"#,
+                ])
+            } else {
+                XCTFail("Missing expected rendered code block.")
+            }
+            
+            // The second snippet (without an explanation)
+            if case .codeListing(let codeListing) = snippetRenderBlocks.dropFirst(2).first {
+                XCTAssertEqual(codeListing.syntax, "swift")
+                XCTAssertEqual(codeListing.code, [
+                    #"print("1 + 2 = \(1+2)")"#
+                ])
+            } else {
+                XCTFail("Missing expected rendered code block.")
+            }
+            
+            // The third snippet is a slice, so it doesn't display its explanation
+            if case .codeListing(let codeListing) = snippetRenderBlocks.dropFirst(3).first {
+                XCTAssertEqual(codeListing.syntax, "swift")
+                XCTAssertEqual(codeListing.code, [
+                    #"// Some code comment"#,
+                ])
+            } else {
+                XCTFail("Missing expected rendered code block.")
+            }
+            
+            XCTAssertNil(snippetRenderBlocks.dropFirst(4).first, "There's no more content after the snippets")
+        }
+    }
+    
+    func testWarningsAboutMisspelledSnippetPathsAndMisspelledSlice() throws {
+        for pathPrefix in optionalPathPrefixes.prefix(1) {
+            let (problems, logOutput, snippetRenderBlocks) = try makeSnippetContext(
+                snippets: [
+                    makeSnippet(
+                        pathComponents: ["Snippets", "First"],
+                        explanation: """
+                        Some _formatted_ **content** that provides context to the snippet.
+                        """,
+                        code: """
+                        // Some code comment
+                        print("Hello, world!")
+                        """,
+                        slices: [
+                            "comment": 0..<1,
+                            "print":   1..<2,
+                        ]
+                    ),
+                ],
+                rootContent: """
+                @Snippet(path: \(pathPrefix)Frst)
+                
+                @Snippet(path: \(pathPrefix)First, slice: commt)
+                """
+            )
+            
+            // The first snippet has a misspelled path and the second has a misspelled slice
+            XCTAssertEqual(problems.map(\.diagnostic.summary), [
+                "Snippet named 'Frst' couldn't be found",
+                "Slice named 'commt' doesn't exist in snippet 'First'",
+            ])
+            
+            // Verify that the suggested solutions correct the issues.
+            let rootMarkupContent = """
+            # Heading
+            
+            Abstract 
+            
+            ## Subheading 
+            
+            @Snippet(path: \(pathPrefix)Frst)
+            
+            @Snippet(path: \(pathPrefix)First, slice: commt)
+            """
+            do {
+                let snippetPathProblem = try XCTUnwrap(problems.first)
+                let solution = try XCTUnwrap(snippetPathProblem.possibleSolutions.first)
+                let modifiedLines = try solution.applyTo(rootMarkupContent).components(separatedBy: "\n")
+                XCTAssertEqual(modifiedLines[6], "@Snippet(path: \(pathPrefix)First)")
+            }
+            do {
+                let snippetSliceProblem = try XCTUnwrap(problems.last)
+                let solution = try XCTUnwrap(snippetSliceProblem.possibleSolutions.first)
+                let modifiedLines = try solution.applyTo(rootMarkupContent).components(separatedBy: "\n")
+                XCTAssertEqual(modifiedLines[8], "@Snippet(path: \(pathPrefix)First, slice: comment)")
+            }
+            
+            let prefixLength = pathPrefix.count
+            XCTAssertEqual(logOutput, """
+            \u{001B}[1;33mwarning: Snippet named 'Frst' couldn't be found\u{001B}[0;0m
+             --> ModuleName.md:7:\(16 + prefixLength)-7:\(20 + prefixLength)
+            5 | ## Overview
+            6 |
+            7 + @Snippet(path: \(pathPrefix)\u{001B}[1;32mFrst\u{001B}[0;0m)
+              | \(String(repeating: " ", count: prefixLength))               ╰─\u{001B}[1;39msuggestion: Replace 'Frst' with 'First'\u{001B}[0;0m
+            8 |
+            9 | @Snippet(path: \(pathPrefix)First, slice: commt)
+
+            \u{001B}[1;33mwarning: Slice named 'commt' doesn't exist in snippet 'First'\u{001B}[0;0m
+             --> ModuleName.md:9:\(30 + prefixLength)-9:\(35 + prefixLength)
+            7 | @Snippet(path: \(pathPrefix)Frst)
+            8 |
+            9 + @Snippet(path: \(pathPrefix)First, slice: \u{001B}[1;32mcommt\u{001B}[0;0m)
+              | \(String(repeating: " ", count: prefixLength))                             ╰─\u{001B}[1;39msuggestion: Replace 'commt' with 'comment'\u{001B}[0;0m
+            
+            """)
+            
+            // Because the snippet links failed to resolve, their content shouldn't render on the page.
+            XCTAssertTrue(snippetRenderBlocks.isEmpty, "There's no more content after the snippets")
+        }
+    }
+    
+    private func makeSnippetContext(
+        snippets: [SymbolGraph.Symbol],
+        rootContent: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> ([Problem], logOutput: String, some Collection<RenderBlockContent>) {
+        let catalog = Folder(name: "Something.docc", content: [
+            JSONFile(name: "something-snippets.symbols.json", content: makeSymbolGraph(moduleName: "Snippets", symbols: snippets)),
+            // Include a "real" module that's separate from the snippet symbol graph.
+            JSONFile(name: "ModuleName.symbols.json", content: makeSymbolGraph(moduleName: "ModuleName")),
+            
+            TextFile(name: "ModuleName.md", utf8Content: """
+            # ``ModuleName``
+                
+            Always include an abstract here before the custom markup
+            
+            ## Overview
+            
+            \(rootContent)
+            """)
+        ])
+        // We make the "Overview" heading explicit above so that the rendered page will always have a `primaryContentSections`.
+        // This makes it easier for the test to then
+        
+        let logStore = LogHandle.LogStorage()
+        let (bundle, context) = try loadBundle(catalog: catalog, logOutput: LogHandle.memory(logStore))
+        
+        XCTAssertEqual(context.knownIdentifiers.count, 1, "The snippets don't have their own identifiers", file: file, line: line)
+        
+        let reference = try XCTUnwrap(context.soleRootModuleReference, file: file, line: line)
+        let moduleNode = try context.entity(with: reference)
+        let renderNode = DocumentationNodeConverter(bundle: bundle, context: context).convert(moduleNode)
+        
+        let renderBlocks = try XCTUnwrap(renderNode.primaryContentSections.first as? ContentRenderSection, file: file, line: line).content
+        
+        if case .heading(let heading) = renderBlocks.first  {
+            XCTAssertEqual(heading.level, 2, file: file, line: line)
+            XCTAssertEqual(heading.text, "Overview", file: file, line: line)
+        } else {
+            XCTFail("The rendered page is missing the 'Overview' heading. Something unexpected is happening with the page content.", file: file, line: line)
+        }
+        
+        return (context.problems.sorted(by: \.diagnostic.range!.lowerBound.line), logStore.text, renderBlocks.dropFirst())
+    }
+    
+    private func makeSnippet(
+        pathComponents: [String],
+        explanation: String?,
+        code: String,
+        slices: [String: Range<Int>] = [:]
+    ) -> SymbolGraph.Symbol {
+        makeSymbol(
+            id: "$snippet__module-name.\(pathComponents.map { $0.lowercased() }.joined(separator: "."))",
+            kind: .snippet,
+            pathComponents: pathComponents,
+            docComment: explanation,
+            otherMixins: [
+                SymbolGraph.Symbol.Snippet(
+                    language: SourceLanguage.swift.id,
+                    lines: code.components(separatedBy: "\n"),
+                    slices: slices
+                )
+            ]
+        )
+    }
+}

--- a/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/Reference/TabNavigatorTests.swift
@@ -160,15 +160,11 @@ class TabNavigatorTests: XCTestCase {
         
         XCTAssertNotNil(tabNavigator)
 
-        // UnresolvedTopicReference warning expected since the reference to the snippet "Snippets/Snippets/MySnippet" 
-        // should fail to resolve here and then nothing would be added to the content.
-        XCTAssertEqual(
-            problems,
-            ["23: warning – org.swift.docc.unresolvedTopicReference"]
-        )
+        // One warning is expected. This empty context has no snippets so the "Snippets/Snippets/MySnippet" path should fail to resolve.
+        XCTAssertEqual(problems, [
+            "23: warning – org.swift.docc.unresolvedSnippetPath"
+        ])
 
-        
-        
         XCTAssertEqual(renderBlockContent.count, 1)
         XCTAssertEqual(
             renderBlockContent.first,
@@ -202,6 +198,8 @@ class TabNavigatorTests: XCTestCase {
                             "Hey there.",
     
                             .small(RenderBlockContent.Small(inlineContent: [.text("Hey but small.")])),
+                            
+                            // Because the the "Snippets/Snippets/MySnippet" snippet failed to resolve, we're not including any snippet content here.
                         ]
                     ),
                 ]

--- a/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SnippetTests.swift
@@ -15,8 +15,8 @@ import XCTest
 import Markdown
 
 class SnippetTests: XCTestCase {
-    func testNoPath() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testWarningAboutMissingPathPath() throws {
+        let (bundle, _) = try testBundleAndContext()
         let source = """
         @Snippet()
         """
@@ -29,8 +29,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.HasArgument.path", problems[0].diagnostic.identifier)
     }
 
-    func testHasInnerContent() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testWarningAboutInnerContent() throws {
+        let (bundle, _) = try testBundleAndContext()
         let source = """
         @Snippet(path: "path/to/snippet") {
             This content shouldn't be here.
@@ -45,8 +45,8 @@ class SnippetTests: XCTestCase {
         XCTAssertEqual("org.swift.docc.Snippet.NoInnerContentAllowed", problems[0].diagnostic.identifier)
     }
 
-    func testLinkResolves() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testParsesPath() throws {
+        let (bundle, _) = try testBundleAndContext()
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet")
         """
@@ -58,23 +58,50 @@ class SnippetTests: XCTestCase {
         XCTAssertNotNil(snippet)
         XCTAssertTrue(problems.isEmpty)
     }
-    
-    func testUnresolvedSnippetPathDiagnostic() throws {
+    func testLinkResolvesWithoutOptionalPrefix() throws {
         let (bundle, context) = try testBundleAndContext(named: "Snippets")
-        let source = """
-        @Snippet(path: "Test/Snippets/DoesntExist")
-        """
-        let document = Document(parsing: source, options: .parseBlockDirectives)
-        var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: context.rootModules[0])
-        _ = resolver.visit(document)
-        XCTAssertEqual(1, resolver.problems.count)
-        resolver.problems.first.map {
-            XCTAssertEqual("org.swift.docc.unresolvedTopicReference", $0.diagnostic.identifier)
+        
+        for snippetPath in [
+            "/Test/Snippets/MySnippet",
+             "Test/Snippets/MySnippet",
+                  "Snippets/MySnippet",
+                           "MySnippet",
+        ] {
+            let source = """
+            @Snippet(path: "\(snippetPath)")
+            """
+            let document = Document(parsing: source, options: .parseBlockDirectives)
+            var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: try XCTUnwrap(context.soleRootModuleReference))
+            _ = resolver.visit(document)
+            XCTAssertTrue(resolver.problems.isEmpty, "Unexpected problems: \(resolver.problems.map(\.diagnostic.summary))")
         }
     }
     
-    func testSliceResolves() throws {
-        let (bundle, _) = try testBundleAndContext(named: "Snippets")
+    func testWarningAboutUnresolvedSnippetPath() throws {
+        let (bundle, context) = try testBundleAndContext(named: "Snippets")
+        
+        for snippetPath in [
+            "/Test/Snippets/DoesNotExist",
+             "Test/Snippets/DoesNotExist",
+                  "Snippets/DoesNotExist",
+                           "DoesNotExist",
+        ] {
+            let source = """
+            @Snippet(path: "\(snippetPath)")
+            """
+            let document = Document(parsing: source, options: .parseBlockDirectives)
+            var resolver = MarkupReferenceResolver(context: context, bundle: bundle, rootReference: try XCTUnwrap(context.soleRootModuleReference))
+            _ = resolver.visit(document)
+            XCTAssertEqual(1, resolver.problems.count)
+            let problem = try XCTUnwrap(resolver.problems.first)
+            XCTAssertEqual(problem.diagnostic.identifier, "org.swift.docc.unresolvedSnippetPath")
+            XCTAssertEqual(problem.diagnostic.summary, "Snippet named 'DoesNotExist' couldn't be found")
+            XCTAssertEqual(problem.possibleSolutions.count, 0)
+        }
+    }
+    
+    func testParsesSlice() throws {
+        let (bundle, _) = try testBundleAndContext()
         let source = """
         @Snippet(path: "Test/Snippets/MySnippet", slice: "foo")
         """

--- a/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
+++ b/Tests/SwiftDocCTests/XCTestCase+LoadingTestData.swift
@@ -43,21 +43,30 @@ extension XCTestCase {
     /// - Parameters:
     ///   - catalog: The directory structure of the documentation catalog
     ///   - otherFileSystemDirectories: Any other directories in the test file system.
-    ///   - diagnosticEngine: The diagnostic engine for the created context.
+    ///   - diagnosticFilterLevel: The minimum severity for diagnostics to emit.
+    ///   - logOutput: An output stream to capture log output from creating the context.
     ///   - configuration: Configuration for the created context.
     /// - Returns: The loaded documentation bundle and context for the given catalog input.
     func loadBundle(
         catalog: Folder,
         otherFileSystemDirectories: [Folder] = [],
-        diagnosticEngine: DiagnosticEngine = .init(),
+        diagnosticFilterLevel: DiagnosticSeverity = .warning,
+        logOutput: some TextOutputStream = LogHandle.none,
         configuration: DocumentationContext.Configuration = .init()
     ) throws -> (DocumentationBundle, DocumentationContext) {
         let fileSystem = try TestFileSystem(folders: [catalog] + otherFileSystemDirectories)
+        let catalogURL = URL(fileURLWithPath: "/\(catalog.name)")
+        
+        let diagnosticEngine = DiagnosticEngine(filterLevel: diagnosticFilterLevel)
+        diagnosticEngine.add(DiagnosticConsoleWriter(logOutput, formattingOptions: [], baseURL: catalogURL, highlight: true, dataProvider: fileSystem))
         
         let (bundle, dataProvider) = try DocumentationContext.InputsProvider(fileManager: fileSystem)
-            .inputsAndDataProvider(startingPoint: URL(fileURLWithPath: "/\(catalog.name)"), options: .init())
+            .inputsAndDataProvider(startingPoint: catalogURL, options: .init())
 
         let context = try DocumentationContext(bundle: bundle, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
+        
+        diagnosticEngine.flush() // Write to the logOutput
+        
         return (bundle, context)
     }
     


### PR DESCRIPTION
- **Explanation:** This improves the handling of snippet symbol graph files by no longer relying on main module / bystander logic and instead detecting snippets based on their symbol kind and handling them in a dedicated code path.
- **Scope:** Snippets non-deterministically aren't recognized.
- **Issue:** rdar://147926589 rdar://161164434 #1280
- **Risk:** Low. (Isolated to Snippets and the projects that use them).
- **Testing:**  Added tests that verify that snippets are recognized, that they're not processed as "regular" symbols/modules, and that verifies the user-facing diagnostics when they _correctly_ can't be found (for example because of misspellings). Existing automated tests pass.
- **Reviewer:** @QuietMisdreavus @heckj 
- **Original PR:** #1302 


---- 
This also cherry-picks #1308 (a test-only change) which was reviewed by @patshaughnessy 
