### PR TITLE
Deterministically fold platform availabilities

### DIFF
--- a/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
+++ b/Sources/SwiftDocC/Model/ParametersAndReturnValidator.swift
@@ -360,7 +360,7 @@ struct ParametersAndReturnValidator {
     /// Returns the symbol's function signatures for each variant trait, or `nil` if the symbol doesn't have any function signature data.
     private static func traitSpecificSignatures(_ symbol: UnifiedSymbolGraph.Symbol) -> Signatures? {
         var signatures: [DocumentationDataVariantsTrait: SymbolGraph.Symbol.FunctionSignature] = [:]
-        for (selector, mixin) in symbol.mixins {
+        for (selector, mixin) in symbol.mixins.sortedBySelector() {
             guard var signature = mixin.getValueIfPresent(for: SymbolGraph.Symbol.FunctionSignature.self) else {
                 continue
             }

--- a/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/Symbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -558,7 +558,7 @@ extension Symbol {
     }
 
     func mergeDeclarations(unifiedSymbol: UnifiedSymbolGraph.Symbol) throws {
-        for (selector, mixins) in unifiedSymbol.mixins {
+        for (selector, mixins) in unifiedSymbol.mixins.sortedBySelector() {
             if let mergingDeclaration = mixins[SymbolGraph.Symbol.DeclarationFragments.mixinKey] as? SymbolGraph.Symbol.DeclarationFragments {
                 let availability = mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability
                 let alternateSymbols = mixins[SymbolGraph.Symbol.AlternateSymbols.mixinKey] as? SymbolGraph.Symbol.AlternateSymbols
@@ -571,7 +571,7 @@ extension Symbol {
     /// Merge the different availability variants defined in the unified symbol,
     /// and update the availability of the canonical symbol to consider all the different availability mixins instead of only the first one.
     func mergeAvailabilities(unifiedSymbol: UnifiedSymbolGraph.Symbol) {
-        for (selector, mixins) in unifiedSymbol.mixins {
+        for (selector, mixins) in unifiedSymbol.mixins.sortedBySelector() {
             let trait = DocumentationDataVariantsTrait(for: selector)
             if let unifiedSymbolAvailability = mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability {
                 for availabilityItem in unifiedSymbolAvailability.availability {

--- a/Sources/SwiftDocC/Semantics/Symbol/UnifiedSymbol+Extensions.swift
+++ b/Sources/SwiftDocC/Semantics/Symbol/UnifiedSymbol+Extensions.swift
@@ -20,32 +20,7 @@ extension UnifiedSymbolGraph.Symbol {
     private func defaultSelector(
         in selectors: some Sequence<UnifiedSymbolGraph.Selector>
     ) -> UnifiedSymbolGraph.Selector? {
-        // Return the default selector based on the ordering defined below.
-        return selectors.sorted { lhsSelector, rhsSelector in
-            switch (lhsSelector.interfaceLanguage, rhsSelector.interfaceLanguage) {
-                
-            // If both selectors are Swift, pick the one that has the most matching platforms with the other selectors.
-            case ("swift", "swift"):
-                let nonSwiftSelectors = selectors.filter { $0.interfaceLanguage != "swift" }
-                
-                let lhsMatchingPlatformsCount = nonSwiftSelectors.filter { $0.platform == lhsSelector.platform }.count
-                let rhsMatchingPlatformsCount = nonSwiftSelectors.filter { $0.platform == rhsSelector.platform }.count
-                
-                if lhsMatchingPlatformsCount == rhsMatchingPlatformsCount {
-                    // If they have the same number of matching platforms, use the hierarchical platform order.
-                    return PlatformName.areInIncreasingOrder(lhsSelector.platform, rhsSelector.platform)
-                }
-                
-                return lhsMatchingPlatformsCount > rhsMatchingPlatformsCount
-            case ("swift", _):
-                return true
-            case (_, "swift"):
-                return false
-            default:
-                // Use the hierarchical platform order
-                return PlatformName.areInIncreasingOrder(lhsSelector.platform, rhsSelector.platform)
-            }
-        }.first
+        return selectors.min(by: UnifiedSymbolGraph.Selector.Ordering(among: selectors).areInIncreasingOrder)
     }
 
     func symbol(forSelector selector: UnifiedSymbolGraph.Selector?) -> SymbolGraph.Symbol? {
@@ -122,6 +97,59 @@ extension UnifiedSymbolGraph.Symbol {
         } else {
             return identifier(forLanguage: "swift")
         }
+    }
+}
+
+extension UnifiedSymbolGraph.Selector {
+    /// An ordering that wraps the comparator to sort a list of selectors.
+    /// This wrapper computes the number of non-Swift selectors per platform once,
+    /// and allows the comparator to reuse it for each comparison.
+    struct Ordering {
+        private let nonSwiftSelectorsPerPlatform: [String?: Int]
+
+        init(among selectors: some Sequence<UnifiedSymbolGraph.Selector>) {
+            var nonSwiftSelectorsPerPlatform: [String?: Int] = [:]
+            for selector in selectors where selector.interfaceLanguage != "swift" {
+                nonSwiftSelectorsPerPlatform[selector.platform, default: 0] += 1
+            }
+            self.nonSwiftSelectorsPerPlatform = nonSwiftSelectorsPerPlatform
+        }
+
+        /// A comparator that performs a cascading sort on a list of selectors:
+        ///
+        /// - A Swift selector is preferred over a non-Swift one.
+        /// - If both selectors are for Swift, the value with the most non-Swift selectors for its platform is chosen.
+        /// - If it is still a tie, the hierarchical platform order is used.
+        func areInIncreasingOrder(
+            _ lhs: UnifiedSymbolGraph.Selector,
+            _ rhs: UnifiedSymbolGraph.Selector
+        ) -> Bool {
+            switch (lhs.interfaceLanguage, rhs.interfaceLanguage) {
+            // If both selectors are Swift, choose the one with the highest number of non-Swift selectors for its platform
+            case ("swift", "swift"):
+                let lhsMatchingPlatformsCount = nonSwiftSelectorsPerPlatform[lhs.platform, default: 0]
+                let rhsMatchingPlatformsCount = nonSwiftSelectorsPerPlatform[rhs.platform, default: 0]
+                if lhsMatchingPlatformsCount != rhsMatchingPlatformsCount {
+                    return lhsMatchingPlatformsCount > rhsMatchingPlatformsCount
+                }
+                // Use the hierarchical platform order
+                return PlatformName.areInIncreasingOrder(lhs.platform, rhs.platform)
+            case ("swift", _):
+                return true
+            case (_, "swift"):
+                return false
+            default:
+                // Use the hierarchical platform order
+                return PlatformName.areInIncreasingOrder(lhs.platform, rhs.platform)
+            }
+        }
+    }
+}
+
+extension Dictionary where Key == UnifiedSymbolGraph.Selector {
+    func sortedBySelector() -> [(key: Key, value: Value)] {
+        let ordering = UnifiedSymbolGraph.Selector.Ordering(among: keys)
+        return sorted { ordering.areInIncreasingOrder($0.key, $1.key) }
     }
 }
 

--- a/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
+++ b/Tests/SwiftDocCTests/Infrastructure/PathHierarchyTests.swift
@@ -153,7 +153,7 @@ struct PathHierarchyTests_new {
         #expect(links["some-symbol-id"] == "/ModuleName/\(symbolName)", "Links allow any special characters")
     }
 
-    // This verifies determinism in a previously non-deterministic behavior that cannot be reproduced reliably in a test.
+    // This verifies determinism in previously non-deterministic behavior that cannot be reproduced reliably in a test.
     // If you suspect that your changes might affect this test,
     // you need to run it repeatedly (and relaunch for each repetition) to verify that the behavior remains deterministic.
     @Test
@@ -183,7 +183,7 @@ struct PathHierarchyTests_new {
         #expect(paths[symbolID] == "/ModuleName/FirstName")
     }
 
-    // This verifies determinism in a previously non-deterministic behavior that cannot be reproduced reliably in a test.
+    // This verifies determinism in previously non-deterministic behavior that cannot be reproduced reliably in a test.
     // If you suspect that your changes might affect this test,
     // you need to run it repeatedly (and relaunch for each repetition) to verify that the behavior remains deterministic.
     @Test

--- a/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
+++ b/Tests/SwiftDocCTests/Model/AvailabilityTests.swift
@@ -326,6 +326,44 @@ struct AvailabilityTests {
         }
     }
     
+    // This verifies determinism in previously non-deterministic behavior that cannot be reproduced reliably in a test.
+    // If you suspect that your changes might affect this test,
+    // you need to run it repeatedly (and relaunch for each repetition) to verify that the behavior remains deterministic.
+    @Test
+    func mergedAvailabilityResolvesConflictDeterministically() async throws {
+        let catalog = Folder(name: "unit-test.docc") {
+            for (osName, iOSIntroducedVersion) in [
+                ("ios",      SymbolGraph.SemanticVersion(major: 17, minor: 0, patch: 0)),
+                ("visionos", SymbolGraph.SemanticVersion(major: 13, minor: 0, patch: 0)),
+            ] {
+                JSONFile(name: "ModuleName-\(osName).symbols.json", content: makeSymbolGraph(
+                    moduleName: "ModuleName",
+                    platform: .init(operatingSystem: .init(name: osName), environment: nil),
+                    symbols: [
+                        makeSymbol(
+                            id: "some-symbol-id",
+                            kind: .class,
+                            pathComponents: ["SomeClass"],
+                            availability: [
+                                makeAvailabilityItem(domainName: "iOS", introduced: iOSIntroducedVersion)
+                            ]
+                        )
+                    ]
+                ))
+            }
+        }
+        let context = try await load(catalog: catalog)
+        #expect(context.diagnostics.isEmpty, "Unexpected problems: \(context.diagnostics.map(\.summary))")
+        let node = try #require(context.documentationCache["some-symbol-id"])
+        let symbol = try #require(node.semantic as? Symbol)
+
+        let iOSAvailability = try #require(
+            symbol.availabilityVariants[.swift]?.availability
+                .first { $0.domain?.rawValue == "iOS" }
+        )
+        #expect(iOSAvailability.introducedVersion == .init(major: 17, minor: 0, patch: 0))
+    }
+
     @Test
     func fallbackAvailabilityDoesNotOverrideInSourceAvailability() async throws {
         let catalog = Folder(name: "unit-test.docc") {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://184277552

## Summary

Availability items are accumulated per platform into a language trait that collapses availabilities for each interface language. The availability is processed by iterating a dictionary, whose ordering is not stable, leading to platform availability varying based on the first processed selector for that platform. Sort availabilities with the same comparator as used to identify the default comparator, to ensure that the accumulated availabilities are consistent.

## Dependencies

N/A

## Testing

1. Create a catalog with symbol graphs for two different platforms.
2. Add a symbol to both symbol graphs, where it is marked unconditionally available for platform A on one and unconditionally unavailable for platform A on the other (can be done with `#if os(<os>)` in source)
3. Build the catalog multiple times. Previously, a platform would appear and disappear. It is now consistently included.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
