### PR TITLE
[4/n] Add result builder for constructing HTML element hierarchies

### DIFF
--- a/Sources/DocCHTML/CMakeLists.txt
+++ b/Sources/DocCHTML/CMakeLists.txt
@@ -8,6 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_library(DocCHTML STATIC
+  HTMLBuilder.swift
   HTMLFormatter.swift
   HTMLNode.swift
   HTMLNode+Attributes.swift

--- a/Sources/DocCHTML/HTMLBuilder.swift
+++ b/Sources/DocCHTML/HTMLBuilder.swift
@@ -1,0 +1,177 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@resultBuilder
+package struct HTMLBuilder {
+    
+    // Support passing HTMLNode values as expressions
+    package static func buildExpression(_ expression: consuming HTMLNode) -> HTMLNode {
+        expression
+    }
+    
+    // Support passing strings as expressions
+    package static func buildExpression(_ text: consuming String) -> HTMLNode {
+        .text(consume text)
+    }
+    
+    // Support `if` statements without an `else` statement.
+    package static func buildOptional(_ component: consuming HTMLNode?) -> HTMLNode { component ?? .text("") }
+
+    // Support `if-else` and `switch` statements.
+    package static func buildEither(first  component: consuming HTMLNode) -> HTMLNode { component }
+    package static func buildEither(second component: consuming HTMLNode) -> HTMLNode { component }
+
+    // Support `for-in` loops
+    package typealias Loop = [ [HTMLNode] ]
+    package static func buildArray(_ components: consuming Loop) -> Loop {
+        components
+    }
+    
+    // This implementation makes a compromise between expressivity and performance.
+    // It can be difficult to achieve good performance in a result builder that builds an array and also supports loops.
+    //
+    // The naive implementation makes every component an array and flat-maps the block to create the array result:
+    //
+    //     static func buildExpression(_ expression: HTMLNode) -> [HTMLNode] { [expression] }
+    //     package static func buildBlock(_ components: [HTMLNode]...) -> [HTMLNode] { components.flatMap { $0 } }
+    //
+    // Such an implementation is short but can be a bit inefficient, hiding `[ [a], [b], [c] ].flatMap { $0 }` behind:
+    //
+    //     let _e1 = Builder.buildExpression(expr1)
+    //     let _e2 = Builder.buildExpression(expr2)
+    //     let _e3 = Builder.buildExpression(expr3)
+    //     return Builder.buildBlock(_e1, _e2, _e3)
+    //
+    // In some measurements, depending on the size of the blocks and ratio between basic blocks and loops,
+    // this can be 3-4 times slower than direct creation / manipulation of an array.
+    //
+    // Using `buildPartialBlock(...)`, introduced in SE-0348, one can improve performance over the naive implementation by about 30-35%.
+    // By also leveraging a "partial" component that doesn't wrap individual expressions in arrays and using `buildFinalResult(...)` to create the final array,
+    // one can push this another 15–20%, resulting in roughly a 50% improvement over the naive implementation, but still 2 times slower than direct array creation.
+    // The resulting implementation becomes a series of `append()` calls, hiding behind:
+    //
+    //    let _e1 = Builder.buildExpression(expr1)
+    //    let _e2 = Builder.buildExpression(expr2)
+    //    let _e3 = Builder.buildExpression(expr3)
+    //    let _v1 = Builder.buildPartialBlock(first: _e1)
+    //    let _v2 = Builder.buildPartialBlock(accumulated: _v1, next: _e2)
+    //    let _v3 = Builder.buildPartialBlock(accumulated: _v2, next: _e3)
+    //    return Builder.buildFinalResult(_v3)
+    //
+    // If we _didn't_ need to support loops in the builder, a naive implementation like below would come quite close to the performance of direct array creation:
+    //
+    //     static func buildExpression(_ expression: HTMLNode) -> HTMLNode { expression }
+    //     package static func buildBlock(_ components: HTMLNode...) -> [HTMLNode] { components }
+    //
+    // Because this builder isn't intended to be a general purpose library, we can put some restrictions on how loops can be used.
+    // Specifically, by only supporting a single loop in a given scope, with some number of non-loops before and after,
+    // we can implement specific overloads for each location that the loop may appear in the block (see below).
+    // This offers a significant improvement in performance that's about 2.2 times faster than the initial implementation and only 1.15 times slower than direct array creation.
+    
+    // Support any number of non-loop expressions / components.
+    package static func buildBlock(_ rest: HTMLNode...) -> [HTMLNode] {
+        rest
+    }
+    
+    // The ten overloads below adds support for exactly one loop within a scope,
+    // when preceded by 0 through 9 non-loop expressions/components and followed by any number of non-loop expressions/components.
+    //
+    // If we find more cases that we need to build but aren't supported by this, we can add more `buildBlock` overloads below.
+    
+    package static func buildBlock(_ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = []
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ node3: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2, node3]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ node3: HTMLNode, _ node4: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2, node3, node4]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ node3: HTMLNode, _ node4: HTMLNode, _ node5: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2, node3, node4, node5]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ node3: HTMLNode, _ node4: HTMLNode, _ node5: HTMLNode, _ node6: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2, node3, node4, node5, node6]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ node3: HTMLNode, _ node4: HTMLNode, _ node5: HTMLNode, _ node6: HTMLNode, _ node7: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2, node3, node4, node5, node6, node7]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+
+    package static func buildBlock(_ node0: HTMLNode, _ node1: HTMLNode, _ node2: HTMLNode, _ node3: HTMLNode, _ node4: HTMLNode, _ node5: HTMLNode, _ node6: HTMLNode, _ node7: HTMLNode, _ node8: HTMLNode, _ loop: Loop, _ rest: HTMLNode...) -> [HTMLNode] {
+        var result: [HTMLNode] = [node0, node1, node2, node3, node4, node5, node6, node7, node8]
+        for elements in loop {
+            result.append(contentsOf: elements)
+        }
+        result.append(contentsOf: rest)
+        return result
+    }
+}

