### PR TITLE
fix(static-hosting): preserve custom templates

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/TransformForStaticHostingAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/TransformForStaticHostingAction.swift
@@ -50,6 +50,15 @@ struct TransformForStaticHostingAction: AsyncAction {
     }
     
     private func emit() throws {
+        // Transform the indexHTML before copying template files because in-place
+        // transformations replace the archive's root index.html below.
+        let indexHTMLData = try StaticHostableTransformer.indexHTMLData(
+            in: htmlTemplateDirectory,
+            with: hostingBasePath,
+            fileManager: fileManager,
+            preservingCustomTemplatesFrom: rootURL.appendingPathComponent(HTMLTemplate.indexFileName.rawValue)
+        )
+
         // If the emit is to create the static hostable content outside of the source archive
         // then the output folder needs to be set up and the archive data copied
         // to the new folder.
@@ -84,13 +93,6 @@ struct TransformForStaticHostingAction: AsyncAction {
             try fileManager._copyItem(at: source, to: target)
         }
         
-        // Transform the indexHTML if needed.
-        let indexHTMLData = try StaticHostableTransformer.indexHTMLData(
-            in: htmlTemplateDirectory,
-            with: hostingBasePath,
-            fileManager: FileManager.default
-        )
-
         // Create a StaticHostableTransformer targeted at the archive data folder
         let transformer = StaticHostableTransformer(dataDirectory: rootURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName), fileManager: fileManager, outputURL: outputURL, indexHTMLData: indexHTMLData)
         try transformer.transform()

--- a/Sources/DocCCommandLine/Transformers/StaticHostableTransformer.swift
+++ b/Sources/DocCCommandLine/Transformers/StaticHostableTransformer.swift
@@ -95,7 +95,8 @@ extension StaticHostableTransformer {
     static func indexHTMLData(
         in htmlTemplateDirectory: URL,
         with hostingBasePath: String?,
-        fileManager: any FileManagerProtocol
+        fileManager: any FileManagerProtocol,
+        preservingCustomTemplatesFrom archiveIndexHTML: URL? = nil
     ) throws -> Data {
         let customHostingBasePathProvided = !(hostingBasePath?.isEmpty ?? true)
         
@@ -127,6 +128,30 @@ extension StaticHostableTransformer {
             indexHTML = indexHTML.replacingOccurrences(of: HTMLTemplate.tag.rawValue, with: replacementString)
         }
         
+        if let archiveIndexHTML,
+           let archiveIndexData = try? fileManager.contents(of: archiveIndexHTML),
+           let archiveIndexContents = String(data: archiveIndexData, encoding: .utf8)
+        {
+            let customTemplates = Self.customTemplateHTML(in: archiveIndexContents)
+            if !customTemplates.isEmpty,
+               let bodyTagRange = indexHTML.range(of: "<body[^>]*>", options: .regularExpression)
+            {
+                indexHTML.replaceSubrange(bodyTagRange, with: indexHTML[bodyTagRange] + customTemplates)
+            }
+        }
+
         return Data(indexHTML.utf8)
+    }
+
+    private static func customTemplateHTML(in indexHTML: String) -> String {
+        let pattern = #"<template\s+id="custom-(?:header|footer)"[^>]*>[\s\S]*?</template>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return ""
+        }
+
+        let range = NSRange(indexHTML.startIndex..<indexHTML.endIndex, in: indexHTML)
+        return regex.matches(in: indexHTML, range: range).compactMap { match in
+            Range(match.range, in: indexHTML).map { String(indexHTML[$0]) }
+        }.joined()
     }
 }

