### PR TITLE
Promote static-hosting-with-content feature to non-experimental and enable by default

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertAction.swift
@@ -36,8 +36,17 @@ public struct ConvertAction: AsyncAction {
     private let documentationCoverageOptions: DocumentationCoverageOptions
     let diagnosticEngine: DiagnosticEngine
 
-    private let transformForStaticHosting: Bool
-    private let includeContentInEachHTMLFile: Bool
+    /// A configuration for how the action should transform the output for static hosting environments
+    package enum TransformForStaticHostingOptions: Equatable {
+        /// Transform the archive to support static hosting environments and minimal browsing without JavaScript enabled.
+        case withContent
+        /// Transform the archive to support static hosting environments but requiring JavaScript to render pages.
+        case withoutContent
+        /// Don't transform the archive to support static hosting environments.
+        case noTransform
+    }
+    
+    private let transformForStaticHostingOptions: TransformForStaticHostingOptions
     private let hostingBasePath: String?
     
     let sourceRepository: SourceRepository?
@@ -75,7 +84,7 @@ public struct ConvertAction: AsyncAction {
     ///   - experimentalEnableCustomTemplates: `true` if the convert action should enable support for custom "header.html" and "footer.html" template files, otherwise `false`.
     ///   - experimentalModifyCatalogWithGeneratedCuration: `true` if the convert action should write documentation extension files containing markdown representations of DocC's automatic curation into the `documentationBundleURL`, otherwise `false`.
     ///   - featureFlags: A collection of feature flags that the convert action uses to enable or disable certain optional behaviors.
-    ///   - transformForStaticHosting: `true` if the convert action should process the build documentation archive so that it supports a static hosting environment, otherwise `false`.
+    ///   - transformForStaticHostingOptions: Options to configure how the convert action transforms the built documentation archive so that it supports a static hosting environment.
     ///   - includeContentInEachHTMLFile: `true` if the convert action should process each static hosting HTML file so that it includes documentation content for environments without JavaScript enabled, otherwise `false`.
     ///   - allowArbitraryCatalogDirectories: `true` if the convert action should consider the root location as a documentation catalog if it doesn't discover another catalog, otherwise `false`.
     ///   - hostingBasePath: The base path where the built documentation archive will be hosted at.
@@ -107,8 +116,7 @@ public struct ConvertAction: AsyncAction {
         experimentalEnableCustomTemplates: Bool = false,
         experimentalModifyCatalogWithGeneratedCuration: Bool = false,
         featureFlags: FeatureFlags = .init(),
-        transformForStaticHosting: Bool = false,
-        includeContentInEachHTMLFile: Bool = false,
+        transformForStaticHostingOptions: TransformForStaticHostingOptions = .noTransform,
         allowArbitraryCatalogDirectories: Bool = false,
         hostingBasePath: String? = nil,
         sourceRepository: SourceRepository? = nil,
@@ -123,8 +131,7 @@ public struct ConvertAction: AsyncAction {
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory
         self.documentationCoverageOptions = documentationCoverageOptions
-        self.transformForStaticHosting = transformForStaticHosting
-        self.includeContentInEachHTMLFile = includeContentInEachHTMLFile
+        self.transformForStaticHostingOptions = transformForStaticHostingOptions
         self.hostingBasePath = hostingBasePath
         self.sourceRepository = sourceRepository
         
@@ -339,7 +346,7 @@ public struct ConvertAction: AsyncAction {
             indexer: indexer,
             enableCustomTemplates: experimentalEnableCustomTemplates,
             // Don't transform for static hosting if the `FileWritingHTMLContentConsumer` will create per-page index.html files
-            transformForStaticHostingIndexHTML: transformForStaticHosting && !includeContentInEachHTMLFile ? indexHTML : nil,
+            transformForStaticHostingIndexHTML: transformForStaticHostingOptions == .withoutContent ? indexHTML : nil,
             inputsID: inputs.id
         )
         
@@ -352,7 +359,7 @@ public struct ConvertAction: AsyncAction {
                 customHeader: experimentalEnableCustomTemplates ? inputs.customHeader : nil,
                 customFooter: experimentalEnableCustomTemplates ? inputs.customFooter : nil
             )
-        } else if includeContentInEachHTMLFile, let indexHTML {
+        } else if transformForStaticHostingOptions == .withContent, let indexHTML {
             htmlConsumer = try FileWritingHTMLContentConsumer(
                 targetFolder: temporaryFolder,
                 fileManager: fileManager,

--- a/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/ActionExtensions/ConvertAction+CommandInitialization.swift
@@ -84,13 +84,24 @@ extension ConvertAction {
             experimentalEnableCustomTemplates: convert.featureFlags.experimentalEnableCustomTemplates,
             experimentalModifyCatalogWithGeneratedCuration: convert.featureFlags.experimentalModifyCatalogWithGeneratedCuration,
             featureFlags: featureFlags,
-            transformForStaticHosting: convert.hostingOptions.transformForStaticHosting,
-            includeContentInEachHTMLFile: convert.hostingOptions.experimentalTransformForStaticHostingWithContent,
+            transformForStaticHostingOptions: convert.hostingOptions.transformForStaticHostingOptions,
             allowArbitraryCatalogDirectories: convert.featureFlags.allowArbitraryCatalogDirectories,
             hostingBasePath: convert.hostingOptions.hostingBasePath,
             sourceRepository: SourceRepository(from: convert.sourceRepositoryArguments),
             dependencies: convert.linkResolutionOptions.dependencies
         )
+    }
+}
+
+extension Docc.Convert.HostingOptions {
+    var transformForStaticHostingOptions: ConvertAction.TransformForStaticHostingOptions {
+        if !transformForStaticHosting {
+            return .noTransform
+        }
+        if omitContentFromStaticHostingOutput {
+            return .withoutContent
+        }
+        return .withContent
     }
 }
 

--- a/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Convert.swift
+++ b/Sources/DocCCommandLine/ArgumentParsing/Subcommands/Convert.swift
@@ -163,30 +163,29 @@ extension Docc {
             )
             var hostingBasePath: String?
 
-            /// A Boolean value that is true if the DocC archive produced by this conversion will support static hosting environments.
+            /// A Boolean value that is true if the DocC archive produced by this conversion will support static hosting environments and will support minimal browsing without JavaScript enabled.
             ///
             /// This value defaults to true but can be explicitly disabled with the `--no-transform-for-static-hosting` flag.
             @Flag(
                 inversion: .prefixedNo,
                 exclusivity: .exclusive,
-                help: "Produce a DocC archive that supports static hosting environments."
+                help: "Produce a DocC archive that include documentation content in each HTML file for static hosting environments."
             )
             var transformForStaticHosting = true
             
-            /// A Boolean value that is true if the DocC archive produced by this conversion will support browsing without JavaScript enabled.
-            @Flag(help: "Include documentation content in each HTML file for static hosting environments.")
-            var experimentalTransformForStaticHostingWithContent = false
+            /// A Boolean value that is true if the DocC archive produced by this conversion won't support browsing without JavaScript enabled.
+            ///
+            /// This value is ignored if ``transformForStaticHosting`` is `false`.
+            @Flag(
+                name: [.customLong("transform-for-static-hosting-without-content")],
+                help: "Omit documentation content from each HTML file for static hosting environments."
+            )
+            var omitContentFromStaticHostingOutput = false
             
-            mutating func validate() throws {
-                if experimentalTransformForStaticHostingWithContent, !transformForStaticHosting {
-                    warnAboutDiagnostic(.init(
-                        severity: .warning,
-                        identifier: "org.swift.docc.IgnoredNoTransformForStaticHosting",
-                        summary: "Passing '--experimental-transform-for-static-hosting-with-content' also implies '--transform-for-static-hosting'. Passing '--no-transform-for-static-hosting' has no effect."
-                    ))
-                    transformForStaticHosting = true
-                }
-            }
+            // Preserve the experimental flag name so that it can be passed redundantly.
+            @Flag(name: [.customLong("experimental-transform-for-static-hosting-with-content")], help: .private)
+            @available(*, deprecated, message: "This flag isn't used for anything. Check 'transformForStaticHosting' or 'omitContentFromStaticHostingOutput' instead.")
+            var _unusedTransformWithContentForBackwardsCompatibility = false // This needs to be defined false to avoid an assertion failure about an unconfigurable flag in Swift Argument Parser
         }
         
         /// The user-provided path to an HTML documentation template.
@@ -365,7 +364,7 @@ extension Docc {
 
             @Option(
                 name: [.customLong("fallback-bundle-version"), .customLong("bundle-version")],
-                help: .hidden
+                help: .private
             )
             @available(*, deprecated, message: "The version isn't used for anything.")
             var _unusedVersionForBackwardsCompatibility: String?
@@ -515,7 +514,7 @@ extension Docc {
             
             // This flag only exist to allow developers to pass the previous '--enable-experimental-...' flag without errors.
             // The last release to support this spelling was 6.2.
-            @Flag(name: .customLong("enable-experimental-mentioned-in"), help: .hidden)
+            @Flag(name: .customLong("enable-experimental-mentioned-in"), help: .private)
             @available(*, deprecated, message: "This flag is unused and only exist for backwards compatibility")
             var _unusedExperimentalMentionedInFlagForBackwardsCompatibility = false
 

--- a/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
+++ b/Tests/DocCCommandLineTests/ArgumentParsing/ConvertSubcommandTests.swift
@@ -568,27 +568,26 @@ class ConvertSubcommandFlagParsingTests {
     
     @Test
     func parsingStaticHostingWithContentFlag() throws {
-        // The feature is disabled when no flag is passed.
+        // The feature is enabled when no flag is passed.
         let noFlagConvert = try Docc.Convert.parse([])
-        #expect(noFlagConvert.hostingOptions.experimentalTransformForStaticHostingWithContent == false)
+        #expect(noFlagConvert.hostingOptions.transformForStaticHosting)
+        #expect(noFlagConvert.hostingOptions.omitContentFromStaticHostingOutput == false)
+        #expect(noFlagConvert.hostingOptions.transformForStaticHostingOptions == .withContent)
         
-        let enabledFlagConvert = try Docc.Convert.parse(["--experimental-transform-for-static-hosting-with-content"])
-        #expect(enabledFlagConvert.hostingOptions.experimentalTransformForStaticHostingWithContent)
+        let disabledFlagConvert = try Docc.Convert.parse(["--transform-for-static-hosting-without-content"])
+        #expect(disabledFlagConvert.hostingOptions.transformForStaticHosting)
+        #expect(disabledFlagConvert.hostingOptions.omitContentFromStaticHostingOutput)
+        #expect(disabledFlagConvert.hostingOptions.transformForStaticHostingOptions == .withoutContent)
         
-        // The '...-transform...-with-content' flag also implies the base '--transform-...' flag.
-        do {
-            let logStorage = LogHandle.LogStorage()
-            Docc.Convert._errorLogHandle = .memory(logStorage)
-            Docc.Convert._diagnosticFormattingOptions = .formatConsoleOutputForTools
-            
-            let conflictingFlagsConvert = try Docc.Convert.parse(["--experimental-transform-for-static-hosting-with-content", "--no-transform-for-static-hosting"])
-            #expect(conflictingFlagsConvert.hostingOptions.experimentalTransformForStaticHostingWithContent)
-            #expect(conflictingFlagsConvert.hostingOptions.transformForStaticHosting)
-            
-            #expect(logStorage.text.trimmingCharacters(in: .whitespacesAndNewlines) == """
-            warning: Passing '--experimental-transform-for-static-hosting-with-content' also implies '--transform-for-static-hosting'. Passing '--no-transform-for-static-hosting' has no effect.
-            """)
-        }
+        let redundantTransformFlagConvert = try Docc.Convert.parse(["--transform-for-static-hosting"])
+        #expect(redundantTransformFlagConvert.hostingOptions.transformForStaticHosting          == noFlagConvert.hostingOptions.transformForStaticHosting)
+        #expect(redundantTransformFlagConvert.hostingOptions.omitContentFromStaticHostingOutput == noFlagConvert.hostingOptions.omitContentFromStaticHostingOutput)
+        #expect(redundantTransformFlagConvert.hostingOptions.transformForStaticHostingOptions   == noFlagConvert.hostingOptions.transformForStaticHostingOptions)
+        
+        let redundantExperimentalFlagConvert = try Docc.Convert.parse(["--experimental-transform-for-static-hosting-with-content"])
+        #expect(redundantExperimentalFlagConvert.hostingOptions.transformForStaticHosting          == noFlagConvert.hostingOptions.transformForStaticHosting)
+        #expect(redundantExperimentalFlagConvert.hostingOptions.omitContentFromStaticHostingOutput == noFlagConvert.hostingOptions.omitContentFromStaticHostingOutput)
+        #expect(redundantExperimentalFlagConvert.hostingOptions.transformForStaticHostingOptions   == noFlagConvert.hostingOptions.transformForStaticHostingOptions)
     }
     
     @Test

--- a/Tests/DocCCommandLineTests/ConvertActionStaticHostableTests.swift
+++ b/Tests/DocCCommandLineTests/ConvertActionStaticHostableTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -41,7 +41,7 @@ class ConvertActionStaticHostableTests: StaticHostingBaseTests {
             emitDigest: false,
             currentPlatforms: nil,
             temporaryDirectory: try createTemporaryDirectory(),
-            transformForStaticHosting: true,
+            transformForStaticHostingOptions: .withoutContent,
             hostingBasePath: basePath
         )
         _ = try await action.perform(logHandle: .none)

--- a/Tests/DocCCommandLineTests/ConvertActionTests.swift
+++ b/Tests/DocCCommandLineTests/ConvertActionTests.swift
@@ -2215,7 +2215,24 @@ class ConvertActionTests: XCTestCase {
         let temporaryDirectory = try createTemporaryDirectory()
         let outputDirectory = temporaryDirectory.appendingPathComponent("output", isDirectory: true)
         let doccCatalogDirectory = try emptyCatalog.write(inside: temporaryDirectory)
-        let htmlTemplateDirectory = try Folder.emptyHTMLTemplateDirectory.write(inside: temporaryDirectory)
+        let template = Folder(name: "template") {
+            TextFile(name: "index.html", utf8Content: """
+            <html>
+              <head>
+                <meta charset="utf-8" />
+                <script>var baseUrl = "/"</script>
+                <title>Documentation</title>
+              </head>
+              <body>
+                <noscript>
+                  <p>Some existing information inside the no script tag</p>
+                </noscript>
+                <div id="app"></div>
+              </body>
+            </html>
+            """)
+        }
+        let htmlTemplateDirectory = try template.write(inside: temporaryDirectory)
         
         SetEnvironmentVariable(TemplateOption.environmentVariableKey, htmlTemplateDirectory.path)
         defer {
@@ -2294,7 +2311,7 @@ class ConvertActionTests: XCTestCase {
             currentPlatforms: nil,
             fileManager: FileManager.default,
             temporaryDirectory: createTemporaryDirectory(),
-            transformForStaticHosting: true
+            transformForStaticHostingOptions: .withoutContent
         )
         
         try await action.performAndHandleResult(logHandle: .none)
@@ -2424,7 +2441,7 @@ class ConvertActionTests: XCTestCase {
             fileManager: FileManager.default,
             temporaryDirectory: createTemporaryDirectory(),
             experimentalEnableCustomTemplates: true,
-            transformForStaticHosting: true
+            transformForStaticHostingOptions: .withoutContent
         )
         let result = try await action.perform(logHandle: .none)
 

--- a/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
+++ b/Tests/DocCCommandLineTests/StaticHostingWithContentTests.swift
@@ -75,8 +75,7 @@ struct StaticHostingWithContentTests {
             fileManager: fileSystem,
             temporaryDirectory: URL(fileURLWithPath: "/tmp"),
             experimentalEnableCustomTemplates: true,
-            transformForStaticHosting: true,
-            includeContentInEachHTMLFile: includeHTMLContent,
+            transformForStaticHostingOptions: includeHTMLContent ? .withContent : .withoutContent,
             hostingBasePath: basePath
         )
         // The old `Indexer` type doesn't work with virtual file systems.


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This promotes the static-hosting-with-content feature to no longer be considered "experimental" and enables it by default.

Before these changes, the 3 spellings for the different static-hosting behaviors were as follows:
 * `--experimental-transform-for-static-hosting-with-content` Create a per page index.html file based on the provided template and modify each page to contain a minimal static representation of the page's content. This allows for the documentation to be minimally browsed without JavaScript enabled and allows tools that don't evaluate JavaScript to access the information on the requested page.
 * `--transform-for-static-hosting` **(default)** Make an identical copy of the same template index.html file for each without any per-page content. The documentation required JavaScript to display any pages and tools that don't evaluate JavaScript cannot access any information on the pages.
 * `--no-transform-for-static-hosting` Don't create or copy any per-page index.html files. The documentation doesn't support static hosting environments and requires custom routing rules on the web server.
 
With these changes, the spellings of these behaviors change accordingly (the spelling of the last behavior is unchanged)

| From | To |
|---|---|
| `--experimental-transform-for-static-hosting-with-content` | `--transform-for-static-hosting` (**default**) | 
|`--transform-for-static-hosting` (**default**) |  `--transform-for-static-hosting-without-content` 
| `--no-transform-for-static-hosting` | `--no-transform-for-static-hosting` (unchanged) |


## Dependencies

None.

## Testing

1. Build some symbol/article documentation and inspect the output.
   - There should be an index.html file for each page in the output.
     - Each index.html file should have a minimal static semantic representation of its content in the `<noscript>` tag, as well as title and description metadata in the page's `<head>` tag.
    
2. Build the same symbol/article documentation, pass `--experimental-transform-for-static-hosting-with-content`, and inspect the output.
   - There should be an index.html file for each page in the output. (same as above)
     - Each index.html file should have a minimal static semantic representation of its content in the `<noscript>` tag, as well as title and description metadata in the page's `<head>` tag. (same as above)
    
3. Build the same symbol/article documentation, pass `--transform-for-static-hosting-without-content`, and inspect the output.
   - There should be an index.html file for each page in the output. (same as above)
     - All index.html files should have identical content and should have the same "This page requires JavaScript" information in the `<noscript>` tag as the template file.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Updated ~Added~ tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
