### PR TITLE
Reset unsupported metadata configuration like the doc comment says

### DIFF
--- a/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
+++ b/Tests/SwiftDocCTests/Semantics/SymbolTests.swift
@@ -1315,8 +1315,6 @@ class SymbolTests: XCTestCase {
                 "org.swift.docc.Metadata.InvalidPageColorInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidTitleHeadingInDocumentationComment",
                 "org.swift.docc.Metadata.InvalidRedirectedInDocumentationComment",
-                
-                "org.swift.docc.unresolvedResource", // For the "test" asset that doesn't exist.
             ]
         )
         


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://161219604

## Summary

This updates the `@Metadata` validation for in-source documentation comments to reset unsupported configuration. 
This behavior both matches the validation function's documentation comment and the user-facing diagnostic which says that the "configuration will be ignored".

## Dependencies

None.

## Testing

Add a `@TitleHeading`, `@CallToAction`, or `@PageImage` (inside `@Metadata`) in an in-source documentation comment for any symbol and build documentation. 

- _Same as today_; The warning that these directives are unsupported in in-source comments continues to be raised.
- _New in this PR;_ these directives are _actually_ ignored and have no effect on the rendered page.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Updated ~Added~ tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