--- a/Sources/DocCHTML/HTMLNode+Tags.swift
+++ b/Sources/DocCHTML/HTMLNode+Tags.swift
@@ -21,8 +21,8 @@
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<html>` element.
-package func html(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.html, attributes: attributes , contents: contents)
+package func html(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.html, attributes: attributes , contents: contents())
 }
 
 // MARK: - Metadata
@@ -35,8 +35,8 @@ package func html(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<head>` element.
-package func head(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.head, attributes: attributes, contents: contents)
+package func head(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.head, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<base>` element with the given attributes.
@@ -97,8 +97,8 @@ package func title(attributes: [HTMLNode.Attribute] = [], text: String) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<body>` element.
-package func body(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.body, attributes: attributes, contents: contents)
+package func body(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.body, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<address>` element with the given attributes and contents.
@@ -109,8 +109,8 @@ package func body(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<address>` element.
-func address(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.address, attributes: attributes, contents: contents)
+func address(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.address, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<article>` element with the given attributes and contents.
@@ -121,8 +121,8 @@ func address(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTM
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<article>` element.
-package func article(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.article, attributes: attributes, contents: contents)
+package func article(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.article, attributes: attributes, contents: contents())
 }
 /// Creates a new `<aside>` element with the given attributes and contents.
 
@@ -133,8 +133,8 @@ package func article(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<aside>` element.
-package func aside(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.aside, attributes: attributes, contents: contents)
+package func aside(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.aside, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<footer>` element with the given attributes and contents.
@@ -145,8 +145,8 @@ package func aside(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<footer>` element.
-package func footer(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.footer, attributes: attributes, contents: contents)
+package func footer(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.footer, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<h1>` element with the given attributes and contents.
@@ -157,8 +157,8 @@ package func footer(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode])
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<h1>` element.
-package func h1(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.h1, attributes: attributes, contents: contents)
+package func h1(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.h1, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<h2>` element with the given attributes and contents.
@@ -169,8 +169,8 @@ package func h1(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<h2>` element.
-package func h2(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.h2, attributes: attributes, contents: contents)
+package func h2(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.h2, attributes: attributes, contents: contents())
 }
 
 /// Creates a new heading element of a given level with the given attributes and contents.
@@ -179,7 +179,7 @@ package func h2(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<h1>`-`<h6>` element.
-func heading(level: Int, attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func heading(level: Int, _ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
     let tag: HTMLNode._Tag = switch level {
         case 1:  .h1
         case 2:  .h2
@@ -188,7 +188,7 @@ func heading(level: Int, attributes: [HTMLNode.Attribute] = [], contents: [HTMLN
         case 5:  .h5
         default: .h6
     }
-    return ._element(tag, attributes: attributes, contents: contents)
+    return ._element(tag, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<hgroup>` element with the given attributes and contents.
@@ -202,7 +202,8 @@ func heading(level: Int, attributes: [HTMLNode.Attribute] = [], contents: [HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<hgroup>` element.
-package func hgroup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+package func hgroup(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy {
         switch $0._tag {
             case .p, .h1, .h2, .h3, .h4, .h5, .h6: true
@@ -220,8 +221,8 @@ package func hgroup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode])
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<header>` element.
-package func header(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.header, attributes: attributes, contents: contents)
+package func header(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.header, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<nav>` element with the given attributes and contents.
@@ -232,8 +233,8 @@ package func header(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode])
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<nav>` element.
-package func nav(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.nav, attributes: attributes, contents: contents)
+package func nav(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.nav, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<section>` element with the given attributes and contents.
@@ -244,8 +245,8 @@ package func nav(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) ->
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<section>` element.
-package func section(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.section, attributes: attributes, contents: contents)
+package func section(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.section, attributes: attributes, contents: contents())
 }
 
 // MARK: - Grouping
@@ -259,8 +260,8 @@ package func section(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<blockquote>` element.
-func blockquote(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.blockquote, attributes: attributes, contents: contents)
+func blockquote(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.blockquote, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<dd>` element with the given attributes and contents.
@@ -271,8 +272,8 @@ func blockquote(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<dd>` element.
-func dd(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.dd, attributes: attributes, contents: contents)
+func dd(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.dd, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<div>` element with the given attributes and contents.
@@ -285,8 +286,8 @@ func dd(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<div>` element.
-func div(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.div, attributes: attributes, contents: contents)
+func div(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.div, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<dl>` element with the given attributes and contents.
@@ -298,7 +299,8 @@ func div(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<dl>` element.
-package func dl(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+package func dl(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .dt || $0._tag == .dd }, "<dl> tags can only contain <dt> and <dd> tags")
     return ._element(.dl, attributes: attributes, contents: contents)
 }
@@ -311,8 +313,8 @@ package func dl(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<dt>` element.
-func dt(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.dt, attributes: attributes, contents: contents)
+func dt(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.dt, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<figcaption>` element with the given attributes and contents.
@@ -323,8 +325,8 @@ func dt(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<figcaption>` element.
-func figcaption(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.figcaption, attributes: attributes, contents: contents)
+func figcaption(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.figcaption, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<figure>` element with the given attributes and contents.
@@ -335,8 +337,8 @@ func figcaption(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<figure>` element.
-func figure(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.figure, attributes: attributes, contents: contents)
+func figure(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.figure, attributes: attributes, contents: contents())
 }
 
 /// A `<hr>` element.
@@ -354,8 +356,8 @@ package let hr = HTMLNode._voidElement(.hr)
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<li>` element.
-package func li(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.li, attributes: attributes, contents: contents)
+package func li(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.li, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<main>` element with the given attributes and contents.
@@ -368,8 +370,8 @@ package func li(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<main>` element.
-func main(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.main, attributes: attributes, contents: contents)
+func main(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.main, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<menu>` element with the given attributes and contents.
@@ -382,7 +384,8 @@ func main(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<menu>` element.
-func menu(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func menu(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .li }, "<menu> tags can only contain <li> tags")
     return ._element(.menu, attributes: attributes, contents: contents)
 }
@@ -396,7 +399,8 @@ func menu(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<ol>` element.
-package func ol(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+package func ol(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .li }, "<ol> tags can only contain <li> tags")
     return ._element(.ol, attributes: attributes, contents: contents)
 }
@@ -409,8 +413,8 @@ package func ol(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<p>` element.
-package func p(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.p, attributes: attributes, contents: contents)
+package func p(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.p, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<pre>` element with the given attributes and contents.
@@ -421,8 +425,8 @@ package func p(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> H
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<pre>` element.
-package func pre(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.pre, attributes: attributes, contents: contents)
+package func pre(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.pre, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<search>` element with the given attributes and contents.
@@ -433,8 +437,8 @@ package func pre(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) ->
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<search>` element.
-func search(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.search, attributes: attributes, contents: contents)
+func search(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.search, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<ul>` element with the given attributes and contents.
@@ -446,7 +450,8 @@ func search(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<ul>` element.
-package func ul(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+package func ul(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .li }, "<ul> tags can only contain <li> tags")
     return ._element(.ul, attributes: attributes, contents: contents)
 }
@@ -462,8 +467,8 @@ package func ul(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<a>` element.
-package func a(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.a, attributes: attributes, contents: contents)
+package func a(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.a, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<abbr>` element with the given attributes and contents.
@@ -476,8 +481,8 @@ package func a(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> H
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<abbr>` element.
-func abbr(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.abbr, attributes: attributes, contents: contents)
+func abbr(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.abbr, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<b>` element with the given attributes and contents.
@@ -490,8 +495,8 @@ func abbr(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<b>` element.
-func b(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.b, attributes: attributes, contents: contents)
+func b(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.b, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<bdi>` element with the given attributes and contents.
@@ -502,8 +507,8 @@ func b(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<bdi>` element.
-func bdi(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.bdi, attributes: attributes, contents: contents)
+func bdi(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.bdi, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<bdo>` element with the given attributes and contents.
@@ -515,8 +520,8 @@ func bdi(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<bdo>` element.
-func bdo(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.bdo, attributes: attributes, contents: contents)
+func bdo(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.bdo, attributes: attributes, contents: contents())
 }
 
 /// A `<br>` element.
@@ -532,8 +537,8 @@ package let br = HTMLNode._voidElement(.br)
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<cite>` element.
-func cite(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.cite, attributes: attributes, contents: contents)
+func cite(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.cite, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<code>` element with the given attributes and contents.
@@ -545,8 +550,8 @@ func cite(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<code>` element.
-package func code(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.code, attributes: attributes, contents: contents)
+package func code(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.code, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<data>` element with the given attributes and contents.
@@ -558,8 +563,8 @@ package func code(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<data>` element.
-func data(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.data, attributes: attributes, contents: contents)
+func data(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.data, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<dfn>` element with the given attributes and contents.
@@ -570,8 +575,8 @@ func data(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<dfn>` element.
-func dfn(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.dfn, attributes: attributes, contents: contents)
+func dfn(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.dfn, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<em>` element with the given attributes and contents.
@@ -583,8 +588,8 @@ func dfn(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<em>` element.
-func em(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.em, attributes: attributes, contents: contents)
+func em(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.em, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<i>` element with the given attributes and contents.
@@ -597,8 +602,8 @@ func em(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<i>` element.
-func i(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.i, attributes: attributes, contents: contents)
+func i(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.i, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<kbd>` element with the given attributes and contents.
@@ -609,8 +614,8 @@ func i(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<kbd>` element.
-func kbd(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.kbd, attributes: attributes, contents: contents)
+func kbd(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.kbd, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<mark>` element with the given attributes and contents.
@@ -621,8 +626,8 @@ func kbd(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<mark>` element.
-func mark(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.mark, attributes: attributes, contents: contents)
+func mark(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.mark, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<q>` element with the given attributes and contents.
@@ -634,8 +639,8 @@ func mark(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<q>` element.
-func q(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.q, attributes: attributes, contents: contents)
+func q(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.q, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<rt>` element with the given attributes and contents.
@@ -648,8 +653,8 @@ func q(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<rt>` element.
-func rt(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.rt, attributes: attributes, contents: contents)
+func rt(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.rt, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<rp>` element with the given attributes and textual contents.
@@ -672,8 +677,8 @@ func rp(attributes: [HTMLNode.Attribute] = [], text: String) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<ruby>` element.
-func ruby(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.ruby, attributes: attributes, contents: contents)
+func ruby(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.ruby, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<s>` element with the given attributes and contents.
@@ -684,8 +689,8 @@ func ruby(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<s>` element.
-func s(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.s, attributes: attributes, contents: contents)
+func s(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.s, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<samp>` element with the given attributes and contents.
@@ -696,8 +701,8 @@ func s(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode 
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<samp>` element.
-func samp(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.samp, attributes: attributes, contents: contents)
+func samp(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.samp, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<small>` element with the given attributes and contents.
@@ -708,8 +713,8 @@ func samp(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<small>` element.
-func small(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.small, attributes: attributes, contents: contents)
+func small(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.small, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<span>` element with the given attributes and contents.
@@ -722,8 +727,8 @@ func small(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<span>` element.
-package func span(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.span, attributes: attributes, contents: contents)
+package func span(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.span, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<strong>` element with the given attributes and contents.
@@ -734,8 +739,8 @@ package func span(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<strong>` element.
-func strong(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.strong, attributes: attributes, contents: contents)
+func strong(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.strong, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<sub>` element with the given attributes and contents.
@@ -747,8 +752,8 @@ func strong(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<sub>` element.
-func sub(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.sub, attributes: attributes, contents: contents)
+func sub(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.sub, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<sup>` element with the given attributes and contents.
@@ -760,8 +765,8 @@ func sub(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<sup>` element.
-func sup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.sup, attributes: attributes, contents: contents)
+func sup(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.sup, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<time>` element with the given attributes and contents.
@@ -773,8 +778,8 @@ func sup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<time>` element.
-func time(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.time, attributes: attributes, contents: contents)
+func time(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.time, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<u>` element with the given attributes and contents.
@@ -785,15 +790,15 @@ func time(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<u>` element.
-func u(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.u, attributes: attributes, contents: contents)
+func u(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.u, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<var>` element with the given attributes and contents.
 ///
 /// The `<var>` element semantically represents a variable. For example a variable in a mathematical expression or programming context, a symbol identifying a physical quantity, or a function parameter.
-func `var`(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.var, attributes: attributes, contents: contents)
+func `var`(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.var, attributes: attributes, contents: contents())
 }
 
 /// A `<wbr>` element.
@@ -812,7 +817,7 @@ package let wbr = HTMLNode._voidElement(.wbr)
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<area>` element.
-func area(attributes: [HTMLNode.Attribute] = []) -> HTMLNode {
+func area(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._voidElement(.area, attributes: attributes)
 }
 
@@ -824,8 +829,8 @@ func area(attributes: [HTMLNode.Attribute] = []) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<audio>` element.
-func audio(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.audio, attributes: attributes, contents: contents)
+func audio(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.audio, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<embed>` element with the given attributes.
@@ -837,7 +842,7 @@ func audio(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<embed>` element.
-func embed(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
+func embed(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._element(.embed, attributes: consume attributes, contents: [])
 }
 
@@ -850,7 +855,7 @@ func embed(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<iframe>` element.
-func iframe(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
+func iframe(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._element(.iframe, attributes: consume attributes, contents: [])
 }
 
@@ -862,7 +867,7 @@ func iframe(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<img>` element.
-func img(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
+func img(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._voidElement(.img, attributes: consume attributes)
 }
 
@@ -874,8 +879,8 @@ func img(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<map>` element.
-func map(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.map, attributes: attributes, contents: contents)
+func map(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.map, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<object>` element with the given attributes and contents.
@@ -886,8 +891,8 @@ func map(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNod
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<object>` element.
-func object(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.object, attributes: attributes, contents: contents)
+func object(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.object, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<picture>` element with the given attributes and contents.
@@ -899,7 +904,8 @@ func object(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<picture>` element.
-func picture(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func picture(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.dropLast().allSatisfy { $0._tag == .source }, "<picture> tag's content can only have <source> tags before the <img> tag")
     assert(contents.last?._tag == .img, "<picture> tag's content can only end with an <img> tag")
     return ._element(.picture, attributes: attributes, contents: contents)
@@ -915,7 +921,7 @@ func picture(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTM
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<source>` element.
-func source(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
+func source(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._voidElement(.source, attributes: consume attributes)
 }
 
@@ -928,7 +934,7 @@ func source(attributes: consuming [HTMLNode.Attribute]) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<track>` element.
-func track(attributes: [HTMLNode.Attribute] = []) -> HTMLNode {
+func track(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._voidElement(.track, attributes: attributes)
 }
 
@@ -940,8 +946,8 @@ func track(attributes: [HTMLNode.Attribute] = []) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<video>` element.
-func video(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.video, attributes: attributes, contents: contents)
+func video(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.video, attributes: attributes, contents: contents())
 }
 
 // MARK: Tables
@@ -955,8 +961,8 @@ func video(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<caption>` element.
-func caption(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.caption, attributes: attributes, contents: contents)
+func caption(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.caption, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<col>` element with the given attributes.
@@ -968,7 +974,7 @@ func caption(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTM
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<col>` element.
-func col(attributes: [HTMLNode.Attribute] = []) -> HTMLNode {
+func col(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
     ._voidElement(.col, attributes: attributes)
 }
 
@@ -981,8 +987,8 @@ func col(attributes: [HTMLNode.Attribute] = []) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<colgroup>` element.
-func colGroup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.colgroup, attributes: attributes, contents: contents)
+func colGroup(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.colgroup, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<table>` element with the given attributes and contents.
@@ -993,7 +999,8 @@ func colGroup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HT
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<table>` element.
-func table(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func table(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy {
         switch $0._tag {
             case .caption, .colgroup, .thead, .tbody, .tfoot: true
@@ -1012,7 +1019,8 @@ func table(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<tbody>` element.
-func tbody(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func tbody(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .tr }, "<tbody> tags can only contain <tr> tags")
     return ._element(.tbody, attributes: attributes, contents: contents)
 }
@@ -1026,8 +1034,8 @@ func tbody(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<td>` element.
-func td(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.td, attributes: attributes, contents: contents)
+func td(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.td, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<tfoot>` element with the given attributes and contents.
@@ -1039,7 +1047,8 @@ func td(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<tfoot>` element.
-func tfoot(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func tfoot(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .tr }, "<tfoot> tags can only contain <tr> tags")
     return ._element(.tfoot, attributes: attributes, contents: contents)
 }
@@ -1053,8 +1062,8 @@ func tfoot(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<th>` element.
-func th(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.th, attributes: attributes, contents: contents)
+func th(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.th, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<thead>` element with the given attributes and contents.
@@ -1066,7 +1075,8 @@ func th(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<thead>` element.
-func thead(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func thead(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .tr }, "<thead> tags can only contain <tr> tags")
     return ._element(.thead, attributes: attributes, contents: contents)
 }
@@ -1080,7 +1090,8 @@ func thead(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<tr>` element.
-func tr(contents: [HTMLNode]) -> HTMLNode {
+func tr(@HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy { $0._tag == .td || $0._tag == .th }, "<tr> tags can only contain <td> and <th> tags")
     return ._element(.tr, contents: contents)
 }
@@ -1095,8 +1106,8 @@ func tr(contents: [HTMLNode]) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<button>` element.
-func button(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.button, attributes: attributes, contents: contents)
+func button(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.button, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<datalist>` element with the given attributes and contents.
@@ -1107,8 +1118,8 @@ func button(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<datalist>` element.
-func dataList(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.datalist, attributes: attributes, contents: contents)
+func dataList(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.datalist, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<fieldset>` element with the given attributes and contents.
@@ -1119,8 +1130,8 @@ func dataList(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HT
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<fieldset>` element.
-func fieldSet(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.fieldset, attributes: attributes, contents: contents)
+func fieldSet(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.fieldset, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<form>` element with the given attributes and contents.
@@ -1133,8 +1144,8 @@ func fieldSet(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HT
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<form>` element.
-func form(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.form, attributes: attributes, contents: contents)
+func form(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.form, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<input>` element with the given attributes.
@@ -1157,8 +1168,8 @@ func input(_ attributes: HTMLNode.Attribute...) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<label>` element.
-func label(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.label, attributes: attributes, contents: contents)
+func label(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.label, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<legend>` element with the given attributes and contents.
@@ -1170,8 +1181,8 @@ func label(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<legend>` element.
-func legend(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.legend, attributes: attributes, contents: contents)
+func legend(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.legend, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<meter>` element with the given attributes and contents.
@@ -1182,8 +1193,8 @@ func legend(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<meter>` element.
-func meter(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.meter, attributes: attributes, contents: contents)
+func meter(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.meter, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<optgroup>` element with the given attributes and contents.
@@ -1195,7 +1206,8 @@ func meter(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLN
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<optgroup>` element.
-func optGroup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func optGroup(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy {
         switch $0._tag {
             case .div, .legend, .noscript, .option, .script, .template: true
@@ -1215,8 +1227,8 @@ func optGroup(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HT
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<option>` element.
-func option(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.option, attributes: attributes, contents: contents)
+func option(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.option, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<output>` element with the given attributes and contents.
@@ -1227,8 +1239,8 @@ func option(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<output>` element.
-func output(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.output, attributes: attributes, contents: contents)
+func output(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.output, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<progress>` element with the given attributes and contents.
@@ -1239,8 +1251,8 @@ func output(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<progress>` element.
-func progress(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.progress, attributes: attributes, contents: contents)
+func progress(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.progress, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<select>` element with the given attributes and contents.
@@ -1253,7 +1265,8 @@ func progress(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HT
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<select>` element.
-func select(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
+func select(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    let contents = contents()
     assert(contents.allSatisfy {
         switch $0._tag {
             case .button, .div, .hr, .noscript, .optgroup, .option, .script, .template: true
@@ -1271,8 +1284,8 @@ func select(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<selectedcontent>` element.
-func selectedContent(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.selectedcontent, attributes: attributes, contents: contents)
+func selectedContent(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.selectedcontent, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<textarea>` element with the given attributes and textual contents.
@@ -1299,8 +1312,8 @@ func textarea(attributes: [HTMLNode.Attribute] = [], text: String) -> HTMLNode {
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<details>` element.
-func details(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.details, attributes: attributes, contents: contents)
+func details(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.details, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<dialog>` element with the given attributes and contents.
@@ -1311,8 +1324,8 @@ func details(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTM
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<dialog>` element.
-func dialog(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.dialog, attributes: attributes, contents: contents)
+func dialog(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.dialog, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<summary>` element with the given attributes and contents.
@@ -1324,8 +1337,8 @@ func dialog(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<summary>` element.
-func summary(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.summary, attributes: attributes, contents: contents)
+func summary(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.summary, attributes: attributes, contents: contents())
 }
 
 // MARK: - Scripting
@@ -1338,8 +1351,8 @@ func summary(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTM
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<canvas>` element.
-func canvas(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.canvas, attributes: attributes, contents: contents)
+func canvas(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.canvas, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<noscript>` element with the given attributes and contents.
@@ -1350,8 +1363,8 @@ func canvas(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<noscript>` element.
-func noScript(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.noscript, attributes: attributes, contents: contents)
+func noScript(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.noscript, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<script>` element with the given attributes and contents.
@@ -1363,8 +1376,8 @@ func noScript(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HT
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<script>` element.
-func script(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.script, attributes: attributes, contents: contents)
+func script(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.script, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<slot>` element with the given attributes and contents.
@@ -1375,8 +1388,8 @@ func script(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTML
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<slot>` element.
-func slot(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.slot, attributes: attributes, contents: contents)
+func slot(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.slot, attributes: attributes, contents: contents())
 }
 
 /// Creates a new `<template>` element with the given attributes and contents.
@@ -1387,8 +1400,8 @@ func slot(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNo
 ///   - attributes: The list of attributes for the new element.
 ///   - contents: The inner contents for the new element.
 /// - Returns: A new `<template>` element.
-func template(attributes: [HTMLNode.Attribute] = [], contents: [HTMLNode]) -> HTMLNode {
-    ._element(.template, attributes: attributes, contents: contents)
+func template(_ attributes: HTMLNode.Attribute..., @HTMLBuilder contents: () -> [HTMLNode]) -> HTMLNode {
+    ._element(.template, attributes: attributes, contents: contents())
 }
 
 // MARK: - Tags

--- a/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
+++ b/Sources/SwiftDocC/Model/Rendering/HTML/HTMLRenderer+FullPage.swift
@@ -108,7 +108,7 @@ package extension HTMLRenderer {
         
         let root = XMLNode.element(named: "html", children: [head, body], attributes: ["lang": "en-US"])
         
-        return HTMLNode(from: root) ?? html(contents: [])
+        return HTMLNode(from: root) ?? html {}
     }
     
     /// Prepares the provided custom header and footer files to be included in the full-page structure.

--- a/Tests/DocCHTMLTests/HTMLFormatterTests.swift
+++ b/Tests/DocCHTMLTests/HTMLFormatterTests.swift
@@ -17,7 +17,7 @@ struct HTMLFormatterTests {
     
     @Test
     func quotesAttributesByDefault() {
-        let html = p(attributes: [.class("something")], contents: [.text("Some text")])
+        let html = p(.class("something")) { "Some text" }
         
         #expect(htmlString(for: html) == #"<p class="something">Some text</p>"#, "The formatter quotes attributes by default")
         #expect(htmlString(for: html, options: .omitOptionalQuotesAroundAttributeValues) == #"<p class=something>Some text</p>"#, "The quotes around this attributes are optional and can be omitted.")
@@ -25,14 +25,14 @@ struct HTMLFormatterTests {
     
     @Test
     func quotesAttributesContainingWhitespace() {
-        let html = p(attributes: [.class("first second")], contents: [.text("Some text")])
+        let html = p(.class("first second")) { "Some text" }
         
         #expect(htmlString(for: html, options: .omitOptionalQuotesAroundAttributeValues) == #"<p class="first second">Some text</p>"#, "The quotes around this attribute are necessary and can't be omitted.")
     }
     
     @Test
     func formatsBooleanAttributesWithoutValue() {
-        let html = p(attributes: [.autoFocus, .hidden(.hidden)], contents: [.text("Some text")])
+        let html = p(.autoFocus, .hidden(.hidden)) { "Some text" }
         
         #expect(htmlString(for: html) == #"<p autofocus hidden>Some text</p>"#, "The quotes around this attribute are necessary and can't be omitted.")
     }
@@ -68,18 +68,18 @@ struct HTMLFormatterTests {
     
     @Test
     func prettyFormatsTagsOnTheirOwnLineAndTextInline() {
-        let html = section(contents: [
-            ul(contents: [
-                li(contents: [.text("First")]),
-                li(contents: [.text("Second")]),
-                li(contents: [
-                    ol(contents: [
-                        li(contents: [.text("Third")]),
-                        li(contents: [.text("Fourth")]),
-                    ])
-                ])
-            ])
-        ])
+        let html = section {
+            ul {
+                li { "First" }
+                li { "Second" }
+                li {
+                    ol {
+                        li { "Third" }
+                        li { "Fourth" }
+                    }
+                }
+            }
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <section>
@@ -99,10 +99,10 @@ struct HTMLFormatterTests {
     
     @Test
     func prettyFormatsTextOnSeparateLineWhenContainerHasAttributes() {
-        let html = ul(contents: [
-            li(contents: [.text("Container without attribute")]),
-            li(attributes: [.id("something")], contents: [.text("Container with attribute")]),
-        ])
+        let html = ul {
+            li { "Container without attribute" }
+            li(.id("something")) { "Container with attribute" }
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <ul>
@@ -125,22 +125,22 @@ struct HTMLFormatterTests {
     
     @Test
     func preservesSignificantWhitespaceInPreTag() {
-        let preTag = pre(contents: [
-            code(contents: [.text("  first")]),
-            .text(" "),
-            code(contents: [.text("second  ")]),
-        ])
+        let preTag = pre {
+            code { "  first" }
+            " "
+            code { "second  " }
+        }
         
         #expect(htmlString(for: preTag, options: .prettyPrint) == htmlString(for: preTag))
         #expect(htmlString(for: preTag, options: .prettyPrint) == "<pre><code>  first</code> <code>second  </code></pre>")
         
-        let html = section(contents: [
-            hgroup(contents: [
-                h1(contents: [.text("Some title")]),
-                p(contents: [.text("Some subheading")]),
-            ]),
+        let html = section {
+            hgroup {
+                h1 { "Some title" }
+                p { "Some subheading" }
+            }
             preTag
-        ])
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <section>
@@ -155,7 +155,7 @@ struct HTMLFormatterTests {
     
     @Test
     func escapesAmpersandAndQuoteInAttribute() {
-        let html = span(attributes: [.title(#"' & " <>"#)], contents: [.text("Some text")])
+        let html = span(.title(#"' & " <>"#)) { "Some text" }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <span title="' &amp; &quot; <>">Some text</span>
@@ -164,14 +164,14 @@ struct HTMLFormatterTests {
     
     @Test
     func escapesAmpersandAndLessThanInText() {
-        let html = pre(contents: [
-            code(contents: [ .text("""
+        let html = pre {
+            code { """
                 func randomACIILetter() -> UTF8.CodeUnit {
                     .random(in: .init(ascii: "a") ..< 123, using: &myGenerator)
                 }
-                """)
-            ])
-        ])
+                """
+            }
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <pre><code>func randomACIILetter() -> UTF8.CodeUnit {
@@ -183,11 +183,11 @@ struct HTMLFormatterTests {
     @Test
     func prettyFormatsTextSemanticElementsOnSameNewLine() {
         func makeExample(paragraphAttributes: [HTMLNode.Attribute]) -> HTMLNode {
-            p(attributes: paragraphAttributes, contents: [
+            ._element(.p, attributes: paragraphAttributes, contents: [
                 .text("Some "),
-                b(contents: [.text("bold")]),
+                b { "bold" },
                 .text(" and "),
-                i(contents: [.text("italicized")]),
+                i { "italicized" },
                 .text(" text."),
             ])
         }
@@ -212,15 +212,15 @@ struct HTMLFormatterTests {
         // At the same time, these anchor elements can look slightly too verbose and out of place if they take up 3 lines (because the anchor has a "href" attribute).
         // To try and address both these readability issues, the formatter presents the anchor on its own _separate_ line from the contents both before and after.
         
-        let html = p(attributes: [.id("something")], contents: [
-            .text("Some "),
-            b(contents: [.text("bold")]),
-            .text("text before a "),
-            a(attributes: [.href("#something")], contents: [.text("link")]),
-            .text(" and some "),
-            i(contents: [.text("italicized")]),
-            .text(" text after."),
-        ])
+        let html = p(.id("something")) {
+            "Some "
+            b { "bold" }
+            "text before a "
+            a(.href("#something")) { "link" }
+            " and some "
+            i { "italicized" }
+            " text after."
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <p id="something">
@@ -235,11 +235,11 @@ struct HTMLFormatterTests {
     func prettyFormatsTextContentsInlineForAnchorElementWithSingleAttribute() {
         // It's fairly common for anchors with only plain text contents to appear within headings and other elements.
         
-        let anchorWithOnlyTextContents = h1(attributes: [.id("something")], contents: [
-            a(attributes: [.href("#something")], contents: [
-                .text("Some plain text"),
-            ])
-        ])
+        let anchorWithOnlyTextContents = h1(.id("something")) {
+            a(.href("#something")) {
+                "Some plain text"
+            }
+        }
         
         #expect(htmlString(for: anchorWithOnlyTextContents, options: .prettyPrint) == """
         <h1 id="something">
@@ -247,11 +247,11 @@ struct HTMLFormatterTests {
         </h1>
         """)
         
-        let anchorWithTwoAttributes = h1(attributes: [.id("something")], contents: [
-            a(attributes: [.href("#something"), .class("some-class")], contents: [
-                .text("Some plain text"),
-            ])
-        ])
+        let anchorWithTwoAttributes = h1(.id("something")) {
+            a(.href("#something"), .class("some-class")) {
+                "Some plain text"
+            }
+        }
         
         #expect(htmlString(for: anchorWithTwoAttributes, options: .prettyPrint) == """
         <h1 id="something">
@@ -261,13 +261,13 @@ struct HTMLFormatterTests {
         </h1>
         """)
         
-        let anchorWithFormattedContents = h1(attributes: [.id("something")], contents: [
-            a(attributes: [.href("#something")], contents: [
-                .text("Some "),
-                b(contents: [.text("formatted")]),
-                .text(" text"),
-            ])
-        ])
+        let anchorWithFormattedContents = h1(.id("something")) {
+            a(.href("#something")) {
+                "Some "
+                b { "formatted" }
+                " text"
+            }
+        }
         
         #expect(htmlString(for: anchorWithFormattedContents, options: .prettyPrint) == """
         <h1 id="something">
@@ -283,51 +283,56 @@ struct HTMLFormatterTests {
         // It's somewhat common for table cells to only have spanning attributes and plain text content.
         // When these spanning table cells are surrounded by other non-spanning cells, they appear more alike if both formats its plain text contents the same.
         
-        // TODO: Update these initializers after https://github.com/swiftlang/swift-docc/pull/1578 is merged.
-        let html = HTMLNode._element(.table, contents: [
-            ._element(.tr, contents: [
-                ._element(.td, contents: [
-                    .text("No attribute")
-                ]),
-                ._element(.td, attributes: [.colSpan(2)], contents: [
-                    .text("One attribute")
-                ]),
-                ._element(.td, attributes: [.colSpan(2), .id("some-id")], contents: [
-                    .text("Two attributes")
-                ]),
-            ])
-        ])
+        let html = table {
+            tbody {
+                tr {
+                    td {
+                        "No attribute"
+                    }
+                    td(.colSpan(2)) {
+                        "One attribute"
+                    }
+                    td(.colSpan(2), .id("some-id")) {
+                        "Two attributes"
+                    }
+                }
+            }
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <table>
-          <tr>
-            <td>No attribute</td>
-            <td colspan="2">One attribute</td>
-            <td colspan="2" id="some-id">
-              Two attributes
-            </td>
-          </tr>
+          <tbody>
+            <tr>
+              <td>No attribute</td>
+              <td colspan="2">One attribute</td>
+              <td colspan="2" id="some-id">
+                Two attributes
+              </td>
+            </tr>
+          </tbody>
         </table>
         """)
         
         #expect(htmlString(for: html, options: [.prettyPrint, .omitOptionalEndTags]) == """
         <table>
-          <tr>
-            <td>No attribute
-            <td colspan="2">One attribute
-            <td colspan="2" id="some-id">
-              Two attributes
+          <tbody>
+            <tr>
+              <td>No attribute
+              <td colspan="2">One attribute
+              <td colspan="2" id="some-id">
+                Two attributes
+          </tbody>
         </table>
         """)
     }
     
     @Test
     func prettyFormatsVoidElementContentsOnSeparateLines() {
-        let html = picture(contents: [
-            source(attributes: [.media("(prefers-color-scheme: light)"), .src("relative/path/to/some-image.png")]),
-            source(attributes: [.media("(prefers-color-scheme: dark)"),  .src("relative/path/to/some-image~dark.png")]),
-            img(attributes: [.alt("Some alt text"), .decoding(.async), .loading(.lazy)]),
-        ])
+        let html = picture {
+            source(.media("(prefers-color-scheme: light)"), .src("relative/path/to/some-image.png"))
+            source(.media("(prefers-color-scheme: dark)"),  .src("relative/path/to/some-image~dark.png"))
+            img(.alt("Some alt text"), .decoding(.async), .loading(.lazy))
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <picture>
@@ -340,10 +345,10 @@ struct HTMLFormatterTests {
     
     @Test
     func prettyFormatsTextSemanticAfterOtherElementOnSeparateLines() {
-        let html = header(contents: [
-            h2(contents: [.text("Some header")]),
-            span(contents: [.text("Some other information")]),
-        ])
+        let html = header {
+            h2 { "Some header" }
+            span { "Some other information" }
+        }
         
         #expect(htmlString(for: html, options: .prettyPrint) == """
         <header>
@@ -355,23 +360,23 @@ struct HTMLFormatterTests {
     
     @Test
     func includesOptionalEndTagsByDefault() {
-        let definitionList = dl(contents: [
-            dt(contents: [.text("range")]),
-            dd(contents: [
-                p(contents: [
-                    .text("The range in which to create a random value. "),
-                    code(contents: [.text("range")]),
-                    .text(" must not be empty.")
-                ])
-            ]),
+        let definitionList = dl {
+            dt { "range" }
+            dd {
+                p {
+                    "The range in which to create a random value. "
+                    code { "range" }
+                    " must not be empty."
+                }
+            }
             
-            dt(contents: [.text("range")]),
-            dd(contents: [
-                p(contents: [
-                    .text("The random number generator to use when creating the new random value."),
-                ])
-            ]),
-        ])
+            dt { "range" }
+            dd {
+                p {
+                    "The random number generator to use when creating the new random value."
+                }
+            }
+        }
         
         #expect(htmlString(for: definitionList) == #"<dl><dt>range</dt><dd><p>The range in which to create a random value. <code>range</code> must not be empty.</p></dd><dt>range</dt><dd><p>The random number generator to use when creating the new random value.</p></dd></dl>"#)
         #expect(htmlString(for: definitionList, options: .omitOptionalEndTags) == #"<dl><dt>range<dd><p>The range in which to create a random value. <code>range</code> must not be empty.<dt>range<dd><p>The random number generator to use when creating the new random value.</dl>"#)
@@ -402,16 +407,16 @@ struct HTMLFormatterTests {
         </dl>
         """)
         
-        let listOfLists = ul(contents: [
-            li(contents: [.text("First")]),
-            li(contents: [.text("Second")]),
-            li(contents: [
-                ol(contents: [
-                    li(contents: [.text("Third")]),
-                    li(contents: [.text("Fourth")]),
-                ])
-            ])
-        ])
+        let listOfLists = ul {
+            li { "First" }
+            li { "Second" }
+            li {
+                ol {
+                    li { "Third" }
+                    li { "Fourth" }
+                }
+            }
+        }
         
         #expect(htmlString(for: listOfLists) == #"<ul><li>First</li><li>Second</li><li><ol><li>Third</li><li>Fourth</li></ol></li></ul>"#)
         #expect(htmlString(for: listOfLists, options: .omitOptionalEndTags) == #"<ul><li>First<li>Second<li><ol><li>Third<li>Fourth</ol></ul>"#)


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://165755530

This is a follow up to https://github.com/swiftlang/swift-docc/pull/1571 ~(still open)~, https://github.com/swiftlang/swift-docc/pull/1578 ~(still open)~, and https://github.com/swiftlang/swift-docc/pull/1583 ~(still open)~ that adds a result builder that makes the syntax nicer for creating `HTMLNode` element hierarchies.

As mentioned in https://github.com/swiftlang/swift-docc/pull/1583; this is not the intended final state but rather a _step_ towards replacing the `XMLNode` hierarchy with an `HTMLNode` hierarchy. Future PRs will update the code that creates `XMLNode` values to create `HTMLNode` values instead.

## Dependencies

This depends on and includes all the changes of:

- https://github.com/swiftlang/swift-docc/pull/1571
- https://github.com/swiftlang/swift-docc/pull/1578
- https://github.com/swiftlang/swift-docc/pull/1583

## Testing

Compared to https://github.com/swiftlang/swift-docc/pull/1583 this is a non-functional change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
