### PR TITLE
feat(cli): Add support for repeating '--additional-symbol-graph-dir' argument to convert / emit-generated-curation commands

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/EmitGeneratedCurationAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/EmitGeneratedCurationAction.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,7 +14,7 @@ import SwiftDocC
 /// An action that emits documentation extension files that reflect the auto-generated curation.
 struct EmitGeneratedCurationAction: AsyncAction {
     let catalogURL: URL?
-    let additionalSymbolGraphDirectory: URL?
+    let additionalSymbolGraphDirectories: [URL]
     let outputURL: URL
     let depthLimit: Int?
     let startingPointSymbolLink: String?
@@ -23,7 +23,7 @@ struct EmitGeneratedCurationAction: AsyncAction {
     
     init(
         documentationCatalog: URL?,
-        additionalSymbolGraphDirectory: URL?,
+        additionalSymbolGraphDirectories: [URL],
         outputURL: URL?,
         depthLimit: Int?,
         startingPointSymbolLink: String?,
@@ -37,7 +37,7 @@ struct EmitGeneratedCurationAction: AsyncAction {
         }
         self.depthLimit = depthLimit
         self.startingPointSymbolLink = startingPointSymbolLink
-        self.additionalSymbolGraphDirectory = additionalSymbolGraphDirectory
+        self.additionalSymbolGraphDirectories = additionalSymbolGraphDirectories
         self.fileManager = fileManager
     }
     
@@ -47,7 +47,7 @@ struct EmitGeneratedCurationAction: AsyncAction {
             startingPoint: catalogURL,
             options: BundleDiscoveryOptions(
                 infoPlistFallbacks: [:],
-                additionalSymbolGraphFiles: symbolGraphFiles(in: additionalSymbolGraphDirectory)
+                additionalSymbolGraphFiles: symbolGraphFiles(in: additionalSymbolGraphDirectories)
             )
         )
         let context = try await DocumentationContext(bundle: bundle, dataProvider: dataProvider)
@@ -62,12 +62,4 @@ struct EmitGeneratedCurationAction: AsyncAction {
         
         return ActionResult(didEncounterError: false, outputs: [outputURL])
     }
-}
-
-private func symbolGraphFiles(in directory: URL?) -> [URL] {
-    guard let directory else { return [] }
-    
-    let subpaths = FileManager.default.subpaths(atPath: directory.path) ?? []
-    return subpaths.map { directory.appendingPathComponent($0) }
-        .filter { DocumentationBundleFileTypes.isSymbolGraphFile($0) }
 }

--- a/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -96,8 +96,8 @@ extension ConvertAction {
 
 package extension Docc.Convert {
     var bundleDiscoveryOptions: BundleDiscoveryOptions {
-        let additionalSymbolGraphFiles = symbolGraphFiles(in: inputsAndOutputs.additionalSymbolGraphDirectory)
-        
+        let additionalSymbolGraphFiles = symbolGraphFiles(in: inputsAndOutputs.additionalSymbolGraphDirectories)
+
         return BundleDiscoveryOptions(
             fallbackDisplayName: infoPlistFallbacks.fallbackBundleDisplayName,
             fallbackIdentifier: infoPlistFallbacks.fallbackBundleIdentifier,
@@ -106,12 +106,4 @@ package extension Docc.Convert {
             additionalSymbolGraphFiles: additionalSymbolGraphFiles
         )
     }
-}
-
-private func symbolGraphFiles(in directory: URL?) -> [URL] {
-    guard let directory else { return [] }
-    
-    let subpaths = FileManager.default.subpaths(atPath: directory.path) ?? []
-    return subpaths.map { directory.appendingPathComponent($0) }
-        .filter { DocumentationBundleFileTypes.isSymbolGraphFile($0) }
 }

--- a/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Convert.swift
@@ -56,14 +56,14 @@ extension Docc {
             @OptionGroup()
             var documentationCatalog: DocumentationCatalogOption
             
-            /// A user-provided path to a directory of additional symbol graph files that the convert action will process.
+            /// User-provided paths to directories of additional symbol graph files that the convert action will process.
             @Option(
                 name: [.customLong("additional-symbol-graph-dir")],
-                help: "A path to a directory of additional symbol graph files.",
+                help: "A path to a directory of additional symbol graph files. May be specified multiple times.",
                 transform: URL.init(fileURLWithPath:)
             )
-            var additionalSymbolGraphDirectory: URL?
-            
+            var additionalSymbolGraphDirectories: [URL] = []
+
             /// A user-provided location where the convert action writes the built documentation.
             @Option(
                 name: [.customLong("output-path"), .customLong("output-dir"), .customShort("o")], // Remove "output-dir" when other tools no longer pass that option. (rdar://72449411)

--- a/Sources/DocCCommandLine/ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Subcommands/EmitGeneratedCuration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -50,13 +50,13 @@ extension Docc.ProcessCatalog {
             @Option(
                 name: [.customLong("additional-symbol-graph-dir")],
                 help: ArgumentHelp(
-                    "Path to a directory of additional symbol graph files.",
+                    "Path to a directory of additional symbol graph files. May be specified multiple times.",
                     valueName: "symbol-graph-dir"
                 ),
                 transform: URL.init(fileURLWithPath:)
             )
-            var additionalSymbolGraphDirectory: URL?
-            
+            var additionalSymbolGraphDirectories: [URL] = []
+
             /// A user-provided location where the command will write the updated catalog output.
             @Option(
                 name: [.customLong("output-path")],
@@ -135,7 +135,7 @@ extension Docc.ProcessCatalog {
         func run() async throws {
             let action = try EmitGeneratedCurationAction(
                 documentationCatalog: inputsAndOutputs.documentationCatalog,
-                additionalSymbolGraphDirectory: inputsAndOutputs.additionalSymbolGraphDirectory,
+                additionalSymbolGraphDirectories: inputsAndOutputs.additionalSymbolGraphDirectories,
                 outputURL: inputsAndOutputs.outputURL,
                 depthLimit: generationOptions.depthLimit,
                 startingPointSymbolLink: generationOptions.startingPointSymbolLink

--- a/Sources/DocCCommandLine/Utility/SymbolGraphFileDiscovery.swift
+++ b/Sources/DocCCommandLine/Utility/SymbolGraphFileDiscovery.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2026 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SwiftDocC
+
+func symbolGraphFiles(in directories: [URL]) -> [URL] {
+    directories
+        // avoid traversing the same exact folders multiple times
+        .uniqueElements(by: \.standardizedFileURL)
+        .flatMap { directory in
+            let subpaths = FileManager.default.subpaths(atPath: directory.path) ?? []
+            return subpaths.map { directory.appendingPathComponent($0) }
+                .filter { DocumentationBundleFileTypes.isSymbolGraphFile($0) }
+        }
+        // if overlapping paths were provided (e.g. 'foo/' and 'foo/folder') omit duplicates
+        .uniqueElements(by: \.standardizedFileURL)
+}

--- a/Sources/DocCCommandLine/Utility/SymbolGraphFileDiscovery.swift
+++ b/Sources/DocCCommandLine/Utility/SymbolGraphFileDiscovery.swift
@@ -11,6 +11,13 @@
 import Foundation
 import SwiftDocC
 
+/// Returns the symbol graph files found by recursively searching the given directories.
+///
+/// Files are deduplicated and returned in the order that their directories were provided in.
+/// Directories that don't exist are ignored.
+///
+/// - Parameter directories: The directories to search for symbol graph files.
+/// - Returns: The symbol graph files in the given directories.
 func symbolGraphFiles(in directories: [URL]) -> [URL] {
     directories
         // avoid traversing the same exact folders multiple times

--- a/Sources/SwiftDocC/Infrastructure/Input Discovery/DocumentationInputsProvider.swift
+++ b/Sources/SwiftDocC/Infrastructure/Input Discovery/DocumentationInputsProvider.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -346,7 +346,7 @@ extension DocumentationContext.InputsProvider {
                 if CommandLine.arguments.contains("--additional-symbol-graph-dir") {
                     message.append("""
 
-                    The provided `--additional-symbol-graph-dir` directory doesn't contain any symbol graph files (with a `.symbols.json` file extension).
+                    The provided `--additional-symbol-graph-dir` directories do not contain any symbol graph files (with a `.symbols.json` file extension).
                     """)
                 } else {
                     message.append("""

--- a/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -18,7 +18,7 @@ import ArgumentParser
 class ConvertSubcommandTests: XCTestCase {
     private let testBundleURL = Bundle.module.url(
         forResource: "LegacyBundle_DoNotUseInNewTests", withExtension: "docc", subdirectory: "Test Bundles")!
-    
+
     private let testTemplateURL = Bundle.module.url(
         forResource: "Test Template", withExtension: nil, subdirectory: "Test Resources")!
 
@@ -244,7 +244,7 @@ class ConvertSubcommandTests: XCTestCase {
                 testBundleURL.path,
             ])
             
-            XCTAssertEqual(convertOptions.inputsAndOutputs.additionalSymbolGraphDirectory, nil)
+            XCTAssertEqual(convertOptions.inputsAndOutputs.additionalSymbolGraphDirectories, [])
         }
         
         // Is set when passed
@@ -256,8 +256,8 @@ class ConvertSubcommandTests: XCTestCase {
             ])
             
             XCTAssertEqual(
-                convertOptions.inputsAndOutputs.additionalSymbolGraphDirectory,
-                URL(fileURLWithPath: "/path/to/folder-of-symbol-graph-files")
+                convertOptions.inputsAndOutputs.additionalSymbolGraphDirectories,
+                [URL(fileURLWithPath: "/path/to/folder-of-symbol-graph-files")]
             )
         }
         
@@ -271,6 +271,77 @@ class ConvertSubcommandTests: XCTestCase {
 
             XCTAssertEqual(convertOptions.bundleDiscoveryOptions.additionalSymbolGraphFiles.map { $0.lastPathComponent }.sorted(), [
                 "FillIntroduced.symbols.json",
+                "MyKit@SideKit.symbols.json",
+                "mykit-iOS.symbols.json",
+                "sidekit.symbols.json",
+            ])
+        }
+
+        let mixedLanguageFrameworkTestBundleURL = Bundle.module.url(
+            forResource: "MixedLanguageFramework", withExtension: "docc", subdirectory: "Test Bundles"
+        )!
+
+        // Is recursively scanned when multiple paths provided
+        do {
+            let convertOptions = try Docc.Convert.parse([
+                testBundleURL.path,
+                "--additional-symbol-graph-dir",
+                testBundleURL.path,
+                "--additional-symbol-graph-dir",
+                mixedLanguageFrameworkTestBundleURL.path
+            ])
+
+            XCTAssertEqual(convertOptions.bundleDiscoveryOptions.additionalSymbolGraphFiles.map { $0.lastPathComponent }.sorted(), [
+                "FillIntroduced.symbols.json",
+                // One in `clang`, one in `swift`
+                "MixedLanguageFramework.symbols.json",
+                "MixedLanguageFramework.symbols.json",
+                "MyKit@SideKit.symbols.json",
+                "mykit-iOS.symbols.json",
+                "sidekit.symbols.json",
+            ])
+        }
+
+        // Is unique when the same directory is provided multiple times
+        do {
+            let convertOptions = try Docc.Convert.parse([
+                testBundleURL.path,
+                "--additional-symbol-graph-dir",
+                testBundleURL.path,
+                "--additional-symbol-graph-dir",
+                mixedLanguageFrameworkTestBundleURL.path,
+                "--additional-symbol-graph-dir",
+                mixedLanguageFrameworkTestBundleURL.path
+            ])
+
+            XCTAssertEqual(convertOptions.bundleDiscoveryOptions.additionalSymbolGraphFiles.map { $0.lastPathComponent }.sorted(), [
+                "FillIntroduced.symbols.json",
+                // One in `clang`, one in `swift`
+                "MixedLanguageFramework.symbols.json",
+                "MixedLanguageFramework.symbols.json",
+                "MyKit@SideKit.symbols.json",
+                "mykit-iOS.symbols.json",
+                "sidekit.symbols.json",
+            ])
+        }
+
+        // Is unique when the directories overlap
+        do {
+            let convertOptions = try Docc.Convert.parse([
+                testBundleURL.path,
+                "--additional-symbol-graph-dir",
+                testBundleURL.path,
+                "--additional-symbol-graph-dir",
+                mixedLanguageFrameworkTestBundleURL.path,
+                "--additional-symbol-graph-dir",
+                mixedLanguageFrameworkTestBundleURL.appendingPathComponent("symbol-graphs/swift").path
+            ])
+
+            XCTAssertEqual(convertOptions.bundleDiscoveryOptions.additionalSymbolGraphFiles.map { $0.lastPathComponent }.sorted(), [
+                "FillIntroduced.symbols.json",
+                // One in `clang`, one in `swift`
+                "MixedLanguageFramework.symbols.json",
+                "MixedLanguageFramework.symbols.json",
                 "MyKit@SideKit.symbols.json",
                 "mykit-iOS.symbols.json",
                 "sidekit.symbols.json",
@@ -308,8 +379,8 @@ class ConvertSubcommandTests: XCTestCase {
         XCTAssertEqual(convertOptions.infoPlistFallbacks.fallbackBundleIdentifier, "com.example.test")
         
         XCTAssertEqual(
-            convertOptions.inputsAndOutputs.additionalSymbolGraphDirectory,
-            testBundleURL
+            convertOptions.inputsAndOutputs.additionalSymbolGraphDirectories,
+            [testBundleURL]
         )
         
         // Verify the action

--- a/Tests/DocCCommandLineTests/EmitGeneratedCurationsActionTests.swift
+++ b/Tests/DocCCommandLineTests/EmitGeneratedCurationsActionTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -40,7 +40,7 @@ class EmitGeneratedCurationsActionTests: XCTestCase {
             
             let action = try EmitGeneratedCurationAction(
                 documentationCatalog: catalogURL,
-                additionalSymbolGraphDirectory: nil,
+                additionalSymbolGraphDirectories: [],
                 outputURL: outputDir,
                 depthLimit: depthLimit,
                 startingPointSymbolLink: startingPointSymbolLink,


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Update `docc convert` and `docc process-catalog emit-generated-curation` to allow repeating the `--additional-symbol-graph-dir` argument to pass multiple directories to be searched for symbol graph files.

Today if you have multiple pre-built collections of symbol graph folders that you want to pass to a single command, you have to copy all of their contents to a single directory first. This can be particularly slow due the number of loose files involved if there are many folders.

Inspired by this bug in Bazel rules_apple https://github.com/bazelbuild/rules_apple/issues/3033 which had incorrectly assumed this is how the CLI worked

## Dependencies

N/A

## Testing

Unit tests are included in this PR.

Manual testing:

Steps:
1. Run `docc convert --additional-symbol-graph-dir {SomeDirectoryA} --additional-symbol-graph-dir {SomeDirectoryB}`
2. Run `docc process-catalog emit-generated-curation --additional-symbol-graph-dir {SomeDirectoryA} --additional-symbol-graph-dir {SomeDirectoryB}`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