--- a/Sources/DocCCommandLine/Transformers/StaticHostableTransformer.swift
+++ b/Sources/DocCCommandLine/Transformers/StaticHostableTransformer.swift
@@ -145,9 +145,7 @@ extension StaticHostableTransformer {
 
     private static func customTemplateHTML(in indexHTML: String) -> String {
         let pattern = #"<template\s+id="custom-(?:header|footer)"[^>]*>[\s\S]*?</template>"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return ""
-        }
+        let regex = try! NSRegularExpression(pattern: pattern)
 
         let range = NSRange(indexHTML.startIndex..<indexHTML.endIndex, in: indexHTML)
         return regex.matches(in: indexHTML, range: range).compactMap { match in

--- a/Tests/DocCCommandLineTests/TransformForStaticHostingActionTests.swift
+++ b/Tests/DocCCommandLineTests/TransformForStaticHostingActionTests.swift
@@ -8,6 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Testing
 import XCTest
 import Foundation
 @testable import SwiftDocC
@@ -174,37 +175,23 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
         }
     }
 
-    func testTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePagesForExternalOutput() async throws {
-        try await assertTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: true)
-    }
+}
 
-    func testTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePagesForInPlaceOutput() async throws {
-        try await assertTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: false)
-    }
-
-    private func assertTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: Bool) async throws {
+struct TransformForStaticHostingActionSwiftTests {
+    @Test(arguments: [true, false])
+    func preservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: Bool) async throws {
         let displayName = "CustomTemplateStaticHosting"
-        let identifier = "com.test.custom-template-static-hosting"
         let headerContent = "<header>custom header</header>"
         let footerContent = "<footer>custom footer</footer>"
         let hostingBasePath = "custom/base/path"
 
         let bundle = Folder(name: "\(displayName).docc", content: [
-            InfoPlist(displayName: displayName, identifier: identifier),
             TextFile(name: "header.html", utf8Content: headerContent),
             TextFile(name: "footer.html", utf8Content: footerContent),
             TextFile(name: "\(displayName).md", utf8Content: """
             # \(displayName)
 
-            @Metadata {
-                @TechnologyRoot
-            }
-
-            An abstract.
-
-            ## Overview
-
-            Some discussion.
+            Some abstract for this page.
             """)
         ])
         let convertTemplate = Folder(name: "convert-template", content: [
@@ -219,15 +206,6 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
             """)
         ])
         let transformTemplate = Folder(name: "transform-template", content: [
-            TextFile(name: "index.html", utf8Content: """
-            <!DOCTYPE html>
-            <html lang="en">
-                <head>
-                    <title>Static Hosting Template</title>
-                </head>
-                <body><script src="/js/app.js"></script></body>
-            </html>
-            """),
             TextFile(name: "index-template.html", utf8Content: """
             <!DOCTYPE html>
             <html lang="en">
@@ -239,31 +217,35 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
             """)
         ])
 
-        let temporaryDirectory = try createTemporaryDirectory()
-        let bundleURL = try bundle.write(inside: temporaryDirectory)
-        let convertTemplateURL = try convertTemplate.write(inside: temporaryDirectory)
-        let transformTemplateURL = try transformTemplate.write(inside: temporaryDirectory)
-        let archiveURL = temporaryDirectory.appendingPathComponent("Result.doccarchive", isDirectory: true)
+        let fileSystem = try TestFileSystem(folders: [
+            bundle,
+            convertTemplate,
+            transformTemplate
+        ])
+        let archiveURL = URL(fileURLWithPath: "/Result.doccarchive", isDirectory: true)
 
-        let convertAction = try ConvertAction(
-            documentationBundleURL: bundleURL,
+        var convertAction = try ConvertAction(
+            documentationBundleURL: URL(fileURLWithPath: "/\(bundle.name)", isDirectory: true),
             outOfProcessResolver: nil,
             analyze: false,
             targetDirectory: archiveURL,
-            htmlTemplateDirectory: convertTemplateURL,
+            htmlTemplateDirectory: URL(fileURLWithPath: "/\(convertTemplate.name)", isDirectory: true),
             emitDigest: false,
             currentPlatforms: nil,
-            temporaryDirectory: try createTemporaryDirectory(),
+            fileManager: fileSystem,
+            temporaryDirectory: fileSystem.uniqueTemporaryDirectory(),
             experimentalEnableCustomTemplates: true
         )
+        convertAction._completelySkipBuildingIndex = true
         _ = try await convertAction.perform(logHandle: .none)
 
-        let outputURL = outputIsExternal ? temporaryDirectory.appendingPathComponent("static-output", isDirectory: true) : nil
+        let outputURL = outputIsExternal ? URL(fileURLWithPath: "/static-output", isDirectory: true) : nil
         let transformAction = try TransformForStaticHostingAction(
             documentationBundleURL: archiveURL,
             outputURL: outputURL,
             hostingBasePath: hostingBasePath,
-            htmlTemplateDirectory: transformTemplateURL
+            htmlTemplateDirectory: URL(fileURLWithPath: "/\(transformTemplate.name)", isDirectory: true),
+            fileManager: fileSystem
         )
         _ = try await transformAction.perform(logHandle: .none)
 
@@ -272,22 +254,22 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
             .appendingPathComponent(NodeURLGenerator.Path.documentationFolderName)
             .appendingPathComponent(displayName.lowercased())
             .appendingPathComponent("index.html")
-        let generatedRouteHTML = try String(contentsOf: generatedRouteIndexHTML)
+        let generatedRouteHTML = try String(decoding: fileSystem.contents(of: generatedRouteIndexHTML), as: UTF8.self)
 
-        XCTAssert(
+        #expect(
             generatedRouteHTML.contains(#"<template id="custom-header">\#(headerContent)</template>"#),
             "Generated route page didn't preserve the custom header template from the archive's root index.html."
         )
-        XCTAssert(
+        #expect(
             generatedRouteHTML.contains(#"<template id="custom-footer">\#(footerContent)</template>"#),
             "Generated route page didn't preserve the custom footer template from the archive's root index.html."
         )
-        XCTAssert(
+        #expect(
             generatedRouteHTML.contains(#"src="/\#(hostingBasePath)/js/app.js""#),
             "Generated route page didn't apply the new hosting base path."
         )
-        XCTAssertFalse(
-            generatedRouteHTML.contains(HTMLTemplate.tag.rawValue),
+        #expect(
+            generatedRouteHTML.contains(HTMLTemplate.tag.rawValue) == false,
             "Generated route page still contains the unresolved hosting base path placeholder."
         )
     }

--- a/Tests/DocCCommandLineTests/TransformForStaticHostingActionTests.swift
+++ b/Tests/DocCCommandLineTests/TransformForStaticHostingActionTests.swift
@@ -173,5 +173,122 @@ class TransformForStaticHostingActionTests: StaticHostingBaseTests {
             }
         }
     }
-}
 
+    func testTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePagesForExternalOutput() async throws {
+        try await assertTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: true)
+    }
+
+    func testTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePagesForInPlaceOutput() async throws {
+        try await assertTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: false)
+    }
+
+    private func assertTransformForStaticHostingPreservesCustomTemplatesInGeneratedRoutePages(outputIsExternal: Bool) async throws {
+        let displayName = "CustomTemplateStaticHosting"
+        let identifier = "com.test.custom-template-static-hosting"
+        let headerContent = "<header>custom header</header>"
+        let footerContent = "<footer>custom footer</footer>"
+        let hostingBasePath = "custom/base/path"
+
+        let bundle = Folder(name: "\(displayName).docc", content: [
+            InfoPlist(displayName: displayName, identifier: identifier),
+            TextFile(name: "header.html", utf8Content: headerContent),
+            TextFile(name: "footer.html", utf8Content: footerContent),
+            TextFile(name: "\(displayName).md", utf8Content: """
+            # \(displayName)
+
+            @Metadata {
+                @TechnologyRoot
+            }
+
+            An abstract.
+
+            ## Overview
+
+            Some discussion.
+            """)
+        ])
+        let convertTemplate = Folder(name: "convert-template", content: [
+            TextFile(name: "index.html", utf8Content: """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Original Template</title>
+                </head>
+                <body><main></main></body>
+            </html>
+            """)
+        ])
+        let transformTemplate = Folder(name: "transform-template", content: [
+            TextFile(name: "index.html", utf8Content: """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Static Hosting Template</title>
+                </head>
+                <body><script src="/js/app.js"></script></body>
+            </html>
+            """),
+            TextFile(name: "index-template.html", utf8Content: """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Static Hosting Template</title>
+                </head>
+                <body><script src="{{BASE_PATH}}/js/app.js"></script></body>
+            </html>
+            """)
+        ])
+
+        let temporaryDirectory = try createTemporaryDirectory()
+        let bundleURL = try bundle.write(inside: temporaryDirectory)
+        let convertTemplateURL = try convertTemplate.write(inside: temporaryDirectory)
+        let transformTemplateURL = try transformTemplate.write(inside: temporaryDirectory)
+        let archiveURL = temporaryDirectory.appendingPathComponent("Result.doccarchive", isDirectory: true)
+
+        let convertAction = try ConvertAction(
+            documentationBundleURL: bundleURL,
+            outOfProcessResolver: nil,
+            analyze: false,
+            targetDirectory: archiveURL,
+            htmlTemplateDirectory: convertTemplateURL,
+            emitDigest: false,
+            currentPlatforms: nil,
+            temporaryDirectory: try createTemporaryDirectory(),
+            experimentalEnableCustomTemplates: true
+        )
+        _ = try await convertAction.perform(logHandle: .none)
+
+        let outputURL = outputIsExternal ? temporaryDirectory.appendingPathComponent("static-output", isDirectory: true) : nil
+        let transformAction = try TransformForStaticHostingAction(
+            documentationBundleURL: archiveURL,
+            outputURL: outputURL,
+            hostingBasePath: hostingBasePath,
+            htmlTemplateDirectory: transformTemplateURL
+        )
+        _ = try await transformAction.perform(logHandle: .none)
+
+        let transformedArchiveURL = outputURL ?? archiveURL
+        let generatedRouteIndexHTML = transformedArchiveURL
+            .appendingPathComponent(NodeURLGenerator.Path.documentationFolderName)
+            .appendingPathComponent(displayName.lowercased())
+            .appendingPathComponent("index.html")
+        let generatedRouteHTML = try String(contentsOf: generatedRouteIndexHTML)
+
+        XCTAssert(
+            generatedRouteHTML.contains(#"<template id="custom-header">\#(headerContent)</template>"#),
+            "Generated route page didn't preserve the custom header template from the archive's root index.html."
+        )
+        XCTAssert(
+            generatedRouteHTML.contains(#"<template id="custom-footer">\#(footerContent)</template>"#),
+            "Generated route page didn't preserve the custom footer template from the archive's root index.html."
+        )
+        XCTAssert(
+            generatedRouteHTML.contains(#"src="/\#(hostingBasePath)/js/app.js""#),
+            "Generated route page didn't apply the new hosting base path."
+        )
+        XCTAssertFalse(
+            generatedRouteHTML.contains(HTMLTemplate.tag.rawValue),
+            "Generated route page still contains the unresolved hosting base path placeholder."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1532.

This preserves custom header and footer templates when `docc process-archive transform-for-static-hosting` regenerates route stub pages.

When an archive already contains custom templates in its root `index.html`, transforming it with a hosting base path previously generated bare per-route `index.html` files and dropped the custom template HTML. This now carries the archive's `custom-header` and `custom-footer` templates into the generated route pages while still applying the requested hosting base path.

## Changes

- Reads the archive root `index.html` before in-place template copying can replace it.
- Preserves `custom-header` and `custom-footer` template blocks in generated static-hosting route pages.
- Uses the injected file manager consistently when building transformed index HTML.
- Adds regression coverage for both external-output and in-place transform modes.

## Alternatives considered

- Leaving route stubs bare was rejected because it loses archive customizations.
- Copying the archive root `index.html` verbatim was rejected because route stubs still need the newly transformed hosting base path.

## Notes

The regression tests remain in the existing XCTest-based static-hosting test file to match the surrounding test suite and reuse its temporary-directory helpers.

## Screenshots

Not applicable; no UI changes.

## Testing

- `swift test --filter TransformForStaticHostingActionTests`
- `swift test --filter StaticHostableTransformerTests`
