### PR TITLE
Deprecate ConvertOutputConsumer to be made non-public in the future 

### DIFF
--- a/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
+++ b/Sources/DocCCommandLine/Action/Actions/Convert/ConvertFileWritingConsumer.swift
@@ -12,7 +12,7 @@ import Foundation
 import SwiftDocC
 private import Markdown
 
-struct ConvertFileWritingConsumer: ConvertOutputConsumer, ExternalNodeConsumer, ConvertOutputMarkdownConsumer {
+struct ConvertFileWritingConsumer: _WillBeMadeNonPublicConvertOutputConsumer, ExternalNodeConsumer, ConvertOutputMarkdownConsumer {
     var targetFolder: URL
     var bundleRootFolder: URL?
     var fileManager: any FileManagerProtocol

--- a/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertActionConverter.swift
@@ -34,7 +34,7 @@ package enum ConvertActionConverter {
     ///   - documentationCoverageOptions: The level of experimental documentation coverage information that the conversion should pass to the consumer.
     package static func convert(
         context: DocumentationContext,
-        outputConsumer: some ConvertOutputConsumer & ExternalNodeConsumer,
+        outputConsumer: some _WillBeMadeNonPublicConvertOutputConsumer & ExternalNodeConsumer,
         htmlContentConsumer: (any HTMLContentConsumer)?,
         sourceRepository: SourceRepository?,
         emitDigest: Bool,

--- a/Sources/SwiftDocC/Infrastructure/ConvertOutputConsumer.swift
+++ b/Sources/SwiftDocC/Infrastructure/ConvertOutputConsumer.swift
@@ -12,7 +12,7 @@
 ///
 /// Types that conform to this protocol manage what to do with documentation conversion products, for example persist them to disk
 /// or store them in memory.
-public protocol ConvertOutputConsumer {
+public protocol _WillBeMadeNonPublicConvertOutputConsumer {
     /// Consumes a render node that was generated during a conversion.
     /// > Warning: This method might be called concurrently.
     func consume(renderNode: RenderNode) throws
@@ -56,7 +56,7 @@ package protocol ConvertOutputMarkdownConsumer {
 
 // Default implementations that discard the documentation conversion products, for consumers that don't need these
 // values.
-public extension ConvertOutputConsumer {
+public extension _WillBeMadeNonPublicConvertOutputConsumer {
     func consume(renderReferenceStore: RenderReferenceStore) throws {}
     func consume(buildMetadata: BuildMetadata) throws {}
     func consume(linkResolutionInformation: SerializableLinkResolutionInformation) throws {}
@@ -71,7 +71,7 @@ package protocol ExternalNodeConsumer {
     func consume(externalRenderNode: ExternalRenderNode) throws
 }
 
-extension ConvertOutputConsumer {
+extension _WillBeMadeNonPublicConvertOutputConsumer {
     @available(*, deprecated, renamed: "consume(assetsInInputs:)", message: "Use 'consume(assetsInInputs:)' instead. This deprecated API will be removed after 6.5 is released.")
     func consume(assetsInBundle inputs: DocumentationContext.Inputs) throws {
         try consume(assetsInInputs: inputs)
@@ -79,7 +79,7 @@ extension ConvertOutputConsumer {
 }
 
 // Default implementation so that conforming types don't need to implement deprecated API.
-public extension ConvertOutputConsumer {
+public extension _WillBeMadeNonPublicConvertOutputConsumer {
     @available(*, deprecated)
     func consume(assetsInInputs inputs: DocumentationContext.Inputs) throws {
         // Despite this protocol being public, it's not possible to configure an output consumer from outside this package.
@@ -87,3 +87,6 @@ public extension ConvertOutputConsumer {
         // This default implementation only exist for the unlikely case that an out-of-package client conforms to this protocol.
     }
 }
+
+@available(*, deprecated, message: "The output consumer is not publicly configurable. This protocol will be made non-public after 6.5 is released.")
+public typealias ConvertOutputConsumer = _WillBeMadeNonPublicConvertOutputConsumer

--- a/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
+++ b/Tests/DocCCommandLineTests/FileWritingHTMLContentConsumerTests.swift
@@ -599,7 +599,7 @@ struct FileWritingHTMLContentConsumerTests {
 
 // MARK: Helpers
 
-private class TestOutputConsumer: ConvertOutputConsumer, ExternalNodeConsumer {
+private class TestOutputConsumer: _WillBeMadeNonPublicConvertOutputConsumer, ExternalNodeConsumer {
     func consume(renderNode: RenderNode) throws { }
     func consume(assetsInInputs _: DocumentationContext.Inputs) throws { }
     func consume(linkableElementSummaries: [LinkDestinationSummary]) throws { }

--- a/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
+++ b/Tests/SwiftDocCTests/Indexing/ExternalRenderNodeTests.swift
@@ -631,7 +631,7 @@ class ExternalRenderNodeTests: XCTestCase {
     }
 }
 
-private class TestExternalRenderNodeOutputConsumer: ConvertOutputConsumer, ExternalNodeConsumer {
+private class TestExternalRenderNodeOutputConsumer: _WillBeMadeNonPublicConvertOutputConsumer, ExternalNodeConsumer {
     let indexBuilder: Synchronized<NavigatorIndex.Builder>!
 
     init(indexBuilder: NavigatorIndex.Builder) {

--- a/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
+++ b/Tests/SwiftDocCTests/TestRenderNodeOutputConsumer.swift
@@ -12,7 +12,7 @@ import Foundation
 @testable import SwiftDocC
 import XCTest
 
-class TestRenderNodeOutputConsumer: ConvertOutputConsumer, ExternalNodeConsumer {
+class TestRenderNodeOutputConsumer: _WillBeMadeNonPublicConvertOutputConsumer, ExternalNodeConsumer {
     var renderNodes = Synchronized<[RenderNode]>([])
     
     func consume(renderNode: RenderNode) throws {


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

It's not possible to configure a `ConvertOutputConsumer` from outside of this package, yet its protocol is public and we follow our policy of not making source-breaking changes to it.

This deprecates the `ConvertOutputConsumer` protocol—in the unlikely case that something outside of this package conforms to it—and renames it to `_WillBeMadeNonPublicConvertOutputConsumer` so that we permit ourselves to make it non-public after 6.5 is released. That will allow us to rethink the "shape" of the output consuming configuration.

## Dependencies

None.

## Testing

Nothing in particular. This isn't a user-facing change.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
