### PR TITLE
Emit remote source links for articles and tutorials

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNode/RenderMetadata.swift
@@ -157,13 +157,15 @@ public struct RenderMetadata: VariantContainer {
     /// The variants for the source file URI of a page.
     public var sourceFileURIVariants: VariantCollection<String?> = .init(defaultValue: nil)
     
-    /// The remote location where the source declaration of the topic can be viewed.
+    /// The remote location where the page's source content can be viewed, hosted by a source code service.
+    ///
+    /// For symbols, this points at the symbol's declaration. For articles and tutorial content, this points at the page's source file.
     public var remoteSource: RemoteSource? {
         get { getVariantDefaultValue(keyPath: \.remoteSourceVariants) }
         set { setVariantDefaultValue(newValue, keyPath: \.remoteSourceVariants) }
     }
-    
-    /// The variants for the topic's remote source.
+
+    /// The variants for the page's remote source.
     public var remoteSourceVariants: VariantCollection<RemoteSource?> = .init(defaultValue: nil)
     
     /// Any tags assigned to the node.
@@ -195,15 +197,15 @@ extension RenderMetadata: Codable {
         public let relatedModules: [String]?
     }
     
-    /// Describes the location of the topic's source code, hosted remotely by a source service.
+    /// Describes the location of a page's source content, hosted remotely by a source service.
     public struct RemoteSource: Codable, Equatable {
-        /// The name of the file where the topic is declared.
+        /// The name of the source file.
         public var fileName: String
-        
-        /// The location of the topic's source code, hosted by a source service.
+
+        /// The location of the source content, hosted by a source service.
         public var url: URL
-        
-        /// Creates a topic's source given its source code's file name and URL.
+
+        /// Creates a page's remote source given its source file's name and URL.
         public init(fileName: String, url: URL) {
             self.fileName = fileName
             self.url = url

--- a/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderNodeTranslator.swift
@@ -178,7 +178,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         let documentationNode = try! context.entity(with: identifier)
         node.variants = variants(for: documentationNode)
-                
+        node.metadata.remoteSource = remoteSource(for: documentationNode)
+
         var intro = visitIntro(tutorial.intro) as! IntroRenderSection
         intro.estimatedTimeInMinutes = tutorial.durationMinutes
         
@@ -412,6 +413,7 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         let documentationNode = try! context.entity(with: identifier)
         node.variants = variants(for: documentationNode)
+        node.metadata.remoteSource = remoteSource(for: documentationNode)
 
         var intro = visitIntro(tableOfContents.intro) as! IntroRenderSection
         if let firstTutorial = self.firstTutorial(ofTechnology: identifier) {
@@ -621,6 +623,19 @@ public struct RenderNodeTranslator: SemanticVisitor {
         return section
     }
     
+    /// Computes the remote source location for a non-symbol page (article or tutorial content file),
+    /// based on the on-disk location of its markup and the configured source repository.
+    private func remoteSource(for documentationNode: DocumentationNode) -> RenderMetadata.RemoteSource? {
+        guard let sourceRepository,
+              let sourceURL = documentationNode.markup.range?.source,
+              let url = sourceRepository.format(sourceFileURL: sourceURL)
+        else {
+            return nil
+        }
+
+        return RenderMetadata.RemoteSource(fileName: sourceURL.lastPathComponent, url: url)
+    }
+
     public mutating func visitArticle(_ article: Article) -> (any RenderTree)? {
         var node = RenderNode(identifier: identifier, kind: .article)
         // Contains symbol references declared in the Topics section.
@@ -647,7 +662,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
         }
         
         let documentationNode = try! context.entity(with: identifier)
-        
+        node.metadata.remoteSource = remoteSource(for: documentationNode)
+
         var hierarchyTranslator = RenderHierarchyTranslator(context: context)
         let hierarchyVariants = hierarchyTranslator.visitArticle(identifier)
         collectedTopicReferences.append(contentsOf: hierarchyTranslator.collectedTopicReferences)
@@ -947,7 +963,8 @@ public struct RenderNodeTranslator: SemanticVisitor {
         
         let documentationNode = try! context.entity(with: identifier)
         node.variants = variants(for: documentationNode)
-        
+        node.metadata.remoteSource = remoteSource(for: documentationNode)
+
         collectedTopicReferences.append(contentsOf: hierarchyTranslator.collectedTopicReferences)
         
         var intro: IntroRenderSection

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
@@ -35,26 +35,10 @@ struct SemaToRenderNodeSourceRepositoryTests {
 
     // MARK: - Symbols
 
-    private func makeSymbolCatalog() -> Folder {
-        Folder(name: "unit-test.docc") {
-            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "ModuleName", symbols: [
-                makeSymbol(
-                    id: "some-symbol-id",
-                    kind: .class,
-                    pathComponents: ["MyStruct"],
-                    location: (
-                        position: .init(line: 9, character: 14),
-                        url: URL(fileURLWithPath: "/path/to/checkout/SourceLocations/MyStruct.swift")
-                    )
-                )
-            ]))
-        }
-    }
-
     @Test
     func doesNotEmitsSourceRepositoryInformationWhenNoSourceIsGiven() async throws {
-        let context = try await load(catalog: makeSymbolCatalog())
-        let node = try #require(context.documentationCache["some-symbol-id"])
+        let context = try await loadFromDisk(catalogName: "SourceLocations")
+        let node = try #require(context.documentationCache["s:32SourceLocations8MyStructV"])
 
         let renderNode = try renderNode(for: node, in: context, sourceRepository: nil)
 
@@ -63,8 +47,8 @@ struct SemaToRenderNodeSourceRepositoryTests {
 
     @Test
     func emitsSourceRepositoryInformationForSymbolsWhenPresent() async throws {
-        let context = try await load(catalog: makeSymbolCatalog())
-        let node = try #require(context.documentationCache["some-symbol-id"])
+        let context = try await loadFromDisk(catalogName: "SourceLocations")
+        let node = try #require(context.documentationCache["s:32SourceLocations8MyStructV"])
 
         let renderNode = try renderNode(
             for: node,

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
@@ -15,8 +15,8 @@ import Testing
 import DocCTestUtilities
 
 struct SemaToRenderNodeSourceRepositoryTests {
-    private func node(in context: DocumentationContext, ofKind kind: DocumentationNode.Kind) throws -> DocumentationNode {
-        let reference = try #require(context.knownPages.first { (try? context.entity(with: $0))?.kind == kind })
+    private func node(in context: DocumentationContext, withLastPathComponent lastPathComponent: String) throws -> DocumentationNode {
+        let reference = try #require(context.knownPages.first(where: { $0.lastPathComponent == lastPathComponent }))
         return try context.entity(with: reference)
     }
 
@@ -115,7 +115,7 @@ struct SemaToRenderNodeSourceRepositoryTests {
     @Test
     func emitsRemoteSourceForArticleWhenSourceRepositoryIsConfigured() async throws {
         let context = try await load(catalog: makeArticleCatalog())
-        let article = try node(in: context, ofKind: .article)
+        let article = try node(in: context, withLastPathComponent: "Article")
 
         let renderNode = try renderNode(
             for: article,
@@ -132,7 +132,7 @@ struct SemaToRenderNodeSourceRepositoryTests {
     @Test
     func doesNotEmitRemoteSourceForArticleWhenNoSourceRepositoryIsConfigured() async throws {
         let context = try await load(catalog: makeArticleCatalog())
-        let article = try node(in: context, ofKind: .article)
+        let article = try node(in: context, withLastPathComponent: "Article")
 
         let renderNode = try renderNode(for: article, in: context, sourceRepository: nil)
 
@@ -141,9 +141,8 @@ struct SemaToRenderNodeSourceRepositoryTests {
 
     // MARK: - Tutorials
 
-    @Test
-    func emitsRemoteSourceForTutorialContent() async throws {
-        let catalog = Folder(name: "unit-test.docc") {
+    private func makeTutorialCatalog() -> Folder {
+        Folder(name: "unit-test.docc") {
             TextFile(name: "TableOfContents.tutorial", utf8Content: """
             @Tutorials(name: "TechnologyX") {
                @Intro(title: "Technology X") {
@@ -196,30 +195,62 @@ struct SemaToRenderNodeSourceRepositoryTests {
             DataFile(name: "figure1.png", data: Data())
             DataFile(name: "step.png", data: Data())
         }
-        let context = try await load(catalog: catalog)
+    }
+
+    private func loadTutorialContext() async throws -> DocumentationContext {
+        let context = try await load(catalog: makeTutorialCatalog())
         #expect(context.diagnostics.isEmpty, "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        return context
+    }
 
-        let sourceRepository = SourceRepository.github(checkoutPath: "/", sourceServiceBaseURL: URL(string: "https://example.com/repo")!)
+    @Test
+    func emitsRemoteSourceForTutorialTableOfContents() async throws {
+        let context = try await loadTutorialContext()
+        let tableOfContents = try node(in: context, withLastPathComponent: "TableOfContents")
 
-        let tableOfContents = try node(in: context, ofKind: .tutorialTableOfContents)
-        let tableOfContentsRenderNode = try renderNode(for: tableOfContents, in: context, sourceRepository: sourceRepository)
-        #expect(tableOfContentsRenderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+        let renderNode = try renderNode(
+            for: tableOfContents,
+            in: context,
+            sourceRepository: .github(checkoutPath: "/", sourceServiceBaseURL: URL(string: "https://example.com/repo")!)
+        )
+
+        #expect(renderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
             fileName: "TableOfContents.tutorial",
             url: URL(string: "https://example.com/repo/unit-test.docc/TableOfContents.tutorial")!
         ))
         // The link points at the top of the page; there's no single meaningful line to anchor to.
-        #expect(tableOfContentsRenderNode.metadata.remoteSource?.url.fragment == nil)
+        #expect(renderNode.metadata.remoteSource?.url.fragment == nil)
+    }
 
-        let tutorial = try node(in: context, ofKind: .tutorial)
-        let tutorialRenderNode = try renderNode(for: tutorial, in: context, sourceRepository: sourceRepository)
-        #expect(tutorialRenderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+    @Test
+    func emitsRemoteSourceForTutorial() async throws {
+        let context = try await loadTutorialContext()
+        let tutorial = try node(in: context, withLastPathComponent: "BasicTutorial")
+
+        let renderNode = try renderNode(
+            for: tutorial,
+            in: context,
+            sourceRepository: .github(checkoutPath: "/", sourceServiceBaseURL: URL(string: "https://example.com/repo")!)
+        )
+
+        #expect(renderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
             fileName: "BasicTutorial.tutorial",
             url: URL(string: "https://example.com/repo/unit-test.docc/BasicTutorial.tutorial")!
         ))
+    }
 
-        let tutorialArticle = try node(in: context, ofKind: .tutorialArticle)
-        let tutorialArticleRenderNode = try renderNode(for: tutorialArticle, in: context, sourceRepository: sourceRepository)
-        #expect(tutorialArticleRenderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+    @Test
+    func emitsRemoteSourceForTutorialArticle() async throws {
+        let context = try await loadTutorialContext()
+        let tutorialArticle = try node(in: context, withLastPathComponent: "TutorialArticle")
+
+        let renderNode = try renderNode(
+            for: tutorialArticle,
+            in: context,
+            sourceRepository: .github(checkoutPath: "/", sourceServiceBaseURL: URL(string: "https://example.com/repo")!)
+        )
+
+        #expect(renderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
             fileName: "TutorialArticle.tutorial",
             url: URL(string: "https://example.com/repo/unit-test.docc/TutorialArticle.tutorial")!
         ))

--- a/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
+++ b/Tests/SwiftDocCTests/Model/SemaToRenderNodeSourceRepositoryTests.swift
@@ -11,32 +11,233 @@
 import Foundation
 @testable import SwiftDocC
 import SymbolKit
-import XCTest
+import Testing
+import DocCTestUtilities
 
-class SemaToRenderNodeSourceRepositoryTests: XCTestCase {
-    func testDoesNotEmitsSourceRepositoryInformationWhenNoSourceIsGiven() async throws {
-        let outputConsumer = try await renderNodeConsumer(
-            for: "SourceLocations",
-            sourceRepository: nil
-        )
-        
-        XCTAssertNil(try outputConsumer.renderNode(withTitle: "MyStruct").metadata.remoteSource)
+struct SemaToRenderNodeSourceRepositoryTests {
+    private func node(in context: DocumentationContext, ofKind kind: DocumentationNode.Kind) throws -> DocumentationNode {
+        let reference = try #require(context.knownPages.first { (try? context.entity(with: $0))?.kind == kind })
+        return try context.entity(with: reference)
     }
-    
-    func testEmitsSourceRepositoryInformationForSymbolsWhenPresent() async throws {
-        let outputConsumer = try await renderNodeConsumer(
-            for: "SourceLocations",
-            sourceRepository: SourceRepository.github(
+
+    private func renderNode(
+        for documentationNode: DocumentationNode,
+        in context: DocumentationContext,
+        sourceRepository: SourceRepository?
+    ) throws -> RenderNode {
+        let converter = DocumentationContextConverter(
+            context: context,
+            renderContext: .init(documentationContext: context),
+            sourceRepository: sourceRepository
+        )
+        return try #require(converter.renderNode(for: documentationNode))
+    }
+
+    // MARK: - Symbols
+
+    private func makeSymbolCatalog() -> Folder {
+        Folder(name: "unit-test.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                makeSymbol(
+                    id: "some-symbol-id",
+                    kind: .class,
+                    pathComponents: ["MyStruct"],
+                    location: (
+                        position: .init(line: 9, character: 14),
+                        url: URL(fileURLWithPath: "/path/to/checkout/SourceLocations/MyStruct.swift")
+                    )
+                )
+            ]))
+        }
+    }
+
+    @Test
+    func doesNotEmitsSourceRepositoryInformationWhenNoSourceIsGiven() async throws {
+        let context = try await load(catalog: makeSymbolCatalog())
+        let node = try #require(context.documentationCache["some-symbol-id"])
+
+        let renderNode = try renderNode(for: node, in: context, sourceRepository: nil)
+
+        #expect(renderNode.metadata.remoteSource == nil)
+    }
+
+    @Test
+    func emitsSourceRepositoryInformationForSymbolsWhenPresent() async throws {
+        let context = try await load(catalog: makeSymbolCatalog())
+        let node = try #require(context.documentationCache["some-symbol-id"])
+
+        let renderNode = try renderNode(
+            for: node,
+            in: context,
+            sourceRepository: .github(
                 checkoutPath: "/path/to/checkout",
                 sourceServiceBaseURL: URL(string: "https://example.com/my-repo")!
             )
         )
-        XCTAssertEqual(
-            try outputConsumer.renderNode(withTitle: "MyStruct").metadata.remoteSource,
-            RenderMetadata.RemoteSource(
-                fileName: "MyStruct.swift",
-                url: URL(string: "https://example.com/my-repo/SourceLocations/MyStruct.swift#L10")!
+
+        #expect(renderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+            fileName: "MyStruct.swift",
+            url: URL(string: "https://example.com/my-repo/SourceLocations/MyStruct.swift#L10")!
+        ))
+    }
+
+    @Test
+    func doesNotEmitRemoteSourceForDocumentationExtensionFiles() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
+            ]))
+
+            TextFile(name: "SomeClass.md", utf8Content: """
+            # ``SomeClass``
+
+            An extension to the in-source documentation.
+            """)
+        }
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        let symbol = try #require(context.documentationCache["some-symbol-id"])
+
+        let renderNode = try renderNode(
+            for: symbol,
+            in: context,
+            sourceRepository: .github(
+                checkoutPath: "/Users/username/path/to",
+                sourceServiceBaseURL: URL(string: "https://example.com/repo")!
             )
         )
+
+        #expect(renderNode.kind == .symbol)
+        // The symbol's remote source still comes from its symbol graph location, not the doc extension markdown file.
+        #expect(renderNode.metadata.remoteSource?.fileName == "SomeFile.swift")
+    }
+
+    // MARK: - Articles
+
+    private func makeArticleCatalog() -> Folder {
+        Folder(name: "unit-test.docc") {
+            JSONFile(symbolGraph: makeSymbolGraph(moduleName: "ModuleName", symbols: [
+                makeSymbol(id: "some-symbol-id", kind: .class, pathComponents: ["SomeClass"])
+            ]))
+
+            TextFile(name: "Article.md", utf8Content: """
+            # Some Article
+
+            An abstract for the article.
+            """)
+        }
+    }
+
+    @Test
+    func emitsRemoteSourceForArticleWhenSourceRepositoryIsConfigured() async throws {
+        let context = try await load(catalog: makeArticleCatalog())
+        let article = try node(in: context, ofKind: .article)
+
+        let renderNode = try renderNode(
+            for: article,
+            in: context,
+            sourceRepository: .github(checkoutPath: "/", sourceServiceBaseURL: URL(string: "https://example.com/repo")!)
+        )
+
+        #expect(renderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+            fileName: "Article.md",
+            url: URL(string: "https://example.com/repo/unit-test.docc/Article.md")!
+        ))
+    }
+
+    @Test
+    func doesNotEmitRemoteSourceForArticleWhenNoSourceRepositoryIsConfigured() async throws {
+        let context = try await load(catalog: makeArticleCatalog())
+        let article = try node(in: context, ofKind: .article)
+
+        let renderNode = try renderNode(for: article, in: context, sourceRepository: nil)
+
+        #expect(renderNode.metadata.remoteSource == nil)
+    }
+
+    // MARK: - Tutorials
+
+    @Test
+    func emitsRemoteSourceForTutorialContent() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            TextFile(name: "TableOfContents.tutorial", utf8Content: """
+            @Tutorials(name: "TechnologyX") {
+               @Intro(title: "Technology X") {
+                  You'll learn all about Technology X.
+               }
+
+               @Chapter(name: "Chapter 1") {
+                  In this chapter, you'll follow the tutorial and the tutorial article below.
+
+                  @Image(source: figure1.png, alt: "Figure 1")
+
+                  @TutorialReference(tutorial: "doc:BasicTutorial")
+                  @TutorialReference(tutorial: "doc:TutorialArticle")
+               }
+            }
+            """)
+
+            TextFile(name: "BasicTutorial.tutorial", utf8Content: """
+            @Tutorial(time: 20) {
+               @Intro(title: "Basic Tutorial") {
+                  This is the tutorial abstract.
+               }
+
+               @Section(title: "Create a New Project") {
+                  @ContentAndMedia {
+                     This is a section.
+                  }
+
+                  @Steps {
+                     @Step {
+                        This is a step.
+
+                        @Image(source: step.png, alt: "Step image")
+                     }
+                  }
+               }
+            }
+            """)
+
+            TextFile(name: "TutorialArticle.tutorial", utf8Content: """
+            @Article(time: 20) {
+               @Intro(title: "A Tutorial Article") {
+                  This is an abstract.
+               }
+
+               Some content.
+            }
+            """)
+
+            DataFile(name: "figure1.png", data: Data())
+            DataFile(name: "step.png", data: Data())
+        }
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected problems: \(context.diagnostics.map(\.summary))")
+
+        let sourceRepository = SourceRepository.github(checkoutPath: "/", sourceServiceBaseURL: URL(string: "https://example.com/repo")!)
+
+        let tableOfContents = try node(in: context, ofKind: .tutorialTableOfContents)
+        let tableOfContentsRenderNode = try renderNode(for: tableOfContents, in: context, sourceRepository: sourceRepository)
+        #expect(tableOfContentsRenderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+            fileName: "TableOfContents.tutorial",
+            url: URL(string: "https://example.com/repo/unit-test.docc/TableOfContents.tutorial")!
+        ))
+        // The link points at the top of the page; there's no single meaningful line to anchor to.
+        #expect(tableOfContentsRenderNode.metadata.remoteSource?.url.fragment == nil)
+
+        let tutorial = try node(in: context, ofKind: .tutorial)
+        let tutorialRenderNode = try renderNode(for: tutorial, in: context, sourceRepository: sourceRepository)
+        #expect(tutorialRenderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+            fileName: "BasicTutorial.tutorial",
+            url: URL(string: "https://example.com/repo/unit-test.docc/BasicTutorial.tutorial")!
+        ))
+
+        let tutorialArticle = try node(in: context, ofKind: .tutorialArticle)
+        let tutorialArticleRenderNode = try renderNode(for: tutorialArticle, in: context, sourceRepository: sourceRepository)
+        #expect(tutorialArticleRenderNode.metadata.remoteSource == RenderMetadata.RemoteSource(
+            fileName: "TutorialArticle.tutorial",
+            url: URL(string: "https://example.com/repo/unit-test.docc/TutorialArticle.tutorial")!
+        ))
     }
 }


### PR DESCRIPTION
<!--
If you are opening a pull request against a release branch, see
https://www.swift.org/contributing#release-branch-pull-requests
-->

Bug/issue #, if applicable: https://github.com/swiftlang/swift-docc/issues/1435

## Summary

Adds automatic "edit this page" / remote source links for articles and tutorial content, extending a mechanism that previously only applied to symbols.

When `docc convert` is run with `--source-service`/`--source-service-base-url`/`--checkout-path`, DocC already computes a `RenderMetadata.remoteSource` link for symbols, pointing back at their declaration in the configured source repository. Articles, tutorials, tutorial articles, and tutorial tables of contents got no such link, so a reader had no way to jump from one of those pages back to its source file to suggest a fix. This PR closes that gap.

This change is intentionally limited to **articles and tutorial content**, driven entirely by the existing CLI flags (no new directive or per-article opt-in). It reuses the existing, already-optional `RenderMetadata.remoteSource` field/URL pattern rather than introducing a new "edit"-specific URL scheme, so it's not a Render-JSON-breaking change. The existing, already-shipped symbol `remoteSource` logic is untouched. Rendering the link in the UI is the responsibility of [swift-docc-render](https://github.com/swiftlang/swift-docc-render) — this PR only emits the Render JSON metadata that already exists for this purpose.

### Implementation Overview

**Render Layer Changes (`RenderNodeTranslator.swift`):**

- Adds a `remoteSource(for:)` helper that resolves a non-symbol page's on-disk markup location
  (`DocumentationNode.markup.range?.source`) through the existing `SourceRepository.format(sourceFileURL:)`,
  mirroring how symbols already compute their `remoteSource`
- Wires the helper into `visitArticle`, `visitTutorial`, `visitTutorialArticle`, and `visitTutorialTableOfContents`
- Omits a line-number anchor, since a whole article/tutorial page has no single meaningful declaration
  line — the link points at the top of the file

**Documentation Updates (`RenderMetadata.swift`):**

- Rewords the `remoteSource`/`remoteSourceVariants`/`RemoteSource` doc comments so they no longer
  read as symbol-only, now that they apply to pages generally

**Test Coverage (`SemaToRenderNodeSourceRepositoryTests.swift`):**

- Migrates the suite from `XCTestCase` to Swift Testing
- Keeps the original symbol coverage backed by the existing on-disk `SourceLocations.docc` fixture,
  unchanged in intent
- Adds coverage for:
  - Article gets `remoteSource` when a source repository is configured
  - Article gets no `remoteSource` when no source repository is configured
  - Tutorial, tutorial article, and tutorial table-of-contents pages all get `remoteSource`
  - Documentation-extension markdown files do **not** get a `remoteSource` via the new path — the
    pre-existing symbol-graph-based `remoteSource` for the symbol they extend is unaffected

## Dependencies

None required to merge. This PR only changes `SwiftDocC`'s Render JSON output (an existing, already-optional field populated for more page kinds); it doesn't require any corresponding swift-docc-render change to merge safely, since unrecognized renderer behavior simply means the link isn't shown yet.

Note: there's a pending discussion about the corresponding swift-docc-render changes needed to actually display this link in the UI. That discussion may still influence the shape of the Render JSON this PR emits, so it's worth confirming alignment there before this is considered final.

## Testing

Steps:

1. Convert the `docc` target's own documentation catalog (`Sources/docc/DocCDocumentation.docc`) with source-repository flags and inspect an article's `metadata.remoteSource` in the output Render JSON:

   ```bash
   export DOCC_JSON_PRETTYPRINT="YES"

   swift run docc convert Sources/docc/DocCDocumentation.docc \
     --source-service github \
     --source-service-base-url https://github.com/swiftlang/swift-docc/blob/main \
     --checkout-path "$(pwd)" \
     --output-path ./docs

   cat ./docs/data/documentation/docc/adding-images.json | grep -A4 remoteSource
   ```

   The article's `metadata.remoteSource` should point at `https://github.com/swiftlang/swift-docc/blob/main/Sources/docc/DocCDocumentation.docc/adding-images.md`.

2. Confirm the pre-existing symbol behavior is unaffected by converting any catalog with the same flags and checking that a symbol page's `metadata.remoteSource` still points at its `.swift` declaration file, not a markdown file.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
