### PR TITLE
Split input and output `FileManagerProtocol`s

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/Action+MoveOutput.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Action+MoveOutput.swift
@@ -19,17 +19,18 @@ extension AsyncAction {
     ///   - template: An optional template for the new directory.
     ///   - fileManager: The file manager to create the new directory.
     /// - Returns: The URL of the new unique directory.
-    static func createUniqueDirectory(inside container: URL, template: URL?, fileManager: any FileManagerProtocol) throws -> URL {
+    static func createUniqueDirectory(inside container: URL, template: URL?, fileManager: any FileManagerProtocol, outputFileManager: (any FileManagerProtocol)? = nil) throws -> URL {
         let targetURL = container.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
+        let outputFileManager = outputFileManager ?? fileManager
 
         if let template {
             // If a template directory has been provided, create the temporary build folder with its contents
             // Ensure that the container exists
-            try? fileManager.createDirectory(at: targetURL.deletingLastPathComponent(), withIntermediateDirectories: false, attributes: nil)
-            try fileManager._copyItem(at: template, to: targetURL)
+            try? outputFileManager.createDirectory(at: targetURL.deletingLastPathComponent(), withIntermediateDirectories: false, attributes: nil)
+            try fileManager.copyItem(at: template, to: targetURL, on: outputFileManager)
         } else {
             // Otherwise, create an empty directory
-            try fileManager.createDirectory(at: targetURL, withIntermediateDirectories: true, attributes: nil)
+            try outputFileManager.createDirectory(at: targetURL, withIntermediateDirectories: true, attributes: nil)
         }
         return targetURL
     }
@@ -39,16 +40,18 @@ extension AsyncAction {
     ///   - source: The file or directory to move.
     ///   - destination: The new location for the file or directory.
     ///   - fileManager: The file manager to move the file or directory.
-    static func moveOutput(from source: URL, to destination: URL, fileManager: any FileManagerProtocol) throws {
+    static func moveOutput(from source: URL, to destination: URL, fileManager: any FileManagerProtocol, outputFileManager: (any FileManagerProtocol)? = nil) throws {
+        let outputFileManager = outputFileManager ?? fileManager
+
         // We only need to move output if it exists
         guard fileManager.fileExists(atPath: source.path) else { return }
         
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
+        if outputFileManager.fileExists(atPath: destination.path) {
+            try outputFileManager.removeItem(at: destination)
         }
         
-        try ensureThatParentFolderExist(for: destination, fileManager: fileManager)
-        try fileManager.moveItem(at: source, to: destination)
+        try ensureThatParentFolderExist(for: destination, fileManager: outputFileManager)
+        try fileManager.moveItem(at: source, to: destination, on: outputFileManager)
     }
     
     private static func ensureThatParentFolderExist(for location: URL, fileManager: any FileManagerProtocol) throws {

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -43,6 +43,8 @@ public struct ConvertAction: AsyncAction {
     let sourceRepository: SourceRepository?
     
     private var fileManager: any FileManagerProtocol
+    private var outputFileManager: any FileManagerProtocol
+
     private let temporaryDirectory: URL
     
     private let diagnosticWriterOptions: (formatting: DiagnosticFormattingOptions, baseURL: URL)
@@ -94,6 +96,7 @@ public struct ConvertAction: AsyncAction {
         fileManager: any FileManagerProtocol = FileManager.default,
         temporaryDirectory: URL,
         outputFormat: Docc.Convert.OutputFormat = .json,
+        outputFileManager: (any FileManagerProtocol)? = nil,
         documentationCoverageOptions: DocumentationCoverageOptions = .noCoverage,
         bundleDiscoveryOptions: BundleDiscoveryOptions = .init(),
         diagnosticLevel: String? = nil,
@@ -121,6 +124,7 @@ public struct ConvertAction: AsyncAction {
         self.outputFormat = outputFormat
         self.buildLMDBIndex = buildIndex
         self.fileManager = fileManager
+        self.outputFileManager = outputFileManager ?? fileManager
         self.temporaryDirectory = temporaryDirectory
         self.documentationCoverageOptions = documentationCoverageOptions
         self.transformForStaticHosting = transformForStaticHosting
@@ -213,11 +217,6 @@ public struct ConvertAction: AsyncAction {
     /// A block of extra work that tests perform to affect the time it takes to convert documentation
     var _extraTestWork: (() async -> Void)?
 
-    /// The `Indexer` type doesn't work with virtual file systems.
-    ///
-    /// Tests that don't verify the contents of the navigator index can set this to `true` so that they can use a virtual, in-memory, file system.
-    var _completelySkipBuildingIndex: Bool = false
-    
     /// Converts each eligible file from the source documentation bundle,
     /// saves the results in the given output alongside the template files.
     public func perform(logHandle: inout LogHandle) async throws -> ActionResult {
@@ -226,25 +225,21 @@ public struct ConvertAction: AsyncAction {
     
     func perform(logHandle: inout LogHandle) async throws -> (ActionResult, DocumentationContext) {
         // FIXME: Use `defer` again when the asynchronous defer-statement miscompilation (rdar://137774949) is fixed.
-        let temporaryFolder: URL
-        switch outputFormat {
-        case .json:
-            temporaryFolder = try createTempFolder(with: htmlTemplateDirectory)
-        case .experimentalHTML:
-            temporaryFolder = try createTempFolder(with: nil)
-            for file in DocCHTML.StaticResources.allFiles {
-                try fileManager.createFile(at: temporaryFolder.appendingPathComponent(file.filename), contents: file.data)
-            }
-        }
+        let temporaryFolder = try Self.createUniqueDirectory(
+            inside: temporaryDirectory,
+            template: nil,
+            fileManager: outputFileManager
+        )
         
         do {
             let result = try await _perform(logHandle: &logHandle, temporaryFolder: temporaryFolder)
+
             diagnosticEngine.flush()
-            try? fileManager.removeItem(at: temporaryFolder)
+            try? outputFileManager.removeItem(at: temporaryFolder)
             return result
         } catch {
             diagnosticEngine.flush()
-            try? fileManager.removeItem(at: temporaryFolder)
+            try? outputFileManager.removeItem(at: temporaryFolder)
             throw error
         }
     }
@@ -255,6 +250,25 @@ public struct ConvertAction: AsyncAction {
             signposter.endInterval("Convert", convertSignpostHandle)
         }
         
+        let generateInFolder: URL = temporaryFolder
+        let generateInFileManager = outputFileManager
+
+        // Populate the directory with the initial files
+        switch outputFormat {
+            case .json:
+                if let htmlTemplateDirectory {
+                    try fileManager.copyItem(
+                        at: htmlTemplateDirectory,
+                        to: generateInFolder,
+                        on: generateInFileManager
+                    )
+                }
+            case .experimentalHTML:
+                for file in DocCHTML.StaticResources.allFiles {
+                    try generateInFileManager.createFile(at: generateInFolder.appendingPathComponent(file.filename), contents: file.data)
+                }
+        }
+
         // Add the default diagnostic console writer now that we know what log handle it should write to.
         if !diagnosticEngine.hasConsumer(matching: { $0 is DiagnosticConsoleWriter }) {
             diagnosticEngine.add(
@@ -283,12 +297,12 @@ public struct ConvertAction: AsyncAction {
         // FIXME: Use `defer` here again when the miscompilation of this asynchronous defer-statement (rdar://137774949) is fixed.
 //        let temporaryFolder = try createTempFolder(with: htmlTemplateDirectory)
 //        defer {
-//            try? fileManager.removeItem(at: temporaryFolder)
+//            try? generateInFileManager.removeItem(at: temporaryFolder)
 //        }
 
         let indexHTML: URL?
         if let htmlTemplateDirectory, outputFormat == .json {
-            let indexHTMLUrl = temporaryFolder.appendingPathComponent(
+            let indexHTMLUrl = generateInFolder.appendingPathComponent(
                 HTMLTemplate.indexFileName.rawValue,
                 isDirectory: false
             )
@@ -304,10 +318,10 @@ public struct ConvertAction: AsyncAction {
                 
                 // A hosting base path was provided which means we need to replace the standard
                 // 'index.html' file with the transformed one.
-                try fileManager.createFile(at: indexHTMLUrl, contents: data)
+                try generateInFileManager.createFile(at: indexHTMLUrl, contents: data)
             }
             
-            let indexHTMLTemplateURL = temporaryFolder.appendingPathComponent(
+            let indexHTMLTemplateURL = generateInFolder.appendingPathComponent(
                 HTMLTemplate.templateFileName.rawValue,
                 isDirectory: false
             )
@@ -315,26 +329,27 @@ public struct ConvertAction: AsyncAction {
             // Delete any existing 'index-template.html' file that
             // was copied into the temporary output directory with the
             // HTML template.
-            try? fileManager.removeItem(at: indexHTMLTemplateURL)
+            try? generateInFileManager.removeItem(at: indexHTMLTemplateURL)
         } else {
             indexHTML = nil
         }
         
         let coverageAction = CoverageAction(
             documentationCoverageOptions: documentationCoverageOptions,
-            workingDirectory: temporaryFolder,
-            fileManager: fileManager)
+            workingDirectory: generateInFolder,
+            fileManager: generateInFileManager)
 
-        let indexer = _completelySkipBuildingIndex ? nil : try Indexer(outputURL: temporaryFolder, bundleID: inputs.id)
+        let indexer = try Indexer(outputURL: generateInFolder, fileManager: generateInFileManager, bundleID: inputs.id)
 
         let registerInterval = signposter.beginInterval("Register", id: signposter.makeSignpostID())
         let context = try await DocumentationContext(bundle: inputs, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
         signposter.endInterval("Register", registerInterval)
         
         let outputConsumer = ConvertFileWritingConsumer(
-            targetFolder: temporaryFolder,
+            targetFolder: generateInFolder,
             bundleRootFolder: rootURL,
             fileManager: fileManager,
+            outputFileManager: generateInFileManager,
             context: context,
             indexer: indexer,
             enableCustomTemplates: experimentalEnableCustomTemplates,
@@ -346,15 +361,17 @@ public struct ConvertAction: AsyncAction {
         let htmlConsumer: (any HTMLContentConsumer)?
         if outputFormat == .experimentalHTML {
             htmlConsumer = try FullPageHTMLContentConsumer(
-                targetFolder: temporaryFolder,
+                targetFolder: generateInFolder,
                 fileManager: fileManager,
+                outputFileManager: generateInFileManager,
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
                 customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
             )
         } else if includeContentInEachHTMLFile, let indexHTML {
             htmlConsumer = try FileWritingHTMLContentConsumer(
-                targetFolder: temporaryFolder,
+                targetFolder: generateInFolder,
                 fileManager: fileManager,
+                outputFileManager: generateInFileManager,
                 htmlTemplate: indexHTML,
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
                 customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
@@ -368,8 +385,8 @@ public struct ConvertAction: AsyncAction {
             let curation = try writer.generateDefaultCurationContents()
             for (url, updatedContent) in curation {
                 guard let data = updatedContent.data(using: .utf8) else { continue }
-                try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
-                try? data.write(to: url, options: .atomic)
+                try? generateInFileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                try? generateInFileManager.createFile(at: url, contents: data, options: .atomic)
             }
         }
         
@@ -421,27 +438,21 @@ public struct ConvertAction: AsyncAction {
             )
         }
         
-        // If we're building a navigation index, finalize the process and collect encountered diagnostics.
-        if let indexer {
-            let finalizeNavigationIndexMetric = benchmark(begin: Benchmark.Duration(id: "finalize-navigation-index"))
-            
-            // Always emit a JSON representation of the index but only emit the LMDB
-            // index if the user has explicitly opted in with the `--emit-lmdb-index` flag.
-            let indexerProblems = signposter.withIntervalSignpost("Finalize navigator index") {
-                indexer.finalize(emitJSON: true, emitLMDB: buildLMDBIndex)
-            }
-            postConversionDiagnostics.append(contentsOf: indexerProblems)
-            
-            benchmark(end: finalizeNavigationIndexMetric)
+        // Finalize the indexing process and collect encountered diagnostics.
+        let finalizeNavigationIndexMetric = benchmark(begin: Benchmark.Duration(id: "finalize-navigation-index"))
+
+        // Always emit a JSON representation of the index but only emit the LMDB
+        // index if the user has explicitly opted in with the `--emit-lmdb-index` flag.
+        let indexerProblems = signposter.withIntervalSignpost("Finalize navigator index") {
+            indexer.finalize(emitJSON: true, emitLMDB: buildLMDBIndex)
         }
+        postConversionDiagnostics.append(contentsOf: indexerProblems)
+
+        benchmark(end: finalizeNavigationIndexMetric)
         
         // Output the diagnostics encountered during the convert process to the user.
         diagnosticEngine.emit(postConversionDiagnostics)
 
-        // Stop the "total time" metric here. The moveOutput time isn't very interesting to include in the benchmark.
-        // New tasks and computations should be added above this line so that they're included in the benchmark.
-        benchmark(end: totalTimeMetric)
-        
         if !didEncounterError {
             let coverageResults = try await coverageAction.perform(logHandle: &logHandle)
             postConversionDiagnostics.append(contentsOf: coverageResults.diagnostics)
@@ -453,17 +464,28 @@ public struct ConvertAction: AsyncAction {
         // However, if the `emitDigest` flag is true, we should replace the current output with our digest of diagnostics.
         // FIXME: We no longer output a diagnostics file in the output. We can remove the `emitDigest` check below.
         if !didEncounterError || emitDigest {
-            try moveOutput(from: temporaryFolder, to: targetDirectory)
+            try signposter.withIntervalSignpost("Move output") {
+                try Self.moveOutput(from: generateInFolder, to: targetDirectory, fileManager: generateInFileManager)
+            }
         }
 
+        // Stop the "total time" metric here. While moveOutput isn't interesting, compression is.
+        benchmark(end: totalTimeMetric)
+
         // Log the output size.
-        benchmark(add: Benchmark.ArchiveOutputSize(archiveDirectory: targetDirectory))
+        benchmark(
+            add: Benchmark.ArchiveOutputSize(
+                archiveDirectory: targetDirectory,
+                fileManager: generateInFileManager
+            )
+        )
         benchmark(
             add: Benchmark.DataDirectoryOutputSize(
                 dataDirectory: targetDirectory.appendingPathComponent(
                     NodeURLGenerator.Path.dataFolderName,
                     isDirectory: true
-                )
+                ),
+                fileManager: generateInFileManager
             )
         )
         benchmark(
@@ -471,17 +493,18 @@ public struct ConvertAction: AsyncAction {
                 indexDirectory: targetDirectory.appendingPathComponent(
                     NodeURLGenerator.Path.indexFolderName,
                     isDirectory: true
-                )
+                ),
+                fileManager: generateInFileManager
             )
         )
         
         if Benchmark.main.isEnabled {
             // Write the benchmark files directly in the target directory.
-
             let outputConsumer = ConvertFileWritingConsumer(
                 targetFolder: targetDirectory,
                 bundleRootFolder: rootURL,
                 fileManager: fileManager,
+                outputFileManager: generateInFileManager,
                 context: context,
                 indexer: nil,
                 transformForStaticHostingIndexHTML: nil,
@@ -496,11 +519,5 @@ public struct ConvertAction: AsyncAction {
     
     func createTempFolder(with templateURL: URL?) throws -> URL {
         return try Self.createUniqueDirectory(inside: temporaryDirectory, template: templateURL, fileManager: fileManager)
-    }
-    
-    func moveOutput(from: URL, to: URL) throws {
-        try signposter.withIntervalSignpost("Move output") {
-            try Self.moveOutput(from: from, to: to, fileManager: fileManager)
-        }
     }
 }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -454,6 +454,10 @@ public struct ConvertAction: AsyncAction {
         // Output the diagnostics encountered during the convert process to the user.
         diagnosticEngine.emit(postConversionDiagnostics)
 
+        // Stop the "total time" metric here. The moveOutput time isn't very interesting to include in the benchmark.
+        // New tasks and computations should be added above this line so that they're included in the benchmark.
+        benchmark(end: totalTimeMetric)
+
         if !didEncounterError {
             let coverageResults = try await coverageAction.perform(logHandle: &logHandle)
             postConversionDiagnostics.append(contentsOf: coverageResults.diagnostics)
@@ -469,9 +473,6 @@ public struct ConvertAction: AsyncAction {
                 try Self.moveOutput(from: generateInFolder, to: targetDirectory, fileManager: generateInFileManager)
             }
         }
-
-        // Stop the "total time" metric here. While moveOutput isn't interesting, compression is.
-        benchmark(end: totalTimeMetric)
 
         // Log the output size.
         benchmark(

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -43,6 +43,8 @@ public struct ConvertAction: AsyncAction {
     let sourceRepository: SourceRepository?
     
     private var fileManager: any FileManagerProtocol
+    private var outputFileManager: any FileManagerProtocol
+
     private let temporaryDirectory: URL
     
     private let diagnosticWriterOptions: (formatting: DiagnosticFormattingOptions, baseURL: URL)
@@ -94,6 +96,7 @@ public struct ConvertAction: AsyncAction {
         fileManager: any FileManagerProtocol = FileManager.default,
         temporaryDirectory: URL,
         outputFormat: Docc.Convert.OutputFormat = .json,
+        outputFileManager: (any FileManagerProtocol)? = nil,
         documentationCoverageOptions: DocumentationCoverageOptions = .noCoverage,
         bundleDiscoveryOptions: BundleDiscoveryOptions = .init(),
         diagnosticLevel: String? = nil,
@@ -121,6 +124,7 @@ public struct ConvertAction: AsyncAction {
         self.outputFormat = outputFormat
         self.buildLMDBIndex = buildIndex
         self.fileManager = fileManager
+        self.outputFileManager = outputFileManager ?? fileManager
         self.temporaryDirectory = temporaryDirectory
         self.documentationCoverageOptions = documentationCoverageOptions
         self.transformForStaticHosting = transformForStaticHosting
@@ -213,11 +217,6 @@ public struct ConvertAction: AsyncAction {
     /// A block of extra work that tests perform to affect the time it takes to convert documentation
     var _extraTestWork: (() async -> Void)?
 
-    /// The `Indexer` type doesn't work with virtual file systems.
-    ///
-    /// Tests that don't verify the contents of the navigator index can set this to `true` so that they can use a virtual, in-memory, file system.
-    var _completelySkipBuildingIndex: Bool = false
-    
     /// Converts each eligible file from the source documentation bundle,
     /// saves the results in the given output alongside the template files.
     public func perform(logHandle: inout LogHandle) async throws -> ActionResult {
@@ -226,25 +225,21 @@ public struct ConvertAction: AsyncAction {
     
     func perform(logHandle: inout LogHandle) async throws -> (ActionResult, DocumentationContext) {
         // FIXME: Use `defer` again when the asynchronous defer-statement miscompilation (rdar://137774949) is fixed.
-        let temporaryFolder: URL
-        switch outputFormat {
-        case .json:
-            temporaryFolder = try createTempFolder(with: htmlTemplateDirectory)
-        case .experimentalHTML:
-            temporaryFolder = try createTempFolder(with: nil)
-            for file in DocCHTML.StaticResources.allFiles {
-                try fileManager.createFile(at: temporaryFolder.appendingPathComponent(file.filename), contents: file.data)
-            }
-        }
+        let temporaryFolder = try Self.createUniqueDirectory(
+            inside: temporaryDirectory,
+            template: nil,
+            fileManager: outputFileManager
+        )
         
         do {
             let result = try await _perform(logHandle: &logHandle, temporaryFolder: temporaryFolder)
+
             diagnosticEngine.flush()
-            try? fileManager.removeItem(at: temporaryFolder)
+            try? outputFileManager.removeItem(at: temporaryFolder)
             return result
         } catch {
             diagnosticEngine.flush()
-            try? fileManager.removeItem(at: temporaryFolder)
+            try? outputFileManager.removeItem(at: temporaryFolder)
             throw error
         }
     }
@@ -255,6 +250,25 @@ public struct ConvertAction: AsyncAction {
             signposter.endInterval("Convert", convertSignpostHandle)
         }
         
+        let generateInFolder: URL = temporaryFolder
+        let generateInFileManager = outputFileManager
+
+        // Populate the directory with the initial files
+        switch outputFormat {
+            case .json:
+                if let htmlTemplateDirectory {
+                    try fileManager.copyItem(
+                        at: htmlTemplateDirectory,
+                        to: generateInFolder,
+                        on: generateInFileManager
+                    )
+                }
+            case .experimentalHTML:
+                for file in DocCHTML.StaticResources.allFiles {
+                    try generateInFileManager.createFile(at: generateInFolder.appendingPathComponent(file.filename), contents: file.data)
+                }
+        }
+
         // Add the default diagnostic console writer now that we know what log handle it should write to.
         if !diagnosticEngine.hasConsumer(matching: { $0 is DiagnosticConsoleWriter }) {
             diagnosticEngine.add(
@@ -283,12 +297,12 @@ public struct ConvertAction: AsyncAction {
         // FIXME: Use `defer` here again when the miscompilation of this asynchronous defer-statement (rdar://137774949) is fixed.
 //        let temporaryFolder = try createTempFolder(with: htmlTemplateDirectory)
 //        defer {
-//            try? fileManager.removeItem(at: temporaryFolder)
+//            try? generateInFileManager.removeItem(at: temporaryFolder)
 //        }
 
         let indexHTML: URL?
         if let htmlTemplateDirectory, outputFormat == .json {
-            let indexHTMLUrl = temporaryFolder.appendingPathComponent(
+            let indexHTMLUrl = generateInFolder.appendingPathComponent(
                 HTMLTemplate.indexFileName.rawValue,
                 isDirectory: false
             )
@@ -304,10 +318,10 @@ public struct ConvertAction: AsyncAction {
                 
                 // A hosting base path was provided which means we need to replace the standard
                 // 'index.html' file with the transformed one.
-                try fileManager.createFile(at: indexHTMLUrl, contents: data)
+                try generateInFileManager.createFile(at: indexHTMLUrl, contents: data)
             }
             
-            let indexHTMLTemplateURL = temporaryFolder.appendingPathComponent(
+            let indexHTMLTemplateURL = generateInFolder.appendingPathComponent(
                 HTMLTemplate.templateFileName.rawValue,
                 isDirectory: false
             )
@@ -315,26 +329,27 @@ public struct ConvertAction: AsyncAction {
             // Delete any existing 'index-template.html' file that
             // was copied into the temporary output directory with the
             // HTML template.
-            try? fileManager.removeItem(at: indexHTMLTemplateURL)
+            try? generateInFileManager.removeItem(at: indexHTMLTemplateURL)
         } else {
             indexHTML = nil
         }
         
         let coverageAction = CoverageAction(
             documentationCoverageOptions: documentationCoverageOptions,
-            workingDirectory: temporaryFolder,
-            fileManager: fileManager)
+            workingDirectory: generateInFolder,
+            fileManager: generateInFileManager)
 
-        let indexer = _completelySkipBuildingIndex ? nil : try Indexer(outputURL: temporaryFolder, bundleID: inputs.id)
+        let indexer = try Indexer(outputURL: generateInFolder, fileManager: generateInFileManager, bundleID: inputs.id)
 
         let registerInterval = signposter.beginInterval("Register", id: signposter.makeSignpostID())
         let context = try await DocumentationContext(bundle: inputs, dataProvider: dataProvider, diagnosticEngine: diagnosticEngine, configuration: configuration)
         signposter.endInterval("Register", registerInterval)
         
         let outputConsumer = ConvertFileWritingConsumer(
-            targetFolder: temporaryFolder,
+            targetFolder: generateInFolder,
             bundleRootFolder: rootURL,
             fileManager: fileManager,
+            outputFileManager: generateInFileManager,
             context: context,
             indexer: indexer,
             enableCustomTemplates: experimentalEnableCustomTemplates,
@@ -346,16 +361,18 @@ public struct ConvertAction: AsyncAction {
         let htmlConsumer: (any HTMLContentConsumer)?
         if outputFormat == .experimentalHTML {
             htmlConsumer = try FullPageHTMLContentConsumer(
-                targetFolder: temporaryFolder,
+                targetFolder: generateInFolder,
                 fileManager: fileManager,
+                outputFileManager: generateInFileManager,
                 prettyPrint: shouldPrettyPrintOutputJSON, // Use the same configuration as the JSON output to make it convenient for the developer.
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
                 customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
             )
         } else if includeContentInEachHTMLFile, let indexHTML {
             htmlConsumer = try FileWritingHTMLContentConsumer(
-                targetFolder: temporaryFolder,
+                targetFolder: generateInFolder,
                 fileManager: fileManager,
+                outputFileManager: generateInFileManager,
                 htmlTemplate: indexHTML,
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
                 customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
@@ -369,8 +386,8 @@ public struct ConvertAction: AsyncAction {
             let curation = try writer.generateDefaultCurationContents()
             for (url, updatedContent) in curation {
                 guard let data = updatedContent.data(using: .utf8) else { continue }
-                try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
-                try? data.write(to: url, options: .atomic)
+                try? generateInFileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                try? generateInFileManager.createFile(at: url, contents: data, options: .atomic)
             }
         }
         
@@ -422,27 +439,21 @@ public struct ConvertAction: AsyncAction {
             )
         }
         
-        // If we're building a navigation index, finalize the process and collect encountered diagnostics.
-        if let indexer {
-            let finalizeNavigationIndexMetric = benchmark(begin: Benchmark.Duration(id: "finalize-navigation-index"))
-            
-            // Always emit a JSON representation of the index but only emit the LMDB
-            // index if the user has explicitly opted in with the `--emit-lmdb-index` flag.
-            let indexerProblems = signposter.withIntervalSignpost("Finalize navigator index") {
-                indexer.finalize(emitJSON: true, emitLMDB: buildLMDBIndex)
-            }
-            postConversionDiagnostics.append(contentsOf: indexerProblems)
-            
-            benchmark(end: finalizeNavigationIndexMetric)
+        // Finalize the indexing process and collect encountered diagnostics.
+        let finalizeNavigationIndexMetric = benchmark(begin: Benchmark.Duration(id: "finalize-navigation-index"))
+
+        // Always emit a JSON representation of the index but only emit the LMDB
+        // index if the user has explicitly opted in with the `--emit-lmdb-index` flag.
+        let indexerProblems = signposter.withIntervalSignpost("Finalize navigator index") {
+            indexer.finalize(emitJSON: true, emitLMDB: buildLMDBIndex)
         }
+        postConversionDiagnostics.append(contentsOf: indexerProblems)
+
+        benchmark(end: finalizeNavigationIndexMetric)
         
         // Output the diagnostics encountered during the convert process to the user.
         diagnosticEngine.emit(postConversionDiagnostics)
 
-        // Stop the "total time" metric here. The moveOutput time isn't very interesting to include in the benchmark.
-        // New tasks and computations should be added above this line so that they're included in the benchmark.
-        benchmark(end: totalTimeMetric)
-        
         if !didEncounterError {
             let coverageResults = try await coverageAction.perform(logHandle: &logHandle)
             postConversionDiagnostics.append(contentsOf: coverageResults.diagnostics)
@@ -454,17 +465,28 @@ public struct ConvertAction: AsyncAction {
         // However, if the `emitDigest` flag is true, we should replace the current output with our digest of diagnostics.
         // FIXME: We no longer output a diagnostics file in the output. We can remove the `emitDigest` check below.
         if !didEncounterError || emitDigest {
-            try moveOutput(from: temporaryFolder, to: targetDirectory)
+            try signposter.withIntervalSignpost("Move output") {
+                try Self.moveOutput(from: generateInFolder, to: targetDirectory, fileManager: generateInFileManager)
+            }
         }
 
+        // Stop the "total time" metric here. While moveOutput isn't interesting, compression is.
+        benchmark(end: totalTimeMetric)
+
         // Log the output size.
-        benchmark(add: Benchmark.ArchiveOutputSize(archiveDirectory: targetDirectory))
+        benchmark(
+            add: Benchmark.ArchiveOutputSize(
+                archiveDirectory: targetDirectory,
+                fileManager: generateInFileManager
+            )
+        )
         benchmark(
             add: Benchmark.DataDirectoryOutputSize(
                 dataDirectory: targetDirectory.appendingPathComponent(
                     NodeURLGenerator.Path.dataFolderName,
                     isDirectory: true
-                )
+                ),
+                fileManager: generateInFileManager
             )
         )
         benchmark(
@@ -472,17 +494,18 @@ public struct ConvertAction: AsyncAction {
                 indexDirectory: targetDirectory.appendingPathComponent(
                     NodeURLGenerator.Path.indexFolderName,
                     isDirectory: true
-                )
+                ),
+                fileManager: generateInFileManager
             )
         )
         
         if Benchmark.main.isEnabled {
             // Write the benchmark files directly in the target directory.
-
             let outputConsumer = ConvertFileWritingConsumer(
                 targetFolder: targetDirectory,
                 bundleRootFolder: rootURL,
                 fileManager: fileManager,
+                outputFileManager: generateInFileManager,
                 context: context,
                 indexer: nil,
                 transformForStaticHostingIndexHTML: nil,
@@ -497,11 +520,5 @@ public struct ConvertAction: AsyncAction {
     
     func createTempFolder(with templateURL: URL?) throws -> URL {
         return try Self.createUniqueDirectory(inside: temporaryDirectory, template: templateURL, fileManager: fileManager)
-    }
-    
-    func moveOutput(from: URL, to: URL) throws {
-        try signposter.withIntervalSignpost("Move output") {
-            try Self.moveOutput(from: from, to: to, fileManager: fileManager)
-        }
     }
 }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -16,6 +16,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
     var targetFolder: URL
     var bundleRootFolder: URL?
     var fileManager: any FileManagerProtocol
+    var outputFileManager: any FileManagerProtocol
     var context: DocumentationContext
     var renderNodeWriter: JSONEncodingRenderNodeWriter
     var indexer: ConvertAction.Indexer?
@@ -31,6 +32,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         targetFolder: URL,
         bundleRootFolder: URL?,
         fileManager: any FileManagerProtocol,
+        outputFileManager: any FileManagerProtocol,
         context: DocumentationContext,
         indexer: ConvertAction.Indexer?,
         enableCustomTemplates: Bool = false,
@@ -40,10 +42,12 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         self.targetFolder = targetFolder
         self.bundleRootFolder = bundleRootFolder
         self.fileManager = fileManager
+        self.outputFileManager = outputFileManager
         self.context = context
         self.renderNodeWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
             fileManager: fileManager,
+            outputFileManager: outputFileManager,
             transformForStaticHostingIndexHTML: transformForStaticHostingIndexHTML
         )
         self.indexer = indexer
@@ -71,7 +75,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         encoder.outputFormatting.insert(.prettyPrinted)
         #endif
         let data = try encoder.encode(markdownManifest)
-        try fileManager.createFile(at: url, contents: data)
+        try outputFileManager.createFile(at: url, contents: data)
     }
     
     func consume(externalRenderNode: ExternalRenderNode) throws {
@@ -83,9 +87,10 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         func copyAsset(_ asset: DataAsset, to destinationFolder: URL) throws {
             for sourceURL in asset.variants.values where !sourceURL.isAbsoluteWebURL {
                 let assetName = sourceURL.lastPathComponent
-                try fileManager._copyItem(
+                try fileManager.copyItem(
                     at: sourceURL,
-                    to: destinationFolder.appendingPathComponent(assetName, isDirectory: false)
+                    to: destinationFolder.appendingPathComponent(assetName, isDirectory: false),
+                    on: outputFileManager
                 )
             }
         }
@@ -97,8 +102,8 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         let imagesDirectory = targetFolder
             .appendingPathComponent("images", isDirectory: true)
             .appendingPathComponent(bundleID.rawValue, isDirectory: true)
-        if !fileManager.directoryExists(atPath: imagesDirectory.path) {
-            try fileManager.createDirectory(at: imagesDirectory, withIntermediateDirectories: true, attributes: nil)
+        if !outputFileManager.directoryExists(atPath: imagesDirectory.path) {
+            try outputFileManager.createDirectory(at: imagesDirectory, withIntermediateDirectories: true, attributes: nil)
         }
         
         // Copy all registered images to the output directory.
@@ -110,8 +115,8 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         let videosDirectory = targetFolder
             .appendingPathComponent("videos", isDirectory: true)
             .appendingPathComponent(bundleID.rawValue, isDirectory: true)
-        if !fileManager.directoryExists(atPath: videosDirectory.path) {
-            try fileManager.createDirectory(at: videosDirectory, withIntermediateDirectories: true, attributes: nil)
+        if !outputFileManager.directoryExists(atPath: videosDirectory.path) {
+            try outputFileManager.createDirectory(at: videosDirectory, withIntermediateDirectories: true, attributes: nil)
         }
         
         // Copy all registered videos to the output directory.
@@ -123,8 +128,8 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         let downloadsDirectory = targetFolder
             .appendingPathComponent(DownloadReference.locationName, isDirectory: true)
             .appendingPathComponent(bundleID.rawValue, isDirectory: true)
-        if !fileManager.directoryExists(atPath: downloadsDirectory.path) {
-            try fileManager.createDirectory(at: downloadsDirectory, withIntermediateDirectories: true, attributes: nil)
+        if !outputFileManager.directoryExists(atPath: downloadsDirectory.path) {
+            try outputFileManager.createDirectory(at: downloadsDirectory, withIntermediateDirectories: true, attributes: nil)
         }
 
         // Copy all downloads into the output directory.
@@ -151,33 +156,33 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         // that the renderer template may already contain.
         if let themeSettings = bundle.themeSettings {
             let targetFile = targetFolder.appendingPathComponent(themeSettings.lastPathComponent, isDirectory: false)
-            if fileManager.fileExists(atPath: targetFile.path) {
-                try fileManager.removeItem(at: targetFile)
+            if outputFileManager.fileExists(atPath: targetFile.path) {
+                try outputFileManager.removeItem(at: targetFile)
             }
-            try fileManager._copyItem(at: themeSettings, to: targetFile)
+            try fileManager.copyItem(at: themeSettings, to: targetFile, on: outputFileManager)
         }
 
         // If a custom favicon is provided, it will be copied in the output directory
         // The custom favicon will override the default one.
         if let customFavicon = bundle.customFavicon {
             let targetFile = targetFolder.appendingPathComponent(customFavicon.lastPathComponent, isDirectory: false)
-            if fileManager.fileExists(atPath: targetFile.path) {
-                try fileManager.removeItem(at: targetFile)
+            if outputFileManager.fileExists(atPath: targetFile.path) {
+                try outputFileManager.removeItem(at: targetFile)
             }
-            try fileManager._copyItem(at: customFavicon, to: targetFile)
+            try fileManager.copyItem(at: customFavicon, to: targetFile, on: outputFileManager)
         }
     }
     
     func consume(linkableElementSummaries summaries: [LinkDestinationSummary]) throws {
         let linkableElementsURL = targetFolder.appendingPathComponent(Self.linkableEntitiesFileName, isDirectory: false)
         let data = try encode(summaries)
-        try fileManager.createFile(at: linkableElementsURL, contents: data)
+        try outputFileManager.createFile(at: linkableElementsURL, contents: data)
     }
     
     func consume(indexingRecords: [IndexingRecord]) throws {
         let recordsURL = targetFolder.appendingPathComponent("indexing-records.json", isDirectory: false)
         let data = try encode(indexingRecords)
-        try fileManager.createFile(at: recordsURL, contents: data)
+        try outputFileManager.createFile(at: recordsURL, contents: data)
     }
     
     func consume(assets: [RenderReferenceType : [any RenderReference]]) throws {
@@ -191,32 +196,32 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
 
         let assetsURL = targetFolder.appendingPathComponent("assets.json", isDirectory: false)
         let data = try encode(digest)
-        try fileManager.createFile(at: assetsURL, contents: data)
+        try outputFileManager.createFile(at: assetsURL, contents: data)
     }
     
     func consume(benchmarks: Benchmark) throws {
         let data = try encode(benchmarks)
         let benchmarkURL = targetFolder.appendingPathComponent("benchmark.json", isDirectory: false)
-        try fileManager.createFile(at: benchmarkURL, contents: data)
+        try outputFileManager.createFile(at: benchmarkURL, contents: data)
     }
 
     func consume(documentationCoverageInfo: [CoverageDataEntry]) throws {
         let data = try encode(documentationCoverageInfo)
         let docCoverageURL = targetFolder.appendingPathComponent(Self.docCoverageFileName, isDirectory: false)
-        try fileManager.createFile(at: docCoverageURL, contents: data)
+        try outputFileManager.createFile(at: docCoverageURL, contents: data)
     }
     
     func consume(buildMetadata: BuildMetadata) throws {
         let data = try encode(buildMetadata)
         let buildMetadataURL = targetFolder.appendingPathComponent(Self.buildMetadataFileName, isDirectory: false)
-        try fileManager.createFile(at: buildMetadataURL, contents: data)
+        try outputFileManager.createFile(at: buildMetadataURL, contents: data)
     }
     
     func consume(linkResolutionInformation: SerializableLinkResolutionInformation) throws {
         let data = try encode(linkResolutionInformation)
         let linkResolutionInfoURL = targetFolder.appendingPathComponent(Self.linkHierarchyFileName, isDirectory: false)
         
-        try fileManager.createFile(at: linkResolutionInfoURL, contents: data)
+        try outputFileManager.createFile(at: linkResolutionInfoURL, contents: data)
     }
     
     /// Encodes the given value using the default render node JSON encoder.
@@ -243,7 +248,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         let template = "<template id=\"\(id.rawValue)\">\(templateContents)</template>"
         var newIndexContents = indexContents
         newIndexContents.replaceSubrange(bodyTagRange, with: indexContents[bodyTagRange] + template)
-        try fileManager.createFile(at: index, contents: Data(newIndexContents.utf8))
+        try outputFileManager.createFile(at: index, contents: Data(newIndexContents.utf8))
     }
     
     /// File name for the documentation coverage file emitted during conversion.

--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -46,8 +46,7 @@ struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, 
         self.context = context
         self.renderNodeWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
-            fileManager: fileManager,
-            outputFileManager: outputFileManager,
+            fileManager: outputFileManager,
             transformForStaticHostingIndexHTML: transformForStaticHostingIndexHTML
         )
         self.indexer = indexer

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -104,6 +104,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
     init(
         targetFolder: URL,
         fileManager: some FileManagerProtocol,
+        outputFileManager: some FileManagerProtocol,
         htmlTemplate: URL,
         customHeader: URL?,
         customFooter: URL?,
@@ -130,6 +131,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
         self.fileWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
             fileManager: fileManager,
+            outputFileManager: outputFileManager,
             transformForStaticHostingIndexHTML: nil
         )
     }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FileWritingHTMLContentConsumer.swift
@@ -130,8 +130,7 @@ struct FileWritingHTMLContentConsumer: HTMLContentConsumer {
         self.prettyPrintOutput = prettyPrintOutput
         self.fileWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
-            fileManager: fileManager,
-            outputFileManager: outputFileManager,
+            fileManager: outputFileManager,
             transformForStaticHostingIndexHTML: nil
         )
     }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
@@ -33,6 +33,7 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
     init(
         targetFolder: URL,
         fileManager: some FileManagerProtocol,
+        outputFileManager: some FileManagerProtocol,
         customHeader: URL?,
         customFooter: URL?
     ) throws {
@@ -41,6 +42,7 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
         self.fileWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
             fileManager: fileManager,
+            outputFileManager: outputFileManager,
             transformForStaticHostingIndexHTML: nil
         )
     }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
@@ -45,8 +45,7 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
         
         self.fileWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
-            fileManager: fileManager,
-            outputFileManager: outputFileManager,
+            fileManager: outputFileManager,
             transformForStaticHostingIndexHTML: nil
         )
     }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/FullPageHTMLContentConsumer.swift
@@ -35,6 +35,7 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
     init(
         targetFolder: URL,
         fileManager: some FileManagerProtocol,
+        outputFileManager: some FileManagerProtocol,
         prettyPrint: Bool,
         customHeader: URL?,
         customFooter: URL?
@@ -45,6 +46,7 @@ struct FullPageHTMLContentConsumer: HTMLContentConsumer {
         self.fileWriter = JSONEncodingRenderNodeWriter(
             targetFolder: targetFolder,
             fileManager: fileManager,
+            outputFileManager: outputFileManager,
             transformForStaticHostingIndexHTML: nil
         )
     }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/Indexer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/Indexer.swift
@@ -33,11 +33,12 @@ extension ConvertAction {
         /// - Parameters:
         ///   - outputURL: The target directory to create the index file.
         ///   - bundleID: The identifier of the bundle being indexed.
-        init(outputURL: URL, bundleID: DocumentationBundle.Identifier) throws {
+        init(outputURL: URL, fileManager: any FileManagerProtocol, bundleID: DocumentationBundle.Identifier) throws {
             let indexURL = outputURL.appendingPathComponent("index", isDirectory: true)
             indexBuilder = Synchronized<NavigatorIndex.Builder>(
                 NavigatorIndex.Builder(
                     outputURL: indexURL,
+                    fileManager: fileManager,
                     bundleIdentifier: bundleID.rawValue,
                     sortRootChildrenByName: true,
                     groupByLanguage: true

--- a/Sources/DocCCommandLine/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -18,6 +18,7 @@ class JSONEncodingRenderNodeWriter {
     private let targetFolder: URL
     private let transformForStaticHostingIndexHTML: URL?
     private let fileManager: any FileManagerProtocol
+    private let outputFileManager: any FileManagerProtocol
     private let renderReferenceCache = RenderReferenceCache([:])
     
     /// Creates a writer object that write render node JSON into a given folder.
@@ -25,10 +26,11 @@ class JSONEncodingRenderNodeWriter {
     /// - Parameters:
     ///   - targetFolder: The folder to which the writer object writes the files.
     ///   - fileManager: The file manager with which the writer object writes data to files.
-    init(targetFolder: URL, fileManager: any FileManagerProtocol, transformForStaticHostingIndexHTML: URL?) {
+    init(targetFolder: URL, fileManager: any FileManagerProtocol, outputFileManager: any FileManagerProtocol, transformForStaticHostingIndexHTML: URL?) {
         self.targetFolder = targetFolder
         self.transformForStaticHostingIndexHTML = transformForStaticHostingIndexHTML
         self.fileManager = fileManager
+        self.outputFileManager = outputFileManager
     }
     
     // The already created directories on disk
@@ -70,23 +72,16 @@ class JSONEncodingRenderNodeWriter {
         // Note that it doesn't make sense to use the above-described `directoryIndex` for this use
         // case since we expect every 'index.html' file to require the creation of
         // its own unique parent directory.
-        try fileManager.createDirectory(
+        try outputFileManager.createDirectory(
             at: htmlTargetFolderURL,
             withIntermediateDirectories: true,
             attributes: nil
         )
         
-        do {
-            try fileManager._copyItem(at: indexHTML, to: htmlTargetFileURL)
-        } catch let error as NSError where error.code == NSFileWriteFileExistsError {
-            // We already have an 'index.html' file at this path. This could be because
-            // we're writing to an output directory that already contains built documentation
-            // or because we we're given bad input such that multiple documentation pages
-            // have the same path on the filesystem. Either way, we don't want this to error out
-            // so just remove the destination item and try the copy operation again.
-            try fileManager.removeItem(at: htmlTargetFileURL)
-            try fileManager._copyItem(at: indexHTML, to: htmlTargetFileURL)
+        if outputFileManager.fileExists(atPath: htmlTargetFileURL.path) {
+            try outputFileManager.removeItem(at: htmlTargetFileURL)
         }
+        try outputFileManager.copyItem(at: indexHTML, to: htmlTargetFileURL, on: outputFileManager)
     }
     
     /// Writes a markdown node to a file at a location based on the node's relative URL.
@@ -121,7 +116,7 @@ class JSONEncodingRenderNodeWriter {
         try directoryIndex.sync { directoryIndex in
             let (insertedRenderNodeTargetFolderURL, _) = directoryIndex.insert(containingFolderURL)
             if insertedRenderNodeTargetFolderURL {
-                try fileManager.createDirectory(
+                try outputFileManager.createDirectory(
                     at: containingFolderURL,
                     withIntermediateDirectories: true,
                     attributes: nil
@@ -129,6 +124,6 @@ class JSONEncodingRenderNodeWriter {
             }
         }
         
-        try fileManager.createFile(at: fileURL, contents: data, options: nil)
+        try outputFileManager.createFile(at: fileURL, contents: data, options: nil)
     }
 }

--- a/Sources/DocCCommandLine/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/JSONEncodingRenderNodeWriter.swift
@@ -18,7 +18,6 @@ class JSONEncodingRenderNodeWriter {
     private let targetFolder: URL
     private let transformForStaticHostingIndexHTML: URL?
     private let fileManager: any FileManagerProtocol
-    private let outputFileManager: any FileManagerProtocol
     private let renderReferenceCache = RenderReferenceCache([:])
     
     /// Creates a writer object that write render node JSON into a given folder.
@@ -26,11 +25,10 @@ class JSONEncodingRenderNodeWriter {
     /// - Parameters:
     ///   - targetFolder: The folder to which the writer object writes the files.
     ///   - fileManager: The file manager with which the writer object writes data to files.
-    init(targetFolder: URL, fileManager: any FileManagerProtocol, outputFileManager: any FileManagerProtocol, transformForStaticHostingIndexHTML: URL?) {
+    init(targetFolder: URL, fileManager: any FileManagerProtocol, transformForStaticHostingIndexHTML: URL?) {
         self.targetFolder = targetFolder
         self.transformForStaticHostingIndexHTML = transformForStaticHostingIndexHTML
         self.fileManager = fileManager
-        self.outputFileManager = outputFileManager
     }
     
     // The already created directories on disk
@@ -72,16 +70,16 @@ class JSONEncodingRenderNodeWriter {
         // Note that it doesn't make sense to use the above-described `directoryIndex` for this use
         // case since we expect every 'index.html' file to require the creation of
         // its own unique parent directory.
-        try outputFileManager.createDirectory(
+        try fileManager.createDirectory(
             at: htmlTargetFolderURL,
             withIntermediateDirectories: true,
             attributes: nil
         )
         
-        if outputFileManager.fileExists(atPath: htmlTargetFileURL.path) {
-            try outputFileManager.removeItem(at: htmlTargetFileURL)
+        if fileManager.fileExists(atPath: htmlTargetFileURL.path) {
+            try fileManager.removeItem(at: htmlTargetFileURL)
         }
-        try outputFileManager.copyItem(at: indexHTML, to: htmlTargetFileURL, on: outputFileManager)
+        try fileManager.copyItem(at: indexHTML, to: htmlTargetFileURL, on: fileManager)
     }
     
     /// Writes a markdown node to a file at a location based on the node's relative URL.
@@ -116,7 +114,7 @@ class JSONEncodingRenderNodeWriter {
         try directoryIndex.sync { directoryIndex in
             let (insertedRenderNodeTargetFolderURL, _) = directoryIndex.insert(containingFolderURL)
             if insertedRenderNodeTargetFolderURL {
-                try outputFileManager.createDirectory(
+                try fileManager.createDirectory(
                     at: containingFolderURL,
                     withIntermediateDirectories: true,
                     attributes: nil
@@ -124,6 +122,6 @@ class JSONEncodingRenderNodeWriter {
             }
         }
         
-        try outputFileManager.createFile(at: fileURL, contents: data, options: nil)
+        try fileManager.createFile(at: fileURL, contents: data, options: nil)
     }
 }

--- a/Sources/DocCCommandLine/Action/Actions/IndexAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/IndexAction.swift
@@ -42,6 +42,7 @@ public struct IndexAction: AsyncAction {
     private func buildIndex() throws -> [Diagnostic] {
         let indexBuilder = NavigatorIndex.Builder(archiveURL: archiveURL,
                                                   outputURL: outputURL,
+                                                  fileManager: FileManager.default,
                                                   bundleIdentifier: bundleIdentifier,
                                                   sortRootChildrenByName: true,
                                                   groupByLanguage: true)

--- a/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -34,7 +34,7 @@ extension MergeAction {
         }
     }
     
-    func readRootNodeRenderReferencesIn(dataDirectory: URL) throws -> RootRenderReferences {
+    func readRootNodeRenderReferencesIn(dataDirectory: URL, on fileManager: any ReadOnlyFileManagerProtocol) throws -> RootRenderReferences {
         func inner(url: URL) throws -> [RootRenderReferences.Information] {
             // Path might not exist (e.g. tutorials for a reference-only archive)
             guard let contents = try? fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])

--- a/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction+SynthesizedLandingPage.swift
@@ -34,7 +34,7 @@ extension MergeAction {
         }
     }
     
-    func readRootNodeRenderReferencesIn(dataDirectory: URL, on fileManager: any ReadOnlyFileManagerProtocol) throws -> RootRenderReferences {
+    func readRootNodeRenderReferencesIn(dataDirectory: URL, using fileManager: any ReadOnlyFileManagerProtocol) throws -> RootRenderReferences {
         func inner(url: URL) throws -> [RootRenderReferences.Information] {
             // Path might not exist (e.g. tutorials for a reference-only archive)
             guard let contents = try? fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: [])

--- a/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction.swift
@@ -108,7 +108,7 @@ struct MergeAction: AsyncAction {
         
         let reference = ResolvedTopicReference(bundleID: .init(rawValue: landingPageName), path: "/documentation", sourceLanguage: language)
         
-        let rootRenderReferences = try readRootNodeRenderReferencesIn(dataDirectory: targetURL.appendingPathComponent("data", isDirectory: true))
+        let rootRenderReferences = try readRootNodeRenderReferencesIn(dataDirectory: targetURL.appendingPathComponent("data", isDirectory: true), on: fileManager)
         
         guard !rootRenderReferences.isEmpty else {
             // No need to synthesize a landing page if the combined archive is empty.

--- a/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Merge/MergeAction.swift
@@ -108,7 +108,7 @@ struct MergeAction: AsyncAction {
         
         let reference = ResolvedTopicReference(bundleID: .init(rawValue: landingPageName), path: "/documentation", sourceLanguage: language)
         
-        let rootRenderReferences = try readRootNodeRenderReferencesIn(dataDirectory: targetURL.appendingPathComponent("data", isDirectory: true), on: fileManager)
+        let rootRenderReferences = try readRootNodeRenderReferencesIn(dataDirectory: targetURL.appendingPathComponent("data", isDirectory: true), using: fileManager)
         
         guard !rootRenderReferences.isEmpty else {
             // No need to synthesize a landing page if the combined archive is empty.

--- a/Sources/DocCTestUtilities/TestFileSystem.swift
+++ b/Sources/DocCTestUtilities/TestFileSystem.swift
@@ -40,7 +40,7 @@ import SwiftDocC
 ///
 /// - Note: This class is thread-safe by using a naive locking for each access to the files dictionary.
 /// - Warning: Use this type for unit testing.
-package class TestFileSystem: FileManagerProtocol {
+package class TestFileSystem: FileManagerProtocol, @unchecked Sendable {
     package let currentDirectoryPath = "/"
         
     /// Thread safe access to the file system.
@@ -65,6 +65,17 @@ package class TestFileSystem: FileManagerProtocol {
     /// For example use this for large conversions when the output is not of interest.
     var disableWriting = false
     
+    package convenience init(files someFiles: [any File]) throws {
+        self.init()
+
+        files["/"] = .folder
+        files["/tmp"] = .folder
+
+        let rootURL = URL(filePath: "/")
+        let fileList = try filesFrom(files: someFiles, at: rootURL)
+        files.merge(fileList, uniquingKeysWith: { _, new in new })
+    }
+
     package convenience init(folders: [Folder]) throws {
         self.init()
         
@@ -103,12 +114,9 @@ package class TestFileSystem: FileManagerProtocol {
         try contentsOfURL(url)
     }
     
-    private func filesIn(folder: Folder, at: URL) throws -> [String: Contents] {
-        filesLock.lock()
-        defer { filesLock.unlock() }
-
+    private func filesFrom(files: [any File], at: URL) throws -> [String: Contents] {
         var result = [String: Contents]()
-        for file in folder.content {
+        for file in files {
             switch file {
                 case let folder as Folder:
                     result[at.appendingPathComponent(folder.name).path] = .folder
@@ -144,7 +152,10 @@ package class TestFileSystem: FileManagerProtocol {
                 default: break
             }
         }
-        return result
+        return result    }
+
+    private func filesIn(folder: Folder, at url: URL) throws -> [String: Contents] {
+        return try filesFrom(files: folder.content, at: url)
     }
     
     @discardableResult
@@ -332,6 +343,28 @@ package class TestFileSystem: FileManagerProtocol {
             files:       Array( allContents[..<partitionIndex] ),
             directories: Array( allContents[partitionIndex...] )
         )
+    }
+
+    package func sizeOfDirectory(
+        at url: URL,
+        options: FileManager.DirectoryEnumerationOptions
+    ) throws -> Int64 {
+        filesLock.lock()
+        defer {
+            filesLock.unlock()
+        }
+
+        var total: Int64 = 0
+
+        let path = url.path.appendingTrailingSlash
+
+        for (subpath, item) in files where subpath.hasPrefix(path) {
+            if case let .file(data) = item {
+                total += Int64(data.count)
+            }
+        }
+
+        return total
     }
 
     package func uniqueTemporaryDirectory() -> URL {

--- a/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
+++ b/Sources/SwiftDocC/Benchmark/Metrics/OutputSize.swift
@@ -17,8 +17,9 @@ extension Benchmark {
         public static let displayName = "Total DocC archive size"
         public var result: MetricValue?
         
-        public init(archiveDirectory: URL) {
-            self.result = MetricValue(directory: archiveDirectory)
+        public init(archiveDirectory: URL, fileManager: some FileManagerProtocol = FileManager.default) {
+            self.result = MetricValue(directory: archiveDirectory,
+                                      fileManager: fileManager)
         }
     }
     
@@ -28,8 +29,9 @@ extension Benchmark {
         public static let displayName = "Data subdirectory size"
         public var result: MetricValue?
         
-        public init(dataDirectory: URL) {
-            self.result = MetricValue(directory: dataDirectory)
+        public init(dataDirectory: URL, fileManager: some FileManagerProtocol = FileManager.default) {
+            self.result = MetricValue(directory: dataDirectory,
+                                      fileManager: fileManager)
         }
     }
     
@@ -39,8 +41,9 @@ extension Benchmark {
         public static let displayName = "Index subdirectory size"
         public var result: MetricValue?
         
-        public init(indexDirectory: URL) {
-            self.result = MetricValue(directory: indexDirectory)
+        public init(indexDirectory: URL, fileManager: some FileManagerProtocol = FileManager.default) {
+            self.result = MetricValue(directory: indexDirectory,
+                                      fileManager: fileManager)
         }
     }
 }
@@ -52,21 +55,15 @@ extension MetricValue {
     /// in the given directory and not the disk space reserved for storing the
     /// corresponding files. This behavior helps produce real deltas between
     /// multiple benchmarks.
-    init?(directory: URL) {
-        guard let enumerator = FileManager.default.enumerator(
-            at: directory,
-            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey],
-            options: .skipsHiddenFiles,
-            errorHandler: nil
-        ) else {
+    init?(directory: URL, fileManager: some FileManagerProtocol) {
+        do {
+            let bytes = try fileManager.sizeOfDirectory(
+                at: directory,
+                options: [.skipsHiddenFiles]
+            )
+            self = .bytesOnDisk(bytes)
+        } catch {
             return nil
         }
-        
-        var bytes: Int64 = 0
-        for case let url as URL in enumerator {
-            bytes += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
-        }
-        
-        self = .bytesOnDisk(bytes)
     }
 }

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -76,6 +76,9 @@ public class NavigatorIndex {
     /// The url of the index.
     public let url: URL
     
+    /// The filesystem to use.
+    public var fileManager: any FileManagerProtocol
+
     /// The LMDB environment.
     var environment: LMDB.Environment?
     
@@ -184,6 +187,7 @@ public class NavigatorIndex {
         
         return NavigatorIndex(
             url: url,
+            fileManager: FileManager.default,
             presentationIdentifier: presentationIdentifier,
             bundleIdentifier: bundleIdentifier,
             environment: environment,
@@ -198,6 +202,7 @@ public class NavigatorIndex {
     
     fileprivate init(
         url: URL,
+        fileManager: any FileManagerProtocol,
         presentationIdentifier: String?,
         bundleIdentifier: String,
         environment: LMDB.Environment,
@@ -209,6 +214,7 @@ public class NavigatorIndex {
         navigatorTree: NavigatorTree
     ) {
         self.url = url
+        self.fileManager = fileManager
         self.presentationIdentifier = presentationIdentifier
         self.bundleIdentifier = bundleIdentifier
         self.environment = environment
@@ -228,8 +234,9 @@ public class NavigatorIndex {
      
      - Note: Don't expose this initializer as it's used **ONLY** for building an index.
      */
-    fileprivate init(withEmptyTree url: URL, bundleIdentifier: String) throws {
+    fileprivate init(withEmptyTree url: URL, fileManager: any FileManagerProtocol, bundleIdentifier: String) throws {
         self.url = url
+        self.fileManager = fileManager
         self.bundleIdentifier = bundleIdentifier
         self.presentationIdentifier = nil
         self.navigatorTree = NavigatorTree(root: NavigatorTree.rootNode(bundleIdentifier: bundleIdentifier))
@@ -495,6 +502,9 @@ extension NavigatorIndex {
         /// The output URL.
         public let outputURL: URL
         
+        /// The filesystem in which to work.
+        public let fileManager: any FileManagerProtocol
+
         /// The bundle name.
         public let bundleIdentifier: String
         
@@ -586,9 +596,10 @@ extension NavigatorIndex {
         ///    - groupByLanguage: Configure the builder to group the entries by language.
         ///    - writePathsOnDisk: Configure the builder to write each navigator item's path components to the location.
         ///    - usePageTitle: Configure the builder to use the "page title" instead of the "navigator title" as the title for each entry.
-        public init(archiveURL: URL? = nil, outputURL: URL, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
+        public init(archiveURL: URL? = nil, outputURL: URL, fileManager: any FileManagerProtocol, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
             self.archiveURL = archiveURL
             self.outputURL = outputURL
+            self.fileManager = fileManager
             self.bundleIdentifier = bundleIdentifier
             self.sortRootChildrenByName = sortRootChildrenByName
             self.groupByLanguage = groupByLanguage
@@ -603,12 +614,12 @@ extension NavigatorIndex {
             
             do {
                 // The folder in which the environment, if existing, will be overwritten.
-                if FileManager.default.fileExists(atPath: outputURL.path) {
-                    try FileManager.default.removeItem(at: outputURL)
+                if fileManager.fileExists(atPath: outputURL.path) {
+                    try fileManager.removeItem(at: outputURL)
                 }
-                try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(at: outputURL, withIntermediateDirectories: true, attributes: nil)
                 
-                navigatorIndex = try NavigatorIndex(withEmptyTree: outputURL, bundleIdentifier: bundleIdentifier)
+                navigatorIndex = try NavigatorIndex(withEmptyTree: outputURL, fileManager: fileManager, bundleIdentifier: bundleIdentifier)
             } catch {
                 // FIXME: This isn't a user-actionable error. We should throw a Swift.Error instead.
                 diagnostics.append(error.makeDiagnostic(source: outputURL,
@@ -1051,7 +1062,8 @@ extension NavigatorIndex {
                 let jsonNavigatorIndexURL = outputURL.appendingPathComponent("index.json")
                 do {
                     let renderIndexData = try jsonEncoder.encode(renderIndex)
-                    try renderIndexData.write(to: jsonNavigatorIndexURL)
+                    try fileManager.createFile(at: jsonNavigatorIndexURL,
+                                               contents: renderIndexData)
                 } catch {
                     // FIXME: This isn't a user-actionable error. We should throw a Swift.Error instead.
                     diagnostics.append(
@@ -1066,13 +1078,32 @@ extension NavigatorIndex {
                 return
             }
             
+            // LMDB can only write directly to the actual filesystem, so to deal with that we create a temporary directory and write into that instead.
+            let temporaryDirectory = FileManager.default.temporaryDirectory
+            let lmdbTemporaryURL = temporaryDirectory.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString).appendingPathComponent("lmdb")
+
+            do {
+                if FileManager.default.fileExists(atPath: lmdbTemporaryURL.path) {
+                    try FileManager.default.removeItem(at: lmdbTemporaryURL)
+                }
+                try FileManager.default.createDirectory(at: lmdbTemporaryURL, withIntermediateDirectories: true, attributes: [:])
+            } catch {
+                // FIXME: This isn't a user-actionable error. We should throw a Swift.Error instead.
+                diagnostics.append(
+                    error.makeDiagnostic(source: nil, severity: .error, summaryPrefix: "Failed to create temporary directory for LMDB generation"
+                    )
+                )
+
+                return
+
+            }
             let environment: LMDB.Environment
             if let alreadyDefinedEnvironment = navigatorIndex.environment {
                 environment = alreadyDefinedEnvironment
             } else {
                 do {
                     environment = try LMDB.Environment(
-                        path: navigatorIndex.url.path,
+                        path: lmdbTemporaryURL.path,
                         flags: [.noLock],
                         maxDBs: 4, mapSize: 100 * 1024 * 1024 // mapSize = 100MB
                     )
@@ -1234,7 +1265,22 @@ extension NavigatorIndex {
                                                         severity: .error,
                                                         summaryPrefix: "LMDB failed to store the content"))
             }
-                        
+
+            // Now move the LMDB database to the right place
+            do {
+                try FileManager.default.moveItem(
+                    at: lmdbTemporaryURL.appendingPathComponent("data.mdb"),
+                    to: navigatorIndex.url.appendingPathComponent("data.mdb"),
+                    on: fileManager
+                )
+                try? FileManager.default.removeItem(at: lmdbTemporaryURL)
+            } catch {
+                // FIXME: This isn't a user-actionable error. We should throw a Swift.Error instead.
+                diagnostics.append(error.makeDiagnostic(source: navigatorIndex.url,
+                                                        severity: .error,
+                                                        summaryPrefix: "Couldn't copy the LMDB index to its final location"))
+            }
+
             // FIXME: These aren't about issues with the developer's documentation. We should either remove these or find a different means to pass this information.
             diagnostics.append(Diagnostic(
                 source: outputURL,
@@ -1299,7 +1345,7 @@ extension NavigatorIndex {
             setup()
             
             let dataDirectory = archiveURL.appendingPathComponent(NodeURLGenerator.Path.dataFolderName, isDirectory: true)
-            for file in FileManager.default.recursiveFiles(startingPoint: dataDirectory) where file.pathExtension.lowercased() == "json" {
+            for file in fileManager.recursiveFiles(startingPoint: dataDirectory) where file.pathExtension.lowercased() == "json" {
                 do {
                     let data = try Data(contentsOf: file)
                     let renderNode = try RenderNode.decode(fromJSON: data)

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -202,7 +202,7 @@ public class NavigatorIndex {
     
     fileprivate init(
         url: URL,
-        fileManager: any FileManagerProtocol,
+        fileManager: any FileManagerProtocol = FileManager.default,
         presentationIdentifier: String?,
         bundleIdentifier: String,
         environment: LMDB.Environment,
@@ -234,7 +234,7 @@ public class NavigatorIndex {
      
      - Note: Don't expose this initializer as it's used **ONLY** for building an index.
      */
-    fileprivate init(withEmptyTree url: URL, fileManager: any FileManagerProtocol, bundleIdentifier: String) throws {
+    fileprivate init(withEmptyTree url: URL, fileManager: any FileManagerProtocol = FileManager.default, bundleIdentifier: String) throws {
         self.url = url
         self.fileManager = fileManager
         self.bundleIdentifier = bundleIdentifier
@@ -596,7 +596,7 @@ extension NavigatorIndex {
         ///    - groupByLanguage: Configure the builder to group the entries by language.
         ///    - writePathsOnDisk: Configure the builder to write each navigator item's path components to the location.
         ///    - usePageTitle: Configure the builder to use the "page title" instead of the "navigator title" as the title for each entry.
-        public init(archiveURL: URL? = nil, outputURL: URL, fileManager: any FileManagerProtocol, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
+        public init(archiveURL: URL? = nil, outputURL: URL, fileManager: any FileManagerProtocol = FileManager.default, bundleIdentifier: String, sortRootChildrenByName: Bool = false, groupByLanguage: Bool = false, writePathsOnDisk: Bool = true, usePageTitle: Bool = false) {
             self.archiveURL = archiveURL
             self.outputURL = outputURL
             self.fileManager = fileManager

--- a/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
+++ b/Sources/SwiftDocC/Indexing/Navigator/NavigatorIndex.swift
@@ -77,7 +77,7 @@ public class NavigatorIndex {
     public let url: URL
     
     /// The filesystem to use.
-    public var fileManager: any FileManagerProtocol
+    var fileManager: any FileManagerProtocol
 
     /// The LMDB environment.
     var environment: LMDB.Environment?

--- a/Sources/SwiftDocC/Infrastructure/Input Discovery/DataProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Input Discovery/DataProvider.swift
@@ -8,10 +8,10 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-package import Foundation
+public import Foundation
 
 /// A type that provides data for files.
-package protocol DataProvider {
+public protocol DataProvider {
     /// Returns the contents of the file at the specified location.
     ///
     /// - Parameter url: The url of the file to read.

--- a/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
+++ b/Sources/SwiftDocC/Utility/FileManagerProtocol.swift
@@ -8,7 +8,69 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-package import Foundation
+public import Foundation
+
+/// A read-only file manager.
+///
+/// A file-system manager is a type that's central to *managing* files on
+/// a file-system, it performs actions like creating new files, copying, renaming
+/// and deleting files, and organizing them in directories.
+///
+/// The Cocoa `FileManager` type is the default implementation of that protocol
+/// that manages files stored on disk.
+///
+/// Should you need a file system with a different storage, create your own
+/// protocol implementations to manage files in memory,
+/// on a network, in a database, or elsewhere.
+public protocol ReadOnlyFileManagerProtocol: DataProvider, Sendable {
+
+    /// Returns the data content of a file at the given path, if it exists.
+    func contents(atPath: String) -> Data?
+    /// Compares the contents of two files at the given paths.
+    func contentsEqual(atPath: String, andPath: String) -> Bool
+
+    /// The *current* directory path.
+    var currentDirectoryPath: String { get }
+
+    /// Returns `true` if a file or a directory exists at the given path.
+    func fileExists(atPath: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool
+    /// Returns `true` if a directory exists at the given path.
+    func directoryExists(atPath: String) -> Bool
+    /// Returns `true` if a file exists at the given path.
+    func fileExists(atPath: String) -> Bool
+    /// Copies a file from one location on the file-system to another.
+    func copyItem(at: URL, to: URL, on: any FileManagerProtocol) throws
+    /// Returns a list of items in a directory
+    func contentsOfDirectory(atPath path: String) throws -> [String]
+    func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions) throws -> [URL]
+
+    /// Returns the data content of a file at the given URL.
+    ///
+    /// - Parameters:
+    ///   - url: The location to create the file
+    ///
+    /// - Note: This method doesn't exist on ``FileManager``.
+    ///         There is a similar looking method but it doesn't provide information about potential errors.
+    ///
+    /// - Throws: If the file couldn't be read.
+    func contents(of url: URL) throws -> Data
+
+    /// Performs a shallow search of the specified directory and returns the file and directory URLs for the contained items.
+    ///
+    /// - Parameters:
+    ///   - url: The URL for the directory whose contents to enumerate.
+    ///   - mark: Options for the enumeration. Because this method performs only shallow enumerations, the only supported option is `skipsHiddenFiles`.
+    /// - Returns: The URLs of each file and directory that's contained in `url`.
+    func contentsOfDirectory(at url: URL, options mask: FileManager.DirectoryEnumerationOptions) throws -> (files: [URL], directories: [URL])
+
+    /// Calculates the total size of the files in the specified directory.
+    ///
+    /// - Parameters:
+    ///   - url: The URL for the directory to compute the size of.
+    /// - Returns: The total size, in bytes, of the specified directory and its contents.
+    func sizeOfDirectory(at url: URL, options mask: FileManager.DirectoryEnumerationOptions) throws -> Int64
+
+}
 
 /// A read-write file manager.
 ///
@@ -22,30 +84,16 @@ package import Foundation
 /// Should you need a file system with a different storage, create your own
 /// protocol implementations to manage files in memory,
 /// on a network, in a database, or elsewhere.
-package protocol FileManagerProtocol: DataProvider {
-    
-    /// Returns the data content of a file at the given path, if it exists.
-    func contents(atPath: String) -> Data?
-    /// Compares the contents of two files at the given paths.
-    func contentsEqual(atPath: String, andPath: String) -> Bool
+public protocol FileManagerProtocol: ReadOnlyFileManagerProtocol {
 
-    /// The *current* directory path.
-    var currentDirectoryPath: String { get }
-    
-    /// Returns `true` if a file or a directory exists at the given path.
-    func fileExists(atPath: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool
-    /// Returns `true` if a directory exists at the given path.
-    func directoryExists(atPath: String) -> Bool
-    /// Returns `true` if a file exists at the given path.
-    func fileExists(atPath: String) -> Bool
+    /// Removes an item from the filesystem.
+    func removeItem(at: URL) throws
     /// Copies a file from one location on the file-system to another.
     func _copyItem(at: URL, to: URL) throws // Use a different name than FileManager to work around https://github.com/swiftlang/swift-foundation/issues/1125
     /// Moves a file from one location on the file-system to another.
+    func moveItem(at: URL, to: URL, on: any FileManagerProtocol) throws
+    /// Moves a file from one location on the file-system to another.
     func moveItem(at: URL, to: URL) throws
-    /// Creates a new file folder at the given location.
-    func createDirectory(at: URL, withIntermediateDirectories: Bool, attributes: [FileAttributeKey : Any]?) throws
-    /// Removes a file from the given location.
-    func removeItem(at: URL) throws
     /// Returns a list of items in a directory
     func contentsOfDirectory(atPath path: String) throws -> [String]
     func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?, options mask: FileManager.DirectoryEnumerationOptions) throws -> [URL]
@@ -67,17 +115,6 @@ package protocol FileManagerProtocol: DataProvider {
     /// - Throws: If the file couldn't be created with the specified contents.
     func createFile(at: URL, contents: Data) throws
     
-    /// Returns the data content of a file at the given URL.
-    ///
-    /// - Parameters:
-    ///   - url: The location to create the file
-    ///
-    /// - Note: This method doesn't exist on ``FileManager``.
-    ///         There is a similar looking method but it doesn't provide information about potential errors.
-    ///
-    /// - Throws: If the file couldn't be read.
-    func contents(of url: URL) throws -> Data
-    
     /// Creates a file with the given contents at the given url with the specified
     /// writing options.
     ///
@@ -88,52 +125,58 @@ package protocol FileManagerProtocol: DataProvider {
     ///              writing options of the file manager.
     func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws
 
-    /// Performs a shallow search of the specified directory and returns the file and directory URLs for the contained items.
+    /// Creates a directory at the given url with the specified attributes.
     ///
     /// - Parameters:
-    ///   - url: The URL for the directory whose contents to enumerate.
-    ///   - mark: Options for the enumeration. Because this method performs only shallow enumerations, the only supported option is `skipsHiddenFiles`.
-    /// - Returns: The URLs of each file and directory that's contained in `url`.
-    func contentsOfDirectory(at url: URL, options mask: FileManager.DirectoryEnumerationOptions) throws -> (files: [URL], directories: [URL])
+    ///   - at: The location to create the directory
+    ///   - withIntermediateDirectories: If `true`, create any parent directories
+    ///         that do not currently exist
+    ///   - attributes: Attributes to set on the newly created directory
+    ///
+    /// - Throws: If the directory couldn't be created.
+    func createDirectory(at: URL, withIntermediateDirectories: Bool, attributes: [FileAttributeKey: Any]?) throws
 }
 
-extension FileManagerProtocol {
+extension ReadOnlyFileManagerProtocol {
+
+    public func contentsEqual(atPath path1: String, andPath path2: String) -> Bool {
+        guard let content1 = contents(atPath: path1),
+              let content2 = contents(atPath: path2) else {
+            return false
+        }
+
+        return content1 == content2
+    }
+
     /// Returns a Boolean value that indicates whether a directory exists at a specified path.
-    package func directoryExists(atPath path: String) -> Bool {
+    public func directoryExists(atPath path: String) -> Bool {
         var isDirectory = ObjCBool(booleanLiteral: false)
         let fileExistsAtPath = fileExists(atPath: path, isDirectory: &isDirectory)
         return fileExistsAtPath && isDirectory.boolValue
     }
-}
 
-/// Add compliance to `FileManagerProtocol` to `FileManager`,
-/// most of the methods are already implemented in Foundation.
-extension FileManager: FileManagerProtocol {
-    // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
-    package func contents(of url: URL) throws -> Data {
-        return try Data(contentsOf: url)
-    }
-    
-    // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
-    package func createFile(at location: URL, contents: Data) throws {
-        try contents.write(to: location, options: .atomic)
-    }
-    
-    package func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws {
-        if let writingOptions {
-            try contents.write(to: location, options: writingOptions)
+    public func copyItem(at source: URL, to destination: URL, on otherFileManager: any FileManagerProtocol) throws {
+        if directoryExists(atPath: source.path) {
+            if destination.path != "/" {
+                if otherFileManager.directoryExists(atPath: destination.path) {
+                    try otherFileManager.removeItem(at: destination)
+                }
+                try otherFileManager.createDirectory(at: destination, withIntermediateDirectories: false, attributes: [:])
+            }
+            for item in try contentsOfDirectory(at: source, includingPropertiesForKeys: [], options: []) {
+                if let relativeItem = item.relative(to: source) {
+                    let destinationItem = destination.appendingPathComponent(relativeItem.path)
+                    try copyItem(at: item, to: destinationItem, on: otherFileManager)
+                }
+            }
         } else {
-            try contents.write(to: location)
+            let data = try contents(of: source)
+            try otherFileManager.createFile(at: destination, contents: data)
         }
-    }
-    
-    // Because we shadow 'FileManager.temporaryDirectory' in our tests, we can't also use 'temporaryDirectory' in FileManagerProtocol/
-    package func uniqueTemporaryDirectory() -> URL {
-        temporaryDirectory.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: true)
+
     }
 
-    // This method doesn't exist on `FileManger`. We define it on the protocol to enable the FileManager to provide an implementation that avoids repeated reads to discover which contained items are files and which are directories.
-    package func contentsOfDirectory(at url: URL, options mask: DirectoryEnumerationOptions) throws -> (files: [URL], directories: [URL]) {
+    public func contentsOfDirectory(at url: URL, options mask: FileManager.DirectoryEnumerationOptions) throws -> (files: [URL], directories: [URL]) {
         var allContents = try contentsOfDirectory(at: url, includingPropertiesForKeys: [.isDirectoryKey], options: .skipsHiddenFiles)
 
         let partitionIndex = try allContents.partition {
@@ -144,8 +187,45 @@ extension FileManager: FileManagerProtocol {
             directories: Array( allContents[partitionIndex...] )
         )
     }
+
+}
+
+extension FileManagerProtocol {
+
+    public func moveItem(at source: URL, to destination: URL, on otherFileManager: any FileManagerProtocol) throws {
+        try self.copyItem(at: source, to: destination, on: otherFileManager)
+        try self.removeItem(at: source)
+    }
+
+}
+
+/// Add compliance to `FileManagerProtocol` to `FileManager`,
+/// most of the methods are already implemented in Foundation.
+extension FileManager: FileManagerProtocol {
+    // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
+    public func contents(of url: URL) throws -> Data {
+        return try Data(contentsOf: url)
+    }
     
-    package func _copyItem(at source: URL, to destination: URL) throws {
+    // This method doesn't exist on `FileManager`. There is a similar looking method but it doesn't provide information about potential errors.
+    public func createFile(at location: URL, contents: Data) throws {
+        try contents.write(to: location, options: .atomic)
+    }
+    
+    public func createFile(at location: URL, contents: Data, options writingOptions: NSData.WritingOptions?) throws {
+        if let writingOptions {
+            try contents.write(to: location, options: writingOptions)
+        } else {
+            try contents.write(to: location)
+        }
+    }
+    
+    // Because we shadow 'FileManager.temporaryDirectory' in our tests, we can't also use 'temporaryDirectory' in FileManagerProtocol/
+    public func uniqueTemporaryDirectory() -> URL {
+        temporaryDirectory.appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString, isDirectory: true)
+    }
+
+    public func _copyItem(at source: URL, to destination: URL) throws {
         // Call `NSFileManager/copyItem(at:to:)` and catch the error to workaround https://github.com/swiftlang/swift-foundation/issues/1125
         do {
             try copyItem(at: source, to: destination)
@@ -195,4 +275,28 @@ extension FileManager: FileManagerProtocol {
             }
         }
     }
+
+    private enum FileManagerError: Error {
+        case unableToEnumerate
+    }
+
+    public func sizeOfDirectory(at url: URL, options mask: FileManager.DirectoryEnumerationOptions) throws -> Int64 {
+        guard let enumerator = enumerator(
+            at: url,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey],
+            options: .skipsHiddenFiles,
+            errorHandler: nil
+        ) else {
+            throw FileManagerError.unableToEnumerate
+        }
+
+        var bytes: Int64 = 0
+        for case let url as URL in enumerator {
+            bytes += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        }
+
+        return bytes
+    }
 }
+
+extension FileManager: ReadOnlyFileManagerProtocol {}

--- a/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -27,9 +27,9 @@ class ConvertSubcommandTests: XCTestCase {
         // by the machine environment.
         let priorWorkingDirectory = FileManager.default.currentDirectoryPath
         let temporaryDirectory = try createTemporaryDirectory()
-        FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path)
+        _ = FileManager.default.changeCurrentDirectoryPath(temporaryDirectory.path)
         addTeardownBlock {
-            FileManager.default.changeCurrentDirectoryPath(priorWorkingDirectory)
+            _ = FileManager.default.changeCurrentDirectoryPath(priorWorkingDirectory)
         }
 
         // By default, send all warnings to `.none` instead of filling the

--- a/Tests/DocCCommandLineTests/ConvertActionIndexerTests.swift
+++ b/Tests/DocCCommandLineTests/ConvertActionIndexerTests.swift
@@ -31,7 +31,7 @@ class ConvertActionIndexerTests: XCTestCase {
             let renderNode = try converter.convert(context.entity(with: reference))
 
             let tempIndexURL = try createTemporaryDirectory(named: "index")
-            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, bundleID: inputs.id)
+            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, fileManager: FileManager.default, bundleID: inputs.id)
             indexer.index(renderNode)
             XCTAssertTrue(indexer.finalize(emitJSON: false, emitLMDB: false).isEmpty)
             let treeDump = try XCTUnwrap(indexer.dumpTree())
@@ -56,7 +56,7 @@ class ConvertActionIndexerTests: XCTestCase {
             let renderNode2 = try converter.convert(context.entity(with: reference2))
 
             let tempIndexURL = try createTemporaryDirectory(named: "index")
-            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, bundleID: inputs.id)
+            let indexer = try ConvertAction.Indexer(outputURL: tempIndexURL, fileManager: FileManager.default, bundleID: inputs.id)
             indexer.index(renderNode1)
             indexer.index(renderNode2)
             XCTAssertTrue(indexer.finalize(emitJSON: false, emitLMDB: false).isEmpty)

--- a/Tests/DocCCommandLineTests/ConvertActionTests.swift
+++ b/Tests/DocCCommandLineTests/ConvertActionTests.swift
@@ -334,7 +334,7 @@ class ConvertActionTests: XCTestCase {
         
         let targetURL = target.absoluteURL.appendingPathComponent("output")
         
-        XCTAssertNoThrow(try action.moveOutput(from: source.absoluteURL, to: targetURL))
+        XCTAssertNoThrow(try ConvertAction.moveOutput(from: source.absoluteURL, to: targetURL, fileManager: testDataProvider))
         XCTAssertTrue(testDataProvider.fileExists(atPath: targetURL.path, isDirectory: nil))
         XCTAssertFalse(testDataProvider.fileExists(atPath: source.absoluteURL.path, isDirectory: nil))
     }
@@ -368,7 +368,7 @@ class ConvertActionTests: XCTestCase {
         
         let targetURL = target.absoluteURL.appendingPathComponent("target").appendingPathComponent("output")
         
-        XCTAssertThrowsError(try action.moveOutput(from: source.absoluteURL, to: targetURL))
+        XCTAssertThrowsError(try ConvertAction.moveOutput(from: source.absoluteURL, to: targetURL, fileManager: testDataProvider))
     }
 
     func testConvertDoesNotLowercasesResourceFileNames() async throws {
@@ -2859,7 +2859,7 @@ class ConvertActionTests: XCTestCase {
             outOfProcessResolver: nil,
             analyze: false,
             targetDirectory: targetURL,
-            htmlTemplateDirectory: Folder.emptyHTMLTemplateDirectory.absoluteURL,
+            htmlTemplateDirectory: nil,
             emitDigest: false,
             currentPlatforms: nil,
             fileManager: fileSystem,
@@ -2882,6 +2882,8 @@ class ConvertActionTests: XCTestCase {
         │     ├─ image-name@2x.png
         │     ├─ image-name~dark.png
         │     ╰─ image-name~dark@2x.png
+        ├─ index/
+        │  ╰─ index.json
         ├─ metadata.json
         ╰─ videos/
            ╰─ unit-test/

--- a/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
@@ -172,6 +172,7 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
         let htmlConsumer = try FileWritingHTMLContentConsumer(
             targetFolder: URL(fileURLWithPath: "/output-dir"),
             fileManager: fileSystem,
+            outputFileManager: fileSystem,
             htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
             customHeader: nil,
             customFooter: nil,
@@ -531,6 +532,7 @@ final class FileWritingHTMLContentConsumerTests: XCTestCase {
                 let htmlConsumer = try FileWritingHTMLContentConsumer(
                     targetFolder: URL(fileURLWithPath: "/output-dir"),
                     fileManager: fileSystem,
+                    outputFileManager: fileSystem,
                     htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
                     customHeader: nil,
                     customFooter: nil,

--- a/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
@@ -171,6 +171,7 @@ struct FileWritingHTMLContentConsumerTests {
         let htmlConsumer = try FileWritingHTMLContentConsumer(
             targetFolder: URL(fileURLWithPath: "/output-dir"),
             fileManager: fileSystem,
+            outputFileManager: fileSystem,
             htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
             customHeader: nil,
             customFooter: nil,
@@ -534,6 +535,7 @@ struct FileWritingHTMLContentConsumerTests {
         let htmlConsumer = try FileWritingHTMLContentConsumer(
             targetFolder: URL(fileURLWithPath: "/output-dir"),
             fileManager: fileSystem,
+            outputFileManager: fileSystem,
             htmlTemplate: URL(fileURLWithPath: "/template/index.html"),
             customHeader: nil,
             customFooter: nil,

--- a/Tests/DocCCommandLineTests/JSONEncodingRenderNodeWriterTests.swift
+++ b/Tests/DocCCommandLineTests/JSONEncodingRenderNodeWriterTests.swift
@@ -31,6 +31,7 @@ class JSONEncodingRenderNodeWriterTests: XCTestCase {
         let writer = JSONEncodingRenderNodeWriter(
             targetFolder: URL(fileURLWithPath: String(repeating: "A", count: 4096)),
             fileManager: FileManager.default,
+            outputFileManager: FileManager.default,
             transformForStaticHostingIndexHTML: indexHTML
         )
         

--- a/Tests/DocCCommandLineTests/JSONEncodingRenderNodeWriterTests.swift
+++ b/Tests/DocCCommandLineTests/JSONEncodingRenderNodeWriterTests.swift
@@ -31,7 +31,6 @@ class JSONEncodingRenderNodeWriterTests: XCTestCase {
         let writer = JSONEncodingRenderNodeWriter(
             targetFolder: URL(fileURLWithPath: String(repeating: "A", count: 4096)),
             fileManager: FileManager.default,
-            outputFileManager: FileManager.default,
             transformForStaticHostingIndexHTML: indexHTML
         )
         

--- a/Tests/DocCCommandLineTests/MergeActionTests.swift
+++ b/Tests/DocCCommandLineTests/MergeActionTests.swift
@@ -936,9 +936,9 @@ class MergeActionTests: XCTestCase {
             let outputPath = baseOutputDir.appendingPathComponent("\(name).doccarchive", isDirectory: true)
             
             let realTempURL = try createTemporaryDirectory() // The navigator builder only support real file systems
-            let indexer = try ConvertAction.Indexer(outputURL: realTempURL, bundleID: inputs.id)
+            let indexer = try ConvertAction.Indexer(outputURL: realTempURL, fileManager: FileManager.default, bundleID: inputs.id)
             
-            let outputConsumer = ConvertFileWritingConsumer(targetFolder: outputPath, bundleRootFolder: catalogDir, fileManager: fileSystem, context: context, indexer: indexer, transformForStaticHostingIndexHTML: nil, bundleID: inputs.id)
+            let outputConsumer = ConvertFileWritingConsumer(targetFolder: outputPath, bundleRootFolder: catalogDir, fileManager: fileSystem, outputFileManager: fileSystem, context: context, indexer: indexer, transformForStaticHostingIndexHTML: nil, bundleID: inputs.id)
             
             try await ConvertActionConverter.convert(context: context, outputConsumer: outputConsumer, htmlContentConsumer: nil, sourceRepository: nil, emitDigest: false, documentationCoverageOptions: .noCoverage)
             
@@ -1310,7 +1310,7 @@ class MergeActionTests: XCTestCase {
     }
 }
 
-private extension TestFileSystem {
+private extension ReadOnlyFileManagerProtocol {
     func renderNode(atPath path: String) throws -> RenderNode {
         let data = try contents(of: URL(fileURLWithPath: path))
         

--- a/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
+++ b/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
@@ -80,8 +80,6 @@ class StaticHostingWithContentTests: XCTestCase {
                 includeContentInEachHTMLFile: includeHTMLContent,
                 hostingBasePath: basePath
             )
-            // The old `Indexer` type doesn't work with virtual file systems.
-            action._completelySkipBuildingIndex = true
             
             _ = try await action.perform(logHandle: .none)
             
@@ -99,6 +97,8 @@ class StaticHostingWithContentTests: XCTestCase {
             ├─ images/
             │  ╰─ Something/
             ├─ index.html
+            ├─ index/
+            │  ╰─ index.json
             ├─ metadata.json
             ╰─ videos/
                ╰─ Something/

--- a/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
+++ b/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
@@ -79,8 +79,6 @@ struct StaticHostingWithContentTests {
             includeContentInEachHTMLFile: includeHTMLContent,
             hostingBasePath: basePath
         )
-        // The old `Indexer` type doesn't work with virtual file systems.
-        action._completelySkipBuildingIndex = true
         
         _ = try await action.perform(logHandle: .none)
         
@@ -98,6 +96,8 @@ struct StaticHostingWithContentTests {
         ├─ images/
         │  ╰─ Something/
         ├─ index.html
+        ├─ index/
+        │  ╰─ index.json
         ├─ metadata.json
         ╰─ videos/
            ╰─ Something/

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -252,7 +252,7 @@ class ExternalRenderNodeTests: XCTestCase {
         let renderContext = RenderContext(documentationContext: context)
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
         for externalLink in context.externalCache {
             let externalRenderNode = ExternalRenderNode(externalEntity: externalLink.value, bundleIdentifier: context.inputs.id)
@@ -355,7 +355,7 @@ class ExternalRenderNodeTests: XCTestCase {
         let renderContext = RenderContext(documentationContext: context)
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
         for externalLink in context.externalCache {
             let externalRenderNode = ExternalRenderNode(externalEntity: externalLink.value, bundleIdentifier: context.inputs.id)
@@ -433,7 +433,7 @@ class ExternalRenderNodeTests: XCTestCase {
         let renderContext = RenderContext(documentationContext: context)
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
         for externalLink in context.externalCache {
             let externalRenderNode = ExternalRenderNode(externalEntity: externalLink.value, bundleIdentifier: context.inputs.id)
@@ -558,7 +558,7 @@ class ExternalRenderNodeTests: XCTestCase {
         XCTAssert(context.diagnostics.isEmpty, "Unexpectedly found problems: \(context.diagnostics.map(\.summary))")
 
         let renderIndexFolder = try createTemporaryDirectory()
-        let indexBuilder = NavigatorIndex.Builder(outputURL: renderIndexFolder, bundleIdentifier: bundle.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let indexBuilder = NavigatorIndex.Builder(outputURL: renderIndexFolder, fileManager: FileManager.default, bundleIdentifier: bundle.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
         indexBuilder.setup()
         let outputConsumer = TestExternalRenderNodeOutputConsumer(indexBuilder: indexBuilder)
 

--- a/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/NavigatorIndexTests.swift
@@ -433,7 +433,7 @@ Root
     func testNavigatorIndexGenerationEmpty() throws {
         let targetURL = try createTemporaryDirectory()
         
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier)
         builder.setup()
         builder.finalize()
                
@@ -497,7 +497,7 @@ Root
 
         let targetURL = try createTemporaryDirectory()
 
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier)
         builder.setup()
         try builder.index(renderNode: renderNode)
         builder.finalize(emitJSONRepresentation: false, emitLMDBRepresentation: false)
@@ -514,7 +514,7 @@ Root
         // Create an index 10 times to ensure we have not non-deterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = try createTemporaryDirectory()
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -696,7 +696,7 @@ Root
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -742,8 +742,8 @@ Root
         let renderContext = RenderContext(documentationContext: context)
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         
-        let fromMemoryBuilder  = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
-        let fromDecodedBuilder = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let fromMemoryBuilder  = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
+        let fromDecodedBuilder = NavigatorIndex.Builder(outputURL: try createTemporaryDirectory(), fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true, groupByLanguage: true)
         fromMemoryBuilder.setup()
         fromDecodedBuilder.setup()
         
@@ -822,7 +822,7 @@ Root
         let jsonData = try Data(contentsOf: jsonFile)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
         
         let renderNode = try XCTUnwrap(RenderJSONDecoder.makeDecoder().decode(RenderNode.self, from: jsonData))
@@ -1045,7 +1045,7 @@ Root
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
 
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier)
         builder.setup()
 
         for identifier in context.knownPages {
@@ -1078,7 +1078,7 @@ Root
         // Create an index 10 times to ensure we have not non-deterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = try createTemporaryDirectory()
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, usePageTitle: true)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, usePageTitle: true)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -1121,7 +1121,7 @@ Root
         // Create an index 10 times to ensure we have not non-deterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = try createTemporaryDirectory()
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, writePathsOnDisk: false)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true, writePathsOnDisk: false)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -1194,7 +1194,7 @@ Root
         // Create an index 10 times to ensure we have no non-deterministic behavior across builds
         for _ in 0..<10 {
             let targetURL = try createTemporaryDirectory()
-            let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
+            let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
             builder.setup()
             
             for identifier in context.knownPages {
@@ -1254,7 +1254,7 @@ Root
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -1358,7 +1358,7 @@ Root
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -1384,7 +1384,7 @@ Root
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: testBundleIdentifier, sortRootChildrenByName: true)
         builder.setup()
         
         // Change the path hasher to the FNV-1 implementation and make sure paths and mappings are still working.
@@ -1840,7 +1840,7 @@ Root
         let converter = DocumentationNodeConverter(context: context)
         
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: "org.swift.docc.test", sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: "org.swift.docc.test", sortRootChildrenByName: true)
         builder.setup()
         
         for identifier in context.knownPages {
@@ -2167,7 +2167,7 @@ Root
         let renderContext = RenderContext(documentationContext: context)
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
         builder.setup()
         for identifier in context.knownPages {
             let entity = try context.entity(with: identifier)
@@ -2212,7 +2212,7 @@ Root
         
         let renderContext = RenderContext(documentationContext: context)
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: context.inputs.id.rawValue, sortRootChildrenByName: true)
         builder.setup()
         for identifier in context.knownPages {
             let entity = try context.entity(with: identifier)
@@ -2264,7 +2264,7 @@ Root
         let converter = DocumentationContextConverter(context: context, renderContext: renderContext)
 
         let targetURL = try createTemporaryDirectory()
-        let builder = NavigatorIndex.Builder(outputURL: targetURL, bundleIdentifier: bundleIdentifier, sortRootChildrenByName: true, groupByLanguage: true)
+        let builder = NavigatorIndex.Builder(outputURL: targetURL, fileManager: FileManager.default, bundleIdentifier: bundleIdentifier, sortRootChildrenByName: true, groupByLanguage: true)
         builder.setup()
 
         for identifier in context.knownPages {

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -797,6 +797,7 @@ final class RenderIndexTests: XCTestCase {
         let indexDirectory = try createTemporaryDirectory()
         let builder = NavigatorIndex.Builder(
             outputURL: indexDirectory,
+            fileManager: FileManager.default,
             bundleIdentifier: context.inputs.id.rawValue,
             sortRootChildrenByName: true
         )

--- a/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/RenderIndexTests.swift
@@ -842,6 +842,7 @@ final class RenderIndexTests: XCTestCase {
         let indexDirectory = try createTemporaryDirectory()
         let builder = NavigatorIndex.Builder(
             outputURL: indexDirectory,
+            fileManager: FileManager.default,
             bundleIdentifier: context.inputs.id.rawValue,
             sortRootChildrenByName: true
         )


### PR DESCRIPTION
In order to output compressed archives, we need first to split `FileManagerProtocol` into `ReadOnlyFileManagerProtocol` and (read-write) `FileManagerProtocol`, then we need to add `outputFileSystem` arguments to various things in the codebase, to reflect the fact that we are now reading from one place and writing to another.

rdar://181216501