### PR TITLE
Fix test that became flaky after recent snippets change

### DIFF
--- a/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/DocumentationContext/DocumentationContextTests.swift
@@ -4935,7 +4935,11 @@ let expected = """
     func testContextDoesNotRecognizeNonOverloadableSymbolKinds() async throws {
         enableFeatureFlag(\.isExperimentalOverloadedSymbolPresentationEnabled)
         
-        let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter { !$0.isOverloadableKind }
+        let nonOverloadableKindIDs = SymbolGraph.Symbol.KindIdentifier.allCases.filter {
+            !$0.isOverloadableKind &&
+            !$0.isSnippetKind      && // avoid mixing snippets with "real" symbols
+            $0 != .module             // avoid creating multiple modules
+        }
         // Generate a 4 symbols with the same name for every non overloadable symbol kind
         let symbols: [SymbolGraph.Symbol] = nonOverloadableKindIDs.flatMap { [
             makeSymbol(id: "first-\($0.identifier)-id",  kind: $0, pathComponents: ["SymbolName"]),


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This fixes a test that became flaky after https://github.com/swiftlang/swift-docc/pull/1302.

The logic in https://github.com/swiftlang/swift-docc/pull/1302 isn't the problem. The problem is that this test was unrealistically mixing snippet symbols with real symbols in the same symbol graph file. 

Depending on which symbol appears _first_ in the dictionary of symbols, the entire symbol graph was categorized as either a snippet symbol graph or a regular symbol graph. This works for real symbol graph files because snippets symbol graphs files are created by a different tool than the module symbol graph files.

## Dependencies

None.

## Testing

Run this test (`testContextDoesNotRecognizeNonOverloadableSymbolKinds`) repeatedly _with_ relaunching the test for each repetition so that the symbols order differently based on their hashes in the dictionary. The test should always pass.

I ran this test 1500 times and it always passed.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
