### PR TITLE
Speed up type-checking for markdown output tests

### DIFF
--- a/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/Markdown/MarkdownOutputTests.swift
@@ -1737,16 +1737,22 @@ struct MarkdownOutputTests {
         
         
         let (_, manifest) = try await markdownOutput(catalog: catalog, path: "LocalSubclass")
-        let related = manifest.relationships.filter { $0.relationshipType == .relatedSymbol }
-        #expect(related.contains(where: {
-            $0.targetIdentifier == "/documentation/MarkdownOutput/LocalSuperclass" && $0.subtype == .inheritsFrom
-        }))
+        let inheritsFrom = MarkdownOutputManifest.Relationship(
+            sourceIdentifier: "/documentation/MarkdownOutput/LocalSubclass",
+            relationshipType: .relatedSymbol,
+            subtype: .inheritsFrom,
+            targetIdentifier: "/documentation/MarkdownOutput/LocalSuperclass"
+        )
+        #expect(manifest.relationships.contains(inheritsFrom))
         
         let (_, parentManifest) = try await markdownOutput(catalog: catalog, path: "LocalSuperclass")
-        let parentRelated = parentManifest.relationships.filter { $0.relationshipType == .relatedSymbol }
-        #expect(parentRelated.contains(where: {
-            $0.targetIdentifier == "/documentation/MarkdownOutput/LocalSubclass" && $0.subtype == .inheritedBy
-        }))
+        let inheritedBy = MarkdownOutputManifest.Relationship(
+            sourceIdentifier: "/documentation/MarkdownOutput/LocalSuperclass",
+            relationshipType: .relatedSymbol,
+            subtype: .inheritedBy,
+            targetIdentifier: "/documentation/MarkdownOutput/LocalSubclass"
+        )
+        #expect(parentManifest.relationships.contains(inheritedBy))
     }
         
     @Test
@@ -1769,23 +1775,32 @@ struct MarkdownOutputTests {
         ])
         
         let (_, manifest) = try await markdownOutput(catalog: catalog, path: "LocalConformer")
-        let related = manifest.relationships.filter { $0.relationshipType == .relatedSymbol }
-        #expect(related.contains(where: {
-            $0.targetIdentifier == "/documentation/MarkdownOutput/LocalProtocol" && $0.subtype == .conformsTo
-        }))
+        let conformsTo = MarkdownOutputManifest.Relationship(
+            sourceIdentifier: "/documentation/MarkdownOutput/LocalConformer",
+            relationshipType: .relatedSymbol,
+            subtype: .conformsTo,
+            targetIdentifier: "/documentation/MarkdownOutput/LocalProtocol"
+        )
+        #expect(manifest.relationships.contains(conformsTo))
         
         let (_, protocolManifest) = try await markdownOutput(catalog: catalog, path: "LocalProtocol")
-        let protocolRelated = protocolManifest.relationships.filter { $0.relationshipType == .relatedSymbol }
-        #expect(protocolRelated.contains(where: {
-            $0.targetIdentifier == "/documentation/MarkdownOutput/LocalConformer" && $0.subtype == .conformingTypes
-        }))
+        let conformingTypes = MarkdownOutputManifest.Relationship(
+            sourceIdentifier: "/documentation/MarkdownOutput/LocalProtocol",
+            relationshipType: .relatedSymbol,
+            subtype: .conformingTypes,
+            targetIdentifier: "/documentation/MarkdownOutput/LocalConformer"
+        )
+        #expect(protocolManifest.relationships.contains(conformingTypes))
         
         let (_, externalManifest) = try await markdownOutput(catalog: catalog, path: "ExternalConformer")
-        let externalRelated = externalManifest.relationships.filter { $0.relationshipType == .relatedSymbol }
         // Unresolved symbol should use the fallback identifier
-        #expect(externalRelated.contains(where: {
-            $0.targetIdentifier == "Swift.Hashable" && $0.subtype == .conformsTo
-        }))
+        let externalConformsTo = MarkdownOutputManifest.Relationship(
+            sourceIdentifier: "/documentation/MarkdownOutput/ExternalConformer",
+            relationshipType: .relatedSymbol,
+            subtype: .conformsTo,
+            targetIdentifier: "Swift.Hashable"
+        )
+        #expect(externalManifest.relationships.contains(externalConformsTo))
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: 186246145

## Summary

Several tests in MarkdownOutputTests were taking too long to type-check. These were all of the format

```
#expect(related.contains(where: {
    $0.targetIdentifier == "/documentation/MarkdownOutput/LocalSuperclass" && $0.subtype == .inheritsFrom
}))
```

`&&` is a generic operator, so both sides need type inference. `==` also requires type inference for both sides. `$0.subtype` is an optional, which further complicates things. 

This change creates the expected relationship value up front and then just checks that it exists. 

## Dependencies

N/A

## Testing

Type checking of the markdown output tests file should be much faster.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests - N/A, improvement to existing tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary N/A
