### PR TITLE
Set "Tool" eyebrow and rename DisplayName to "Documentation (DocC)"

### DIFF
--- a/Sources/docc/DocCDocumentation.docc/DocC Documentation.md
+++ b/Sources/docc/DocCDocumentation.docc/DocC Documentation.md
@@ -1,7 +1,8 @@
 # ``docc``
 
 @Metadata {
-    @DisplayName("DocC")
+    @DisplayName("Documentation (DocC)")
+    @TitleHeading("Tool")
 }
 
 Produce rich API reference documentation and interactive tutorials for your Swift framework or package.


### PR DESCRIPTION
## Summary
- Adds `@TitleHeading("Tool")` to the `docc` root page, so the page shows a "Tool" eyebrow above its title.
- Updates `@DisplayName` from "DocC" to "Documentation (DocC)" to match the label already used for this catalog in the combined Swift.org documentation's "Tools" navigation group.